### PR TITLE
[bugfix] Translate RawToObject fix for newer Thema versions

### DIFF
--- a/k8s/translation.go
+++ b/k8s/translation.go
@@ -58,9 +58,21 @@ func rawToObject(raw []byte, into resource.Object) error {
 			meta[k[len(annotationPrefix):]] = v
 		}
 	}
+	// All the (required) CommonMetadata fields--thema parse gets mad otherwise
+	// TODO: overhaul this whole thing so we can just set everything in the metadata without a two-step process
 	if _, ok := meta["updateTimestamp"]; !ok {
 		meta["updateTimestamp"] = kubeObject.ObjectMetadata.CreationTimestamp.Format(time.RFC3339Nano)
 	}
+	if _, ok := meta["createdBy"]; !ok {
+		meta["createdBy"] = ""
+	}
+	if _, ok := meta["updatedBy"]; !ok {
+		meta["updatedBy"] = ""
+	}
+	meta["resourceVersion"] = kubeObject.ObjectMetadata.ResourceVersion
+	meta["uid"] = kubeObject.ObjectMetadata.UID
+	meta["creationTimestamp"] = kubeObject.ObjectMetadata.CreationTimestamp
+
 	amd, err := json.Marshal(meta)
 	if err != nil {
 		return err


### PR DESCRIPTION
Thema in generated code was unhappy with the unmarshal call missing a few fields in the metadata. Made sure those fields are present. This is a short-term fix, with a better, full fix that should be done to make sure the complete metadata object is passed to the Unmarshal call, rather than being fragmented between Unmarshal and SetCommonMetadata.