### PR TITLE
[operator] Improved Retry Queue logic in InformerController

### DIFF
--- a/operator/informer_controller.go
+++ b/operator/informer_controller.go
@@ -7,9 +7,15 @@ import (
 	"math"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v2"
-
 	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+type ResourceAction string
+
+const (
+	ResourceActionCreate = ResourceAction("CREATE")
+	ResourceActionUpdate = ResourceAction("UPDATE")
+	ResourceActionDelete = ResourceAction("DELETE")
 )
 
 // ErrInformerAlreadyAdded indicates that there is already an informer for the resource kind mapped
@@ -48,6 +54,30 @@ func ExponentialBackoffRetryPolicy(initialDelay time.Duration, maxAttempts int) 
 	}
 }
 
+// RetryDequeuePolicy is a function that defines when a retry should be dequeued when a new action is taken on a resource.
+// It accepts information about the new action being taken, and information about the current queued retry,
+// and returns `true` if the retry should be dequeued.
+// A RetryDequeuePolicy may be called multiple times for the same action, depending on the number of pending retries for the object.
+type RetryDequeuePolicy func(newAction ResourceAction, newObject resource.Object, retryAction ResourceAction, retryObject resource.Object, retryError error) bool
+
+// OpinionatedRetryDequeuePolicy is a RetryDequeuePolicy which has the following logic:
+// 1. If the newAction is a delete, dequeue the retry
+// 2. If the newAction and retryAction are different, keep the retry (for example, a queued create retry, and a received update action)
+// 3. If the generation of newObject and retryObject is the same, keep the retry
+// 4. Otherwise, dequeue the retry
+var OpinionatedRetryDequeuePolicy = func(newAction ResourceAction, newObject resource.Object, retryAction ResourceAction, retryObject resource.Object, retryError error) bool {
+	if newAction == ResourceActionDelete {
+		return true
+	}
+	if newAction != retryAction {
+		return false
+	}
+	if getGeneration(newObject) != getGeneration(retryObject) {
+		return false
+	}
+	return true
+}
+
 // InformerController is an object that handles coordinating informers and observers.
 // Unlike adding a Watcher directly to an Informer with AddEventHandler, the InformerController
 // guarantees sequential execution of watchers, based on add order.
@@ -56,10 +86,13 @@ type InformerController struct {
 	// as retry logic is covered by the RetryPolicy.
 	ErrorHandler func(error)
 	// RetryPolicy is a user-specified retry logic function which will be used when ResourceWatcher function calls fail.
-	RetryPolicy         RetryPolicy
+	RetryPolicy RetryPolicy
+	// RetryDequeuePolicy is a user-specified retry dequeue logic function which will be used for new informer actions
+	// when one or more retries for the object are still pending. If not present, existing retries are always dequeued.
+	RetryDequeuePolicy  RetryDequeuePolicy
 	informers           *ListMap[string, Informer]
 	watchers            *ListMap[string, ResourceWatcher]
-	toRetry             *xsync.MapOf[string, retryInfo]
+	toRetry             *ListMap[string, retryInfo]
 	retryTickerInterval time.Duration
 }
 
@@ -67,6 +100,9 @@ type retryInfo struct {
 	retryAfter time.Time
 	retryFunc  func() error
 	attempt    int
+	action     ResourceAction
+	object     resource.Object
+	err        error
 }
 
 // NewInformerController creates a new controller
@@ -75,7 +111,7 @@ func NewInformerController() *InformerController {
 		RetryPolicy:         DefaultRetryPolicy,
 		informers:           NewListMap[Informer](),
 		watchers:            NewListMap[ResourceWatcher](),
-		toRetry:             xsync.NewMapOf[retryInfo](),
+		toRetry:             NewListMap[retryInfo](),
 		retryTickerInterval: time.Second,
 	}
 }
@@ -89,7 +125,7 @@ func NewInformerController() *InformerController {
 // The most common usage of this is to have informers partitioned by namespace or labels for the same resource kind,
 // which share a watcher.
 //
-//nolint:gocognit
+//nolint:gocognit,funlen,dupl
 func (c *InformerController) AddInformer(informer Informer, resourceKind string) error {
 	if informer == nil {
 		return fmt.Errorf("informer cannot be nil")
@@ -103,8 +139,17 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 			c.watchers.Range(resourceKind, func(idx int, watcher ResourceWatcher) {
 				// Generate the unique key for this object
 				retryKey := c.keyForWatcherEvent(resourceKind, idx, obj)
-				// If we've got a retry queued for this object, stop it
-				c.toRetry.Delete(retryKey)
+
+				// Dequeue retries according to the RetryDequeuePolicy
+				if c.RetryDequeuePolicy != nil {
+					c.toRetry.RemoveItems(retryKey, func(info retryInfo) bool {
+						return c.RetryDequeuePolicy(ResourceActionCreate, obj, info.action, info.object, info.err)
+					}, -1)
+				} else {
+					// If no RetryDequeuePolicy exists, dequeue all retries for the object
+					c.toRetry.RemoveKey(retryKey)
+				}
+
 				// Do the watcher's Add, check for error
 				err := watcher.Add(ctx, obj)
 				if err != nil && c.ErrorHandler != nil {
@@ -119,7 +164,7 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 					}
 					c.queueRetry(retryKey, err, func() error {
 						return closureWatcher.Add(ctx, obj)
-					})
+					}, ResourceActionCreate, obj)
 				}
 			})
 			return nil
@@ -128,8 +173,17 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 			c.watchers.Range(resourceKind, func(idx int, watcher ResourceWatcher) {
 				// Generate the unique key for this object
 				retryKey := c.keyForWatcherEvent(resourceKind, idx, newObj)
-				// If we've got a retry queued for this object, stop it
-				c.toRetry.Delete(retryKey)
+
+				// Dequeue retries according to the RetryDequeuePolicy
+				if c.RetryDequeuePolicy != nil {
+					c.toRetry.RemoveItems(retryKey, func(info retryInfo) bool {
+						return c.RetryDequeuePolicy(ResourceActionUpdate, newObj, info.action, info.object, info.err)
+					}, -1)
+				} else {
+					// If no RetryDequeuePolicy exists, dequeue all retries for the object
+					c.toRetry.RemoveKey(retryKey)
+				}
+
 				// Do the watcher's Update, check for error
 				err := watcher.Update(ctx, oldObj, newObj)
 				if err != nil && c.ErrorHandler != nil {
@@ -144,7 +198,7 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 					}
 					c.queueRetry(retryKey, err, func() error {
 						return closureWatcher.Update(ctx, oldObj, newObj)
-					})
+					}, ResourceActionUpdate, newObj)
 				}
 			})
 			return nil
@@ -153,8 +207,17 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 			c.watchers.Range(resourceKind, func(idx int, watcher ResourceWatcher) {
 				// Generate the unique key for this object
 				retryKey := c.keyForWatcherEvent(resourceKind, idx, obj)
-				// If we've got a retry queued for this object, stop it
-				c.toRetry.Delete(retryKey)
+
+				// Dequeue retries according to the RetryDequeuePolicy
+				if c.RetryDequeuePolicy != nil {
+					c.toRetry.RemoveItems(retryKey, func(info retryInfo) bool {
+						return c.RetryDequeuePolicy(ResourceActionDelete, obj, info.action, info.object, info.err)
+					}, -1)
+				} else {
+					// If no RetryDequeuePolicy exists, dequeue all retries for the object
+					c.toRetry.RemoveKey(retryKey)
+				}
+
 				// Do the watcher's Delete, check for error
 				err := watcher.Delete(ctx, obj)
 				if err != nil && c.ErrorHandler != nil {
@@ -169,7 +232,7 @@ func (c *InformerController) AddInformer(informer Informer, resourceKind string)
 					}
 					c.queueRetry(retryKey, err, func() error {
 						return closureWatcher.Delete(ctx, obj)
-					})
+					}, ResourceActionDelete, obj)
 				}
 			})
 			return nil
@@ -234,33 +297,33 @@ func (c *InformerController) retryTicker(stopCh <-chan struct{}) {
 	for {
 		select {
 		case t := <-ticker.C:
-			c.toRetry.Range(func(key string, val retryInfo) bool {
-				if t.After(val.retryAfter) {
-					err := val.retryFunc()
-					if err != nil {
-						if c.RetryPolicy == nil {
-							// RetryPolicy was removed for some reason
-							c.toRetry.Delete(key)
-							return true
+			for _, key := range c.toRetry.Keys() {
+				// To be simple, we retry all retries which should be done now, and remove them from the list
+				// We then add back in retries which failed and need to be retried again
+				toAdd := make([]retryInfo, 0)
+				c.toRetry.RemoveItems(key, func(val retryInfo) bool {
+					if t.After(val.retryAfter) {
+						err := val.retryFunc()
+						if err != nil && c.RetryPolicy != nil {
+							ok, after := c.RetryPolicy(err, val.attempt+1)
+							if ok {
+								toAdd = append(toAdd, retryInfo{
+									attempt:    val.attempt + 1,
+									retryAfter: t.Add(after),
+									retryFunc:  val.retryFunc,
+									action:     val.action,
+									object:     val.object,
+								})
+							}
 						}
-						ok, after := c.RetryPolicy(err, val.attempt+1)
-						if !ok {
-							// Don't retry anymore
-							c.toRetry.Delete(key)
-							return true
-						}
-
-						c.toRetry.Store(key, retryInfo{
-							attempt:    val.attempt + 1,
-							retryAfter: time.Now().Add(after),
-							retryFunc:  val.retryFunc,
-						})
-					} else {
-						c.toRetry.Delete(key)
+						return true
 					}
+					return false
+				}, -1)
+				for _, inf := range toAdd {
+					c.toRetry.AddItem(key, inf)
 				}
-				return true
-			})
+			}
 		case <-stopCh:
 			return
 		}
@@ -274,17 +337,18 @@ func (*InformerController) keyForWatcherEvent(resourceKind string, watcherIndex 
 	return fmt.Sprintf("%s:%d:%s:%s", resourceKind, watcherIndex, obj.StaticMetadata().Namespace, obj.StaticMetadata().Name)
 }
 
-func (c *InformerController) queueRetry(key string, err error, toRetry func() error) {
+func (c *InformerController) queueRetry(key string, err error, toRetry func() error, action ResourceAction, obj resource.Object) {
 	if c.RetryPolicy == nil {
 		return
 	}
 
 	if ok, after := c.RetryPolicy(err, 0); ok {
-		c.toRetry.Store(key, retryInfo{
+		c.toRetry.AddItem(key, retryInfo{
 			retryAfter: time.Now().Add(after),
 			retryFunc:  toRetry,
+			action:     action,
+			object:     obj,
+			err:        err,
 		})
-	} else {
-		c.toRetry.Delete(key)
 	}
 }

--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -158,8 +158,8 @@ func (o *OpinionatedWatcher) Update(ctx context.Context, old resource.Object, ne
 	}
 
 	// Only fire off Update if the generation has changed (so skip subresource updates)
-	oldGen := o.getGeneration(old)
-	newGen := o.getGeneration(new)
+	oldGen := getGeneration(old)
+	newGen := getGeneration(new)
 	if newGen > 0 && oldGen == newGen {
 		return nil
 	}
@@ -286,7 +286,7 @@ func (*OpinionatedWatcher) getFinalizers(object resource.Object) []string {
 	return make([]string, 0)
 }
 
-func (*OpinionatedWatcher) getGeneration(object resource.Object) int64 {
+func getGeneration(object resource.Object) int64 {
 	g, ok := object.CommonMetadata().ExtraFields["generation"]
 	if !ok {
 		return 0


### PR DESCRIPTION
Currently, in `operator.InformerController`, a user can set a `RetryPolicy` func that will dictate when a failed watcher event should be retried. However, any subsequent actions taken on that object will dequeue any outstanding retries. This is ideal in the default case, where a new update supersedes the old one, but has conflicts with the `OpinionatedWatcher`, as updates which bump the ResourceVersion, but not the Generation, are never received by the underlying update code (`OpinionatedWatcher` drops them and reports back a success). That means if an update fails and enters the retry queue, but a subsequent update which changes non-spec content is received, the outstanding retry for the original update, _which still needs to be performed_, is dropped, and the update code behind the `OpinionatedWatcher` is never actually called, making reconciliation impossible. 

There are additional edge cases where a user may not wish to drop outstanding retries, such as when an add is being retried and an update comes in, but update and add do distinct enough things that both handlers should still be called.

This PR addresses this issue by adding an optional exported field in the `InformerController`: `RetryDequeuePolicy`. When nil, all outstanding retries are dequeued the same as normal, but when present, a user can dictate if a retry should be dequeued or not. The function is passed information about the current action and the retry action to possibly dequeue.

An "opinionated" `RetryDequeuePolicy` is also made available for a user, which follows logic that gels with the `OpinionatedWatcher`, but also allows for concurrent retries which are for different actions (i.e. an add and an update).

Some changes were made to the retry logic to handle multiple retries for the same object (namely moving from a `xsync.MapOf` to `ListMap`), but the core logic of how retries works remains the same.