### PR TITLE
[bugfix] OpinionatedRetryDequeuePolicy incorrect equality check

### DIFF
--- a/operator/informer_controller.go
+++ b/operator/informer_controller.go
@@ -72,7 +72,7 @@ var OpinionatedRetryDequeuePolicy = func(newAction ResourceAction, newObject res
 	if newAction != retryAction {
 		return false
 	}
-	if getGeneration(newObject) != getGeneration(retryObject) {
+	if getGeneration(newObject) == getGeneration(retryObject) {
 		return false
 	}
 	return true


### PR DESCRIPTION
Fix bug in the OpinionatedRetryDequeuePolicy where it would dequeue on the same generation instead of on different generations, added tests for the policy to ensure it behaves correctly.