### PR TITLE
[Actions] Fix Linter Version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: '1.51.2'
         args: --timeout 3m 
         only-new-issues: true
   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: '1.51.2'
+        version: v1.51.2
         args: --timeout 3m 
         only-new-issues: true
   


### PR DESCRIPTION
Use the same version of golangci-lint in the GH actions as we do in the Makefile.