### PR TITLE
Group is a required field

### DIFF
--- a/docs/tutorials/issue-tracker/02-defining-our-kinds.md
+++ b/docs/tutorials/issue-tracker/02-defining-our-kinds.md
@@ -22,6 +22,7 @@ package kinds
 
 issue: {
 	name: "Issue"
+        group: "issue-tracker-project"
 	crd: {}
 	codegen: {
 		frontend: true


### PR DESCRIPTION
The group field is required. User can miss this if hand-coding the example.