### PR TITLE
Add an error check to keep the linter happy

### DIFF
--- a/codegen/templates/operator/main.tmpl
+++ b/codegen/templates/operator/main.tmpl
@@ -73,5 +73,9 @@ func main() {
     }()
 
     // Run
-    op.Run(stopCh)
+    err = op.Run(stopCh)
+    if err != nil {
+		panic(err)
+	}
+
 }


### PR DESCRIPTION
golangci-lint has version 1.53.3 complained about the missing error value check.