### PR TITLE
Use correct string value for cluster-level CRD scope

### DIFF
--- a/resource/schema.go
+++ b/resource/schema.go
@@ -10,7 +10,7 @@ type SchemaScope string
 
 const (
 	NamespacedScope = SchemaScope("Namespaced")
-	ClusterScope    = SchemaScope("Clustered")
+	ClusterScope    = SchemaScope("Cluster")
 )
 
 // Schema represents a schema object


### PR DESCRIPTION
### What

Fix the value for `ClusterScope` schema scope to be `Cluster` instead of `Clustered`.

### Why

Currently the values for cluster-level scope are different between kindsys and app sdk, which means that generating cluster-scoped CRDs is impossible – https://github.com/grafana/kindsys/blob/main/kindcat_custom.cue#L165.

Sine the kindsys value is `Cluster` and that's also the official term in Kubernetes, this is the suggested way to fix the problem
