### PR TITLE
Don't attempt to build the plugin if files are missing

### DIFF
--- a/cmd/grafana-app-sdk/templates/Makefile.tmpl
+++ b/cmd/grafana-app-sdk/templates/Makefile.tmpl
@@ -36,12 +36,16 @@ build/plugin: build/plugin-backend build/plugin-frontend
 build/plugin-frontend:
 ifeq ("$(wildcard plugin/plugin.json)","plugin/plugin.json")
 	@cd plugin && yarn install && yarn build
+else
+	@echo "No plugin.json found, skipping frontend build"
 endif
 
 .PHONY: build/plugin-backend
 build/plugin-backend:
 ifeq ("$(wildcard plugin/Magefile.go)","plugin/Magefile.go")
 	@cd plugin && mage -v
+else
+	@echo "No Magefile.go found, skipping backend build"
 endif
 
 .PHONY: build/operator

--- a/cmd/grafana-app-sdk/templates/Makefile.tmpl
+++ b/cmd/grafana-app-sdk/templates/Makefile.tmpl
@@ -34,11 +34,15 @@ build/plugin: build/plugin-backend build/plugin-frontend
 
 .PHONY: build/plugin-frontend
 build/plugin-frontend:
+ifeq ("$(wildcard plugin/plugin.json)","plugin/plugin.json")
 	@cd plugin && yarn install && yarn build
+endif
 
 .PHONY: build/plugin-backend
 build/plugin-backend:
+ifeq ("$(wildcard plugin/Magefile.go)","plugin/Magefile.go")
 	@cd plugin && mage -v
+endif
 
 .PHONY: build/operator
 build/operator:


### PR DESCRIPTION
Check for the existance of plugin.json or Magefile.go before attempting to build the plugin. Fixes #37