### PR TITLE
[tutorial] Update Shell Commands to allow for GitHub Copy/Paste

### DIFF
--- a/docs/tutorials/issue-tracker/01-project-init.md
+++ b/docs/tutorials/issue-tracker/01-project-init.md
@@ -2,7 +2,10 @@
 
 Before we can begin, we'll need a directory where our project will live. Feel free to make it wherever you want, and name it however you want. Throughout the rest of this tutorial, if it's referenced, our folder name will be `issue-tracker-project`.
 ```shell
-$ mkdir issue-tracker-project && cd issue-tracker-project
+mkdir issue-tracker-project && cd issue-tracker-project
+```
+So now we have an empty directory to work in. The SDK _can_ be used with an existing project, but the setup is simpler with a fresh one.
+```shell
 $ tree .
 .
 
@@ -11,7 +14,7 @@ $ tree .
 
 Now, we could go about initializing a go module, and a cue module, and creating our directory structure here, but we're going to need the `grafana-app-sdk` CLI later for doing our codegen, and it can help us by easily setting up the start of our project, so let's download it now:
 ```shell
-$ go install github.com/grafana/grafana-app-sdk/cmd/grafana-app-sdk@latest
+go install github.com/grafana/grafana-app-sdk/cmd/grafana-app-sdk@latest
 ```
 If you're unfamiliar with `go install`, it's similar to `go get`, but will compile a binary for the `main` package in what it pulls, and put that in `$GOPATH/bin`. If you don't have `$GOPATH/bin` in your path, you will want to add it, otherwise the CLI commands won't work for you. You can check if the CLI was installed successfully with:
 You can then check if the install was successful by running.
@@ -22,7 +25,10 @@ grafana-app-sdk --help
 ```
 
 Now that we have the CLI installed, let's initialize our project. In this tutorial, we're going to use `github.com/grafana/issue-tracker-project` as our go module name, but you can use whatever name you like--it won't affect anything except some imports on code that we work on later.
-
+```shell
+grafana-app-sdk project init "github.com/grafana/issue-tracker-project"
+```
+And the output of the command:
 ```shell
 $ grafana-app-sdk project init "github.com/grafana/issue-tracker-project"
  * Writing file go.mod

--- a/docs/tutorials/issue-tracker/02-defining-our-kinds.md
+++ b/docs/tutorials/issue-tracker/02-defining-our-kinds.md
@@ -14,7 +14,7 @@ While the SDK technically will work with any objects you define so long as they 
 
 Either copy-and-paste the following CUE into a file called `kinds/issue.cue`, or pull down [`cue/issue-v1.cue`](cue/issue-v1.cue) by running:
 ```shell
-$ curl -o kinds/issue.cue https://raw.githubusercontent.com/grafana/grafana-app-sdk/main/docs/tutorials/issue-tracker/cue/issue-v1.cue
+curl -o kinds/issue.cue https://raw.githubusercontent.com/grafana/grafana-app-sdk/main/docs/tutorials/issue-tracker/cue/issue-v1.cue
 ```
 
 ```cue

--- a/docs/tutorials/issue-tracker/03-generate-kind-code.md
+++ b/docs/tutorials/issue-tracker/03-generate-kind-code.md
@@ -2,6 +2,10 @@
 
 Now that we have our kind and schema defined, we want to generate code from them that we can use. In the future, we'll want to re-generate this code whenever we change anything in our `kinds` directory. The SDK provides a command for this: `grafana-app-sdk generate`, but our project init also gave us a make target which will do the same thing, so you can run either. Here, I'm running the make target:
 ```shell
+make generate
+```
+This command should ouput a list of all the files it writes:
+```shell
 $ make generate
  * Writing file pkg/generated/resource/issue/cue.mod/module.cue
  * Writing file pkg/generated/resource/issue/issue_lineage.cue
@@ -108,7 +112,7 @@ with `metadata` or `status`, they will also show up in the `Metadata` or `Status
 ## Generated TypeScript Code
 
 ```shell
-tree plugin
+$ tree plugin
 plugin
 └── src
     └── generated
@@ -126,7 +130,7 @@ Note that this is a CRD of the kind, not just the schema, so the CRD will contai
 This can be used to set up kubernetes as our storage layer for our project.
 
 ```shell
-tree definitions
+$ tree definitions
 definitions
 └── issue.unknown-plugin.plugins.grafana.com.json
 

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -16,6 +16,10 @@ Usage: grafana-app-sdk project component add [options] <components>
 
 Since we're building out everything we can as part of this tutorial, let's go ahead and add all three project components.
 ```shell
+grafana-app-sdk project component add frontend backend operator
+```
+But this gives us an error:
+```shell
 $ grafana-app-sdk project component add frontend backend operator
 plugin-id is required
 ```
@@ -39,6 +43,10 @@ Global Flags:
 We can leave all the global flags empty, like we have for other commands, but it's good to know how we can find information about the CLI commands. 
 
 Let's give our plugin an ID (I'm going to use `issue-tracker-project`, but you can use anything you want as long as it won't conflict with another plugin), and run the command again:
+```shell
+grafana-app-sdk project component add frontend backend operator --plugin-id="issue-tracker-project"
+```
+Just like with any other command that writes files, the output is a list of all written files:
 ```shell
 $ grafana-app-sdk project component add frontend backend operator --plugin-id="issue-tracker-project"
  * Writing file plugin/README.md

--- a/docs/tutorials/issue-tracker/05-local-deployment.md
+++ b/docs/tutorials/issue-tracker/05-local-deployment.md
@@ -17,12 +17,15 @@ make: *** [build/plugin-backend] Error 1
 
 Hang on, something isn't right. Well, we generated code, and build out boilerplate, but go doesn't know about any of the libraries our boilerplate and generated code need to import. You could run `go get` for all the go files, but our Makefile, again, has us covered:
 ```shell
-$ make deps
-go: finding module for package github.com/grafana/grafana-app-sdk/k8s
-...trimmed output...
+make deps
 ```
+This will `go get` all the go modules we use, and then vendor them in the `vendor` directory.
 
 Now we can run our biuld successfully:
+```shell
+make build
+```
+We get _a lot_ of output for this command:
 ```shell
 $ make build
 Running dependency: github.com/grafana/grafana-plugin-sdk-go/build.Build.GenerateManifestFile-fm


### PR DESCRIPTION
Remove leading '$' from standalone shell commands to enable copy-paste from GH UI. Reformat some command blocks to also allow for this.