### PR TITLE
[bugfix] Translate patch operations for kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/puzpuzpuz/xsync/v2 v2.4.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	gomodules.xyz/jsonpatch/v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -804,6 +805,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+gomodules.xyz/jsonpatch/v2 v2.3.0 h1:8NFhfS6gzxNqjLIYnZxg319wZ5Qjnx4m/CcX+Klzazc=
+gomodules.xyz/jsonpatch/v2 v2.3.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3 h1:DnoIG+QAMaF5NvxnGe/oKsgKcAc6PcUyl8q0VetfQ8s=

--- a/k8s/gvclient.go
+++ b/k8s/gvclient.go
@@ -153,7 +153,7 @@ func (g *groupVersionClient) updateSubresource(ctx context.Context, plural, subr
 //nolint:revive,unused
 func (g *groupVersionClient) patch(ctx context.Context, identifier resource.Identifier, plural string,
 	patch resource.PatchRequest, into resource.Object, _ resource.PatchOptions) error {
-	bytes, err := json.Marshal(patch.Operations)
+	bytes, err := marshalJSONPatch(patch)
 	if err != nil {
 		return err
 	}

--- a/k8s/translation.go
+++ b/k8s/translation.go
@@ -231,8 +231,8 @@ func getV1ObjectMetaFields() map[string]struct{} {
 		if len(jsonTag) == 0 || jsonTag[0] == '-' || jsonTag[0] == ',' {
 			continue
 		}
-		if strings.Index(jsonTag, ",") > 0 {
-			jsonTag = jsonTag[:strings.Index(jsonTag, ",")]
+		if idx := strings.Index(jsonTag, ","); idx > 0 {
+			jsonTag = jsonTag[:idx]
 		}
 		fields[jsonTag] = struct{}{}
 	}

--- a/k8s/translation.go
+++ b/k8s/translation.go
@@ -179,6 +179,66 @@ func marshalJSON(obj resource.Object, extraLabels map[string]string, cfg ClientC
 	return json.Marshal(co)
 }
 
+var metaV1Fields = getV1ObjectMetaFields()
+
+func marshalJSONPatch(patch resource.PatchRequest) ([]byte, error) {
+	// Correct for differing metadata paths in kubernetes
+	for idx, op := range patch.Operations {
+		// We don't allow a patch on the metadata object as a whole
+		if op.Path == "/metadata" {
+			return nil, fmt.Errorf("cannot patch entire metadata object")
+		}
+
+		// We only need to (possibly) correct patch operations for the metadata
+		if len(op.Path) < len("/metadata/") || op.Path[:len("/metadata/")] != "/metadata/" {
+			continue
+		}
+		// If the next part of the path isn't a key in metav1.ObjectMeta, then we put it in annotations
+		parts := strings.Split(strings.Trim(op.Path, "/"), "/")
+		if len(parts) <= 1 {
+			return nil, fmt.Errorf("invalid patch path")
+		}
+		if _, ok := metaV1Fields[parts[1]]; ok {
+			// Normal kube metadata
+			continue
+		}
+		// UNLESS it's extraFields, which holds implementation-specific extra fields
+		if parts[1] == "extraFields" {
+			if len(parts) < 3 {
+				return nil, fmt.Errorf("cannot patch entire extraFields, please patch fields in extraFields instead")
+			}
+			// Just take the remaining part of the path and put it after /metadata
+			// If it's not a valid kubernetes metadata object, that's because the user has done something funny with extraFields,
+			// and it wouldn't be properly encoded/decoded by the translator anyway
+			op.Path = "/metadata/" + strings.Join(parts[2:], "/")
+		} else {
+			// Otherwise, update the path to be in annotations, as that's where all the custom and non-kubernetes common metadata goes
+			// We just have to prefic the remaining part of the path with the annotationPrefix
+			// And replace '/' with '~1' for encoding into a patch path
+			endPart := strings.Join(parts[1:], "~1") // If there were slashes, we need to encode them
+			op.Path = fmt.Sprintf("/metadata/annotations/%s%s", strings.ReplaceAll(annotationPrefix, "/", "~1"), endPart)
+		}
+		patch.Operations[idx] = op
+	}
+	return json.Marshal(patch.Operations)
+}
+
+func getV1ObjectMetaFields() map[string]struct{} {
+	fields := make(map[string]struct{})
+	typ := reflect.TypeOf(metav1.ObjectMeta{})
+	for i := 0; i < typ.NumField(); i++ {
+		jsonTag := typ.Field(i).Tag.Get("json")
+		if len(jsonTag) == 0 || jsonTag[0] == '-' || jsonTag[0] == ',' {
+			continue
+		}
+		if strings.Index(jsonTag, ",") > 0 {
+			jsonTag = jsonTag[:strings.Index(jsonTag, ",")]
+		}
+		fields[jsonTag] = struct{}{}
+	}
+	return fields
+}
+
 func getV1ObjectMeta(obj resource.Object, cfg ClientConfig) metav1.ObjectMeta {
 	cMeta := obj.CommonMetadata()
 	meta := metav1.ObjectMeta{


### PR DESCRIPTION
Translate patch requests in translation layer, as metadata fields that are custom, non-kubernetes common, or are in extraFields need to have their paths updated if the provided path is based on the resource's metadata object. If the provided path uses the kubernetes path, the translation layer will not change it.

This came up while working on admission control, but I think it warrants a separate PR before that upcoming one, which is still in-progress.

Resolves https://github.com/grafana/grafana-app-sdk/issues/14