### PR TITLE
Chore: move kindsys into app-sdk and simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ See [Writing Back-End Plugins](docs/plugin-backend.md) for more details on using
 
 ## Dependencies
 
-The grafana-app-sdk code generation uses [kindsys](https://github.com/grafana/kindsys) for it's CUE kind definitions, and [thema](https://github.com/grafana/thema) for the generated code's unmarshaling.
+The grafana-app-sdk code generation uses [kindsys](https://github.com/grafana/grafana-app-sdk/kindsys) for it's CUE kind definitions, and [thema](https://github.com/grafana/thema) for the generated code's unmarshaling.
 
-If you use the generated code, you must take a project dependency on [thema](https://github.com/grafana/thema), as it is used as a depndency in the generated code (kindsys is only used in the generation process, and is not needed in your project).
+If you use the generated code, you must take a project dependency on [thema](https://github.com/grafana/thema), as it is used as a dependency in the generated code (kindsys is only used in the generation process, and is not needed in your project).
 
 ## Further Reading
 

--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -8,7 +8,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"

--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -14,7 +14,7 @@ import (
 	"text/template"
 
 	"cuelang.org/go/cue/cuecontext"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/spf13/cobra"
 

--- a/cmd/grafana-app-sdk/templates/kind.cue.tmpl
+++ b/cmd/grafana-app-sdk/templates/kind.cue.tmpl
@@ -62,7 +62,7 @@ package {{ .Package }}
 			// common across all kinds, and becomes present in the unified lineage used for code generation and other tooling.
 			// `metadata` is optional, and should contain kind- or schema-specific metadata. The kind system adds
 			// an explicit set of common metadata which can be found at in the kindsys public repository at:
-			// https://github.com/grafana/kindsys/blob/452481b6348225a1bdb02c9abaef25d29ffe680d/kindcat_custom.cue#L25
+			// https://github.com/grafana/grafana-app-sdk/kindsys/blob/452481b6348225a1bdb02c9abaef25d29ffe680d/kindcat_custom.cue#L25
 			// additional metadata fields cannot conflict with the kindsys common metadata
 			{{end}}schema: {
 				{{ if eq .Target "model" }}// Example fields, make sure to use int32 or int64 types instead of int for Thema compatibility

--- a/codegen/generator_backendplugin.go
+++ b/codegen/generator_backendplugin.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/generator_crd.go
+++ b/codegen/generator_crd.go
@@ -7,7 +7,7 @@ import (
 	cueopenapi "cuelang.org/go/encoding/openapi"
 	cueyaml "cuelang.org/go/pkg/encoding/yaml"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/openapi"
 	goyaml "gopkg.in/yaml.v3"

--- a/codegen/generator_gotypes.go
+++ b/codegen/generator_gotypes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/gocode"
 	"github.com/grafana/thema/encoding/openapi"

--- a/codegen/generator_gotypes_test.go
+++ b/codegen/generator_gotypes_test.go
@@ -7,7 +7,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/codegen/generator_lineage.go
+++ b/codegen/generator_lineage.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/generator_operator.go
+++ b/codegen/generator_operator.go
@@ -6,7 +6,7 @@ import (
 	"go/format"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/generator_resourceobject.go
+++ b/codegen/generator_resourceobject.go
@@ -9,7 +9,7 @@ import (
 
 	"cuelang.org/go/cue"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 	"github.com/grafana/grafana-app-sdk/resource"

--- a/codegen/generator_routercode.go
+++ b/codegen/generator_routercode.go
@@ -6,7 +6,7 @@ import (
 	"go/format"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/generator_schema.go
+++ b/codegen/generator_schema.go
@@ -6,7 +6,7 @@ import (
 	"go/format"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 	"github.com/grafana/grafana-app-sdk/resource"

--- a/codegen/generator_typescript.go
+++ b/codegen/generator_typescript.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cuetsy"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema/encoding/typescript"
 )
 

--- a/codegen/generator_wrappedtype.go
+++ b/codegen/generator_wrappedtype.go
@@ -6,7 +6,7 @@ import (
 	"go/format"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/generators.go
+++ b/codegen/generators.go
@@ -2,7 +2,7 @@ package codegen
 
 import (
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )

--- a/codegen/parser.go
+++ b/codegen/parser.go
@@ -8,7 +8,7 @@ import (
 
 	"cuelang.org/go/cue"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/load"
 	"github.com/hashicorp/go-multierror"

--- a/codegen/parser_test.go
+++ b/codegen/parser_test.go
@@ -8,7 +8,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/grafana/codejen"
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 	"github.com/grafana/thema"
 	"github.com/stretchr/testify/assert"
 )

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana-app-sdk/kindsys"
 )
 
 //go:embed *.tmpl plugin/*.tmpl secure/*.tmpl operator/*.tmpl

--- a/docs/custom-kinds.md
+++ b/docs/custom-kinds.md
@@ -3,7 +3,7 @@
 Custom kinds are the base of code generation in the SDK, and are considered the canonical data model for all resource types handled by the SDK. 
 Custom kinds are defined in CUE.
 
-The CUE definition of a custom kind lives in [kindsys](https://github.com/grafana/kindsys/blob/ebfbbc0e58bf49a00a658341f3286ba5fecc056d/kindcat_custom.cue#L106). When writing a custom kind, you do not need to import kindsys (or thema), as they are implicitly imported as part of the code generation process. 
+The CUE definition of a custom kind lives in [kindsys](https://github.com/grafana/grafana-app-sdk/kindsys/blob/ebfbbc0e58bf49a00a658341f3286ba5fecc056d/kindcat_custom.cue#L106). When writing a custom kind, you do not need to import kindsys (or thema), as they are implicitly imported as part of the code generation process. 
 Instead, you only need to define values which have no deafults (and you are free to define values where you want to diverge from the defaults).
 
 If you have an existing project, you can create a template for a new kind using the CLI with

--- a/docs/tutorials/issue-tracker/02-defining-our-kinds.md
+++ b/docs/tutorials/issue-tracker/02-defining-our-kinds.md
@@ -48,7 +48,7 @@ issue: {
 
 Alright, let's break down what we just wrote.
 
-Like with Go code, any cue file needs to start with a package declaration. In this case, our package is `kinds`. After the package declaration, we can optionally import other CUE packages (for example, `time` if you wanted to use `time.Time` types) using the same syntax as one might with Go. After that, you declare fields. With the grafana-app-sdk, we assume that every top-level field is a kind, and adheres to the [kindsys.Custom](https://github.com/grafana/kindsys/blob/df4488cce33697eccba0536970114fff02b81020/kindcat_custom.cue#L106) kind. That's what our `issue` field is--a Custom kind declaration.
+Like with Go code, any cue file needs to start with a package declaration. In this case, our package is `kinds`. After the package declaration, we can optionally import other CUE packages (for example, `time` if you wanted to use `time.Time` types) using the same syntax as one might with Go. After that, you declare fields. With the grafana-app-sdk, we assume that every top-level field is a kind, and adheres to the [kindsys.Custom](https://github.com/grafana/grafana-app-sdk/kindsys/blob/df4488cce33697eccba0536970114fff02b81020/kindcat_custom.cue#L106) kind. That's what our `issue` field is--a Custom kind declaration.
 
 Now, we get to the actual definition of our `issue` model:
 ```cue

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/grafana/codejen v0.0.3
 	github.com/grafana/cuetsy v0.1.11
 	github.com/grafana/grafana-plugin-sdk-go v0.173.0
-	github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482
 	github.com/grafana/thema v0.0.0-20230511182720-3146087fcc26
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/puzpuzpuz/xsync/v2 v2.5.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	github.com/yalue/merged_fs v1.2.2
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
@@ -96,7 +97,6 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
-	github.com/yalue/merged_fs v1.2.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.42.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cuelang.org/go v0.5.0 h1:D6N0UgTGJCOxFKU8RU+qYvavKNsVc/+ZobmifStVJzU=
 cuelang.org/go v0.5.0/go.mod h1:okjJBHFQFer+a41sAe2SaGm1glWS8oEb6CmJvn5Zdws=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -188,8 +189,6 @@ github.com/grafana/cuetsy v0.1.11 h1:I3IwBhF+UaQxRM79HnImtrAn8REGdb5M3+C4QrYHoWk
 github.com/grafana/cuetsy v0.1.11/go.mod h1:Ix97+CPD8ws9oSSxR3/Lf4ahU1I4Np83kjJmDVnLZvc=
 github.com/grafana/grafana-plugin-sdk-go v0.173.0 h1:hZdLi+dF0Y5aRpcjpXyKYRXU7oNpg/wpzTa2/YjWvl0=
 github.com/grafana/grafana-plugin-sdk-go v0.173.0/go.mod h1:9crAQqSzxvPe0VKC/T23cd+2I9TZb43yoOcUL/qZ5FU=
-github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482 h1:1YNoeIhii4UIIQpCPU+EXidnqf449d0C3ZntAEt4KSo=
-github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482/go.mod h1:GNcfpy5+SY6RVbNGQW264gC0r336Dm+0zgQ5vt6+M8Y=
 github.com/grafana/thema v0.0.0-20230511182720-3146087fcc26 h1:HX927q4X1n451pnGb8U0wq74i8PCzuxVjzv7TyD10kc=
 github.com/grafana/thema v0.0.0-20230511182720-3146087fcc26/go.mod h1:Pn9nfzCk7nV0mvNgwusgCjCROZP6nm4GpwTnmEhLT24=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/kindsys/README.md
+++ b/kindsys/README.md
@@ -1,0 +1,5 @@
+# kindsys
+
+This is the cue+thema + global kindsys wrapper for k8s objects.
+
+Further development on thema is on hold while we evaluate options.

--- a/kindsys/bind_core.go
+++ b/kindsys/bind_core.go
@@ -1,0 +1,50 @@
+package kindsys
+
+import (
+	"github.com/grafana/thema"
+)
+
+// genericCore is a general representation of a parsed and validated Core kind.
+type genericCore struct {
+	def Def[CoreProperties]
+	lin thema.Lineage
+}
+
+var _ Core = genericCore{}
+
+func (k genericCore) Props() SomeKindProperties {
+	return k.def.Properties
+}
+
+func (k genericCore) Name() string {
+	return k.def.Properties.Name
+}
+
+func (k genericCore) MachineName() string {
+	return k.def.Properties.MachineName
+}
+
+func (k genericCore) Maturity() Maturity {
+	return k.def.Properties.Maturity
+}
+
+func (k genericCore) Def() Def[CoreProperties] {
+	return k.def
+}
+
+func (k genericCore) Lineage() thema.Lineage {
+	return k.lin
+}
+
+// TODO docs
+func BindCore(rt *thema.Runtime, def Def[CoreProperties], opts ...thema.BindOption) (Core, error) {
+	lin, err := def.Some().BindKindLineage(rt, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return genericCore{
+		def: def,
+		lin: lin,
+	}, nil
+}

--- a/kindsys/bind_custom.go
+++ b/kindsys/bind_custom.go
@@ -1,0 +1,58 @@
+package kindsys
+
+import (
+	"github.com/grafana/thema"
+)
+
+// genericCustom is a general representation of a parsed and validated Custom kind.
+type genericCustom struct {
+	def Def[CustomProperties]
+	lin thema.Lineage
+}
+
+var _ Custom = genericCustom{}
+
+// Props returns the generic SomeKindProperties
+func (k genericCustom) Props() SomeKindProperties {
+	return k.def.Properties
+}
+
+// Name returns the Name property
+func (k genericCustom) Name() string {
+	return k.def.Properties.Name
+}
+
+// MachineName returns the MachineName property
+func (k genericCustom) MachineName() string {
+	return k.def.Properties.MachineName
+}
+
+// Maturity returns the Maturity property
+func (k genericCustom) Maturity() Maturity {
+	return k.def.Properties.Maturity
+}
+
+// Def returns a Def with the type of ExtendedProperties, containing the bound ExtendedProperties
+func (k genericCustom) Def() Def[CustomProperties] {
+	return k.def
+}
+
+// Lineage returns the underlying bound Lineage
+func (k genericCustom) Lineage() thema.Lineage {
+	return k.lin
+}
+
+// BindCustom creates a Custom-implementing type from a def, runtime, and opts
+//
+//nolint:lll
+func BindCustom(rt *thema.Runtime, def Def[CustomProperties], opts ...thema.BindOption) (Custom, error) {
+	lin, err := def.Some().BindKindLineage(rt, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return genericCustom{
+		def: def,
+		lin: lin,
+	}, nil
+}

--- a/kindsys/cue.mod/module.cue
+++ b/kindsys/cue.mod/module.cue
@@ -1,0 +1,1 @@
+module: "github.com/grafana/grafana-app-sdk/kindsys"

--- a/kindsys/embed.go
+++ b/kindsys/embed.go
@@ -1,0 +1,10 @@
+package kindsys
+
+import (
+	"embed"
+)
+
+// CueSchemaFS embeds all CUE files in the Kindsys project.
+//
+//go:embed cue.mod/module.cue *.cue
+var CueSchemaFS embed.FS

--- a/kindsys/errors.go
+++ b/kindsys/errors.go
@@ -1,0 +1,18 @@
+package kindsys
+
+import "errors"
+
+// TODO consider rewriting with https://github.com/cockroachdb/errors
+
+var (
+	// ErrValueNotExist indicates that a necessary CUE value did not exist.
+	ErrValueNotExist = errors.New("cue value does not exist")
+
+	// ErrValueNotAKind indicates that a provided CUE value is not any variety of
+	// Kind. This is almost always a user error - they oops'd and provided the
+	// wrong path, file, etc.
+	ErrValueNotAKind = errors.New("not a kind")
+
+	// ErrInvalidCUE indicates that the CUE representing the kind is invalid.
+	ErrInvalidCUE = errors.New("CUE syntax error")
+)

--- a/kindsys/kind.go
+++ b/kindsys/kind.go
@@ -1,0 +1,85 @@
+package kindsys
+
+import (
+	"fmt"
+
+	"github.com/grafana/thema"
+)
+
+// TODO docs
+type Maturity string
+
+const (
+	MaturityMerged       Maturity = "merged"
+	MaturityExperimental Maturity = "experimental"
+	MaturityStable       Maturity = "stable"
+	MaturityMature       Maturity = "mature"
+)
+
+func maturityIdx(m Maturity) int {
+	// icky to do this globally, this is effectively setting a default
+	if string(m) == "" {
+		m = MaturityMerged
+	}
+
+	for i, ms := range maturityOrder {
+		if m == ms {
+			return i
+		}
+	}
+	panic(fmt.Sprintf("unknown maturity milestone %s", m))
+}
+
+var maturityOrder = []Maturity{
+	MaturityMerged,
+	MaturityExperimental,
+	MaturityStable,
+	MaturityMature,
+}
+
+func (m Maturity) Less(om Maturity) bool {
+	return maturityIdx(m) < maturityIdx(om)
+}
+
+func (m Maturity) String() string {
+	return string(m)
+}
+
+// Kind describes a Grafana kind object: a Go representation of the definition of
+// one of Grafana's categories of kinds.
+type Kind interface {
+	// Props returns a [kindsys.SomeKindProps], representing the properties
+	// of the kind as declared in the .cue source. The underlying type is
+	// determined by the category of kind.
+	//
+	// This method is largely for convenience, as all actual kind categories are
+	// expected to implement one of the other interfaces, each of which contain
+	// a Def() method through which these same properties are accessible.
+	Props() SomeKindProperties
+
+	// TODO docs
+	Lineage() thema.Lineage
+
+	// TODO remove, unnecessary with Props()
+	Name() string
+
+	// TODO remove, unnecessary with Props()
+	MachineName() string
+
+	// TODO remove, unnecessary with Props()
+	Maturity() Maturity // TODO unclear if we want maturity for raw kinds
+}
+
+type Core interface {
+	Kind
+
+	// TODO docs
+	Def() Def[CoreProperties]
+}
+
+type Custom interface {
+	Kind
+
+	// TODO docs
+	Def() Def[CustomProperties]
+}

--- a/kindsys/kindcat_custom.cue
+++ b/kindsys/kindcat_custom.cue
@@ -1,0 +1,175 @@
+package kindsys
+
+import (
+	"strings"
+	"struct"
+	"time"	
+)
+
+// _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.
+// It is not exhaustive and only includes fields which may be relevant to a kind's implementation,
+// As it is also intended to be generic enough to function with any API Server.
+_kubeObjectMetadata: {
+    uid: string
+    creationTimestamp: string & time.Time
+    deletionTimestamp?: string & time.Time
+    finalizers: [...string]
+    resourceVersion: string
+    labels: {
+        [string]: string
+    }
+}
+
+// CommonMetadata is a combination of API Server metadata and additional metadata 
+// intended to exist commonly across all kinds, but may have varying implementations as to its storage mechanism(s).
+CommonMetadata: {
+    _kubeObjectMetadata
+
+    updateTimestamp: string & time.Time
+    createdBy: string
+    updatedBy: string
+
+	// TODO: additional metadata fields?
+
+	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
+	extraFields: {
+		[string]: _
+	}
+}
+
+// _crdSchema is the schema format for a CRD.
+_crdSchema: {
+	// metadata contains embedded CommonMetadata and can be extended with custom string fields
+	// TODO: use CommonMetadata instead of redefining here; currently needs to be defined here 
+	// without external reference as using the CommonMetadata reference breaks thema codegen.
+	metadata: {
+		_kubeObjectMetadata
+		
+		updateTimestamp: string & time.Time
+		createdBy: string
+		updatedBy: string
+
+		// TODO: additional metadata fields?
+		// Additional metadata can be added at any future point, as it is allowed to be constant across lineage versions
+
+		// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
+		extraFields: {
+			[string]: _
+		}
+	} & {
+		// All extensions to this metadata need to have string values (for APIServer encoding-to-annotations purposes)
+		// Can't use this as it's not yet enforced CUE:
+		//...string
+		// Have to do this gnarly regex instead
+		[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
+	}
+	spec: _
+
+	// cuetsy is not happy creating spec with the MinFields constraint directly
+	_specIsNonEmpty: spec & struct.MinFields(0)
+
+	status: {
+		#OperatorState: {
+			// lastEvaluation is the ResourceVersion last evaluated
+			lastEvaluation: string
+			// state describes the state of the lastEvaluation.
+			// It is limited to three possible states for machine evaluation.
+			state: "success" | "in_progress" | "failed"
+			// descriptiveState is an optional more descriptive state field which has no requirements on format
+			descriptiveState?: string
+			// details contains any extra information that is operator-specific
+			details?: {
+				[string]: _
+			}
+		}
+		// operatorStates is a map of operator ID to operator state evaluations.
+		// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
+		operatorStates?: {
+			[string]: #OperatorState
+		}
+		// additionalFields is reserved for future use
+		additionalFields?: {
+			[string]: _
+		}
+	} & {
+		[string]: _
+	}
+}
+
+// Custom specifies the kind category for plugin-defined arbitrary types.
+// Custom kinds have the same purpose as Core kinds, differing only in
+// that they are defined by external plugins rather than in Grafana core. As such,
+// this specification is kept closely aligned with the Core kind.
+//
+// Grafana provides Kubernetes apiserver-shaped HTTP APIs for interacting with custom
+// kinds - the same API patterns (and clients) used to interact with k8s CustomResources.
+Custom: S={
+	_sharedKind
+
+	// group is the unique identifier of owner/grouping of this Custom kind
+	group: =~"^([a-z][a-z0-9-]*[a-z0-9])$"
+
+	// isCRD is true if the `crd` trait is present in the kind.
+	isCRD: S.crd != _|_
+
+	lineage: { 
+		name: S.machineName
+	}
+	lineageIsGroup: false
+
+	if isCRD {
+		// If the crd trait is defined, the schemas in the lineage must follow the format:
+		// {
+		//     "metadata": CommonMetadata & {...string}
+		//     "spec": {...}
+		//     "status": {...}
+		// }
+		lineage: joinSchema: _crdSchema
+	}
+
+	// crd contains properties specific to converting this kind to a Kubernetes CRD.
+	// Unlike in Core, crd is optional and is used as a signaling mechanism for whether the kind is intended to be registered as a Kubernetes CRD 
+	// and/or a resource in a compatible API server. When present, additional structure is enforced on the kind's lineage's schemas.
+	// When absent, a lineage's schema has no restrictions as it is assumed that a CRD or similar resource type will not be generated from it.
+	// 
+	// TODO: rather than `crd`, should this trait be something more generic, as it really indicates more if a resource should be available in a
+	// kubernetes-compatible APIServer, not specifically as CRD (though that _is_ an implementation)
+	crd?: {
+		// groupOverride is used to override the auto-generated group of "<group>.ext.grafana.com"
+		// if present, this value is used for the CRD group instead.
+		// groupOverride must have at least two parts (i.e. 'foo.bar'), but can be longer.
+		// The length of groupOverride + kind name cannot exceed 62 characters
+		groupOverride?: =~"^([a-z][a-z0-9-.]{0,48}[a-z0-9])\\.([a-z][a-z0-9-]{0,48}[a-z0-9])$"
+
+		// _computedGroups is a list of groups computed from information in the plugin trait.
+		// The first element is always the "most correct" one to use.
+		// This field could be inlined into `group`, but is separate for clarity.
+		_computedGroups: [
+			if S.crd.groupOverride != _|_ {
+				strings.ToLower(S.crd.groupOverride),
+			}
+			strings.ToLower(strings.Replace(S.group, "_","-",-1)) + ".ext.grafana.com"
+		]
+
+		// group is used as the CRD group name in the GVK.
+		// It is computed from information in the plugin trait, using plugin.id unless groupName is specified.
+		// The length of the computed group + the length of the name (plus 1) cannot exceed 63 characters for a valid CRD.
+		// This length restriction is checked via _computedGroupKind
+		group: _computedGroups[0] & =~"^([a-z][a-z0-9-.]{0,61}[a-z0-9])$"
+
+		// _computedGroupKind checks the validity of the CRD kind + group
+		_computedGroupKind: S.machineName + "." + group & =~"^([a-z][a-z0-9-.]{0,63}[a-z0-9])$"
+
+		// scope determines whether resources of this kind exist globally ("Cluster") or
+		// within Kubernetes namespaces.
+		scope: "Cluster" | *"Namespaced"
+	}
+
+	// codegen contains properties specific to generating code using tooling
+	codegen: {
+		// frontend indicates whether front-end TypeScript code should be generated for this kind's schema
+		frontend: bool | *true
+		// backend indicates whether back-end Go code should be generated for this kind's schema
+		backend: bool | *true
+	}
+}

--- a/kindsys/kindcats.cue
+++ b/kindsys/kindcats.cue
@@ -1,0 +1,126 @@
+package kindsys
+
+import (
+	"strings"
+
+	"github.com/grafana/thema"
+)
+
+// A Kind is a specification for a type of object that Grafana knows
+// how to work with. Each kind definition contains a schema, and some
+// declarative metadata and constraints.
+//
+// An instance of a kind is called a resource. Resources are a sequence of
+// bytes - for example, a JSON file or HTTP request body - that conforms
+// to the schemas and other constraints defined in a Kind.
+//
+// Once Grafana has determined a given byte sequence to be an
+// instance of a known Kind, kind-specific behaviors can be applied,
+// requests can be routed, events can be triggered, etc.
+//
+// Grafana's kinds are similar to Kubernetes CustomResourceDefinitions.
+// Grafana provides a standard mechanism for representing its kinds as CRDs.
+//
+Kind: Core | Custom
+
+// properties shared between all kind categories.
+_sharedKind: {
+	// name is the canonical name of a Kind, as expressed in PascalCase.
+	//
+	// To ensure names are generally portable and amenable for consumption
+	// in various mechanical tasks, name largely follows the relatively
+	// strict DNS label naming standard as defined in RFC 1123:
+	//  - Contain at most 63 characters
+	//  - Contain only lowercase alphanumeric characters or '-'
+	//  - Start with an uppercase alphabetic character
+	//  - End with an alphanumeric character
+	name: =~"^([A-Z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$"
+
+	// machineName is the case-normalized (lowercase) version of [name]. This
+	// version of the name is preferred for use in most mechanical contexts,
+	// as case normalization ensures that case-insensitive and case-sensitive
+	// checks will never disagree on uniqueness.
+	//
+	// In addition to lowercase normalization, dashes are transformed to underscores.
+	machineName: strings.ToLower(strings.Replace(name, "-", "_", -1))
+
+	// pluralName is the pluralized form of name. Defaults to name + "s".
+	pluralName: =~"^([A-Z][a-zA-Z0-9-]{0,61}[a-zA-Z])$" | *(name + "s")
+
+	// pluralMachineName is the pluralized form of [machineName]. The same case
+	// normalization and dash transformation is applied to [pluralName] as [machineName]
+	// applies to [name].
+	pluralMachineName: strings.ToLower(strings.Replace(pluralName, "-", "_", -1))
+
+	// lineageIsGroup indicates whether the lineage in this kind is "grouped". In a
+	// grouped lineage, each top-level field in the schema specifies a discrete
+	// object that is expected to exist in the wild
+	//
+	// This value of this field is set by the kindsys framework. It cannot be changed
+	// in the definition of any individual kind.
+	//
+	// This is likely to eventually become a first-class property in Thema:
+	// https://github.com/grafana/thema/issues/62
+	lineageIsGroup: bool
+
+	// lineage is the Thema lineage containing all the schemas that have existed for this kind.
+	lineage: thema.#Lineage
+
+	// currentVersion is computed to be the syntactic version number of the latest
+	// schema in lineage.
+	currentVersion: lineage.#LatestVersion
+
+	maturity: Maturity
+
+	// The kind system itself is not mature enough yet for any single
+	// kind to advance beyond "experimental"
+	// TODO allow more maturity stages once system is ready https://github.com/orgs/grafana/projects/133/views/8
+	maturity: *"merged" | "experimental"
+}
+
+// properties shared by all kinds that represent a complete object from root (i.e., not composable)
+_rootKind: {
+	// description is a brief narrative description of the nature and purpose of the kind.
+	// The contents of this field is shown to end users. Prefer clear, concise wording
+	// with minimal jargon.
+	description: nonEmptyString
+}
+
+// Maturity indicates the how far a given kind definition is in its initial
+// journey. Mature kinds still evolve, but with guarantees about compatibility.
+Maturity: "merged" | "experimental" | "stable" | "mature"
+
+// Core specifies the kind category for core-defined arbitrary types.
+// Familiar types and functional resources in Grafana, such as dashboards and
+// and datasources, are represented as core kinds.
+Core: S=close({
+	_sharedKind
+	_rootKind
+
+	lineage: { name: S.machineName, joinSchema: _crdSchema }
+	lineageIsGroup: false
+
+	// crd contains properties specific to converting this kind to a Kubernetes CRD.
+	crd: {
+		// group is used as the CRD group name in the GVK.
+		group: "\(S.machineName).core.grafana.com"
+
+		// scope determines whether resources of this kind exist globally ("Cluster") or
+		// within Kubernetes namespaces.
+		scope: "Cluster" | *"Namespaced"
+
+		// dummySchema determines whether a dummy OpenAPI schema - where the schema is
+		// simply an empty, open object - should be generated for the kind.
+		//
+		// It is a goal that this option eventually be force dto false. Only set to
+		// true when Grafana's code generators produce OpenAPI that is rejected by
+		// Kubernetes' CRD validation.
+		dummySchema: bool | *false
+
+		// deepCopy determines whether a generic implementation of copying should be
+		// generated, or a passthrough call to a Go function.
+		//   deepCopy: *"generic" | "passthrough"
+	}
+})
+
+nonEmptyString: string & strings.MinRunes(1)

--- a/kindsys/load.go
+++ b/kindsys/load.go
@@ -1,0 +1,225 @@
+package kindsys
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sync"
+	"testing/fstest"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/errors"
+	"github.com/grafana/thema/load"
+	"github.com/yalue/merged_fs"
+)
+
+var defaultFramework cue.Value
+var fwOnce sync.Once
+var ctx = cuecontext.New()
+
+// cueContext returns a singleton instance of [cue.Context].
+func cueContext() *cue.Context {
+	return ctx
+}
+
+func init() {
+	loadpFrameworkOnce()
+}
+
+func loadpFrameworkOnce() {
+	fwOnce.Do(func() {
+		var err error
+		defaultFramework, err = doLoadFrameworkCUE(cueContext())
+		if err != nil {
+			panic(err)
+		}
+		ctx = cuecontext.New()
+	})
+}
+
+func doLoadFrameworkCUE(ctx *cue.Context) (cue.Value, error) {
+	v, err := BuildInstance(ctx, ".", "kindsys", nil)
+	if err != nil {
+		return v, err
+	}
+
+	if err = v.Validate(cue.Concrete(false), cue.All()); err != nil {
+		return cue.Value{}, fmt.Errorf("kindsys framework loaded cue.Value has err: %w", err)
+	}
+
+	return v, nil
+}
+
+func BuildInstance(ctx *cue.Context, relpath string, pkg string, overlay fs.FS) (cue.Value, error) {
+	bi, err := LoadInstance(relpath, pkg, overlay)
+	if err != nil {
+		return cue.Value{}, err
+	}
+
+	if ctx == nil {
+		ctx = cueContext()
+	}
+
+	v := ctx.BuildInstance(bi)
+	if v.Err() != nil {
+		return v, fmt.Errorf("%s not a valid CUE instance: %w", relpath, v.Err())
+	}
+	return v, nil
+}
+
+// LoadInstance returns a build.Instance populated with the CueSchemaFS at the root and
+// an optional overlay filesystem.
+func LoadInstance(relpath string, pkg string, overlay fs.FS) (*build.Instance, error) {
+	relpath = filepath.ToSlash(relpath)
+
+	var f fs.FS = CueSchemaFS
+	var err error
+	if overlay != nil {
+		f, err = prefixWithCUE(relpath, overlay)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if pkg != "" {
+		return load.InstanceWithThema(f, relpath, load.Package(pkg))
+	}
+	return load.InstanceWithThema(f, relpath)
+}
+
+// prefixWithCUE constructs an fs.FS that merges the provided fs.FS with the
+// embedded FS containing kindsys core CUE files, CueSchemaFS. The provided
+// prefix should be the relative path from the repository root to the directory
+// root of the provided inputfs.
+//
+// The returned fs.FS is suitable for passing to a CUE loader, such as
+// [load.InstanceWithThema].
+func prefixWithCUE(prefix string, inputfs fs.FS) (fs.FS, error) {
+	m, err := prefixFS(prefix, inputfs)
+	if err != nil {
+		return nil, err
+	}
+	return merged_fs.NewMergedFS(m, CueSchemaFS), nil
+}
+
+// TODO such a waste, replace with stateless impl that just transforms paths on the fly
+func prefixFS(prefix string, fsys fs.FS) (fs.FS, error) {
+	m := make(fstest.MapFS)
+
+	prefix = filepath.FromSlash(prefix)
+	err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		b, err := fs.ReadFile(fsys, filepath.ToSlash(path))
+		if err != nil {
+			return err
+		}
+		// fstest can recognize only forward slashes.
+		m[filepath.ToSlash(filepath.Join(prefix, path))] = &fstest.MapFile{Data: b}
+		return nil
+	})
+	return m, err
+}
+
+// CUEFramework returns a cue.Value representing all the kindsys framework raw
+// CUE files.
+//
+// For low-level use in constructing other types and APIs, while still letting
+// us define all the frameworky CUE bits in a single package. Other Go types
+// make the constructs in the returned cue.Value easy to use.
+//
+// Calling this with a nil [cue.Context] (the singleton returned from
+// [CUEContext]) will memoize certain CUE operations. Prefer passing nil unless
+// a different cue.Context is specifically required.
+func CUEFramework(ctx *cue.Context) cue.Value {
+	if ctx == nil || ctx == cueContext() {
+		// Ensure framework is loaded, even if this func is called
+		// from an init() somewhere.
+		loadpFrameworkOnce()
+		return defaultFramework
+	}
+	// Error guaranteed to be nil here because erroring would have caused init() to panic
+	v, _ := doLoadFrameworkCUE(ctx) // nolint:errcheck
+	return v
+}
+
+// ToKindProps takes a cue.Value expected to represent a kind of the category
+// specified by the type parameter and populates the Go type from the cue.Value.
+func ToKindProps[T KindProperties](v cue.Value) (T, error) {
+	props := new(T)
+	if !v.Exists() {
+		return *props, ErrValueNotExist
+	}
+
+	fw := CUEFramework(v.Context())
+	var kdef cue.Value
+
+	anyprops := any(*props).(SomeKindProperties)
+	switch anyprops.(type) {
+	case CoreProperties:
+		kdef = fw.LookupPath(cue.MakePath(cue.Str("Core")))
+	case CustomProperties:
+		kdef = fw.LookupPath(cue.MakePath(cue.Str("Custom")))
+	default:
+		// unreachable so long as all the possibilities in KindProperties have switch branches
+		panic("unreachable")
+	}
+
+	item := v.Unify(kdef)
+	if item.Err() != nil {
+		return *props, errors.Wrap(errors.Promote(ErrValueNotAKind, ""), item.Err())
+	}
+
+	if err := item.Decode(props); err != nil {
+		// Should only be reachable if CUE and Go framework types have diverged
+		panic(errors.Details(err, nil))
+	}
+
+	return *props, nil
+}
+
+// ToDef takes a cue.Value expected to represent a kind of the category
+// specified by the type parameter and populates a Def from the CUE value.
+// The cue.Value in Def.V will be the unified value of the parameter cue.Value
+// and the kindsys CUE kind (Core, Custom, Composable).
+func ToDef[T KindProperties](v cue.Value) (Def[T], error) {
+	def := Def[T]{}
+	props := new(T)
+	if !v.Exists() {
+		return def, ErrValueNotExist
+	}
+
+	fw := CUEFramework(v.Context())
+	var kdef cue.Value
+
+	anyprops := any(*props).(SomeKindProperties)
+	switch anyprops.(type) {
+	case CoreProperties:
+		kdef = fw.LookupPath(cue.MakePath(cue.Str("Core")))
+	case CustomProperties:
+		kdef = fw.LookupPath(cue.MakePath(cue.Str("Custom")))
+	default:
+		// unreachable so long as all the possibilities in KindProperties have switch branches
+		panic("unreachable")
+	}
+
+	def.V = v.Unify(kdef)
+	if def.V.Err() != nil {
+		return def, errors.Wrap(errors.Promote(ErrValueNotAKind, ""), def.V.Err())
+	}
+
+	if err := def.V.Decode(props); err != nil {
+		// Should only be reachable if CUE and Go framework types have diverged
+		panic(errors.Details(err, nil))
+	}
+	def.Properties = *props
+	return def, nil
+}

--- a/kindsys/load_test.go
+++ b/kindsys/load_test.go
@@ -1,0 +1,12 @@
+package kindsys_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/kindsys"
+)
+
+func TestFramework(t *testing.T) {
+	// please don't panic, that's all I ask
+	_ = kindsys.CUEFramework(nil)
+}

--- a/kindsys/props.go
+++ b/kindsys/props.go
@@ -1,0 +1,76 @@
+package kindsys
+
+import "github.com/grafana/thema"
+
+// CommonProperties contains the metadata common to all categories of kinds.
+type CommonProperties struct {
+	Name              string   `json:"name"`
+	PluralName        string   `json:"pluralName"`
+	MachineName       string   `json:"machineName"`
+	PluralMachineName string   `json:"pluralMachineName"`
+	LineageIsGroup    bool     `json:"lineageIsGroup"`
+	Maturity          Maturity `json:"maturity"`
+	Description       string   `json:"description,omitempty"`
+}
+
+// CoreProperties represents the static properties in the definition of a
+// Core kind that are representable with basic Go types. This
+// excludes Thema schemas.
+//
+// When .cue file(s) containing a Core definition is loaded through the standard
+// [LoadCoreKindDef], func, it is fully validated and populated according to all
+// rules specified in CUE for Core kinds.
+type CoreProperties struct {
+	CommonProperties
+	CurrentVersion thema.SyntacticVersion `json:"currentVersion"`
+	CRD            struct {
+		Group       string `json:"group"`
+		Scope       string `json:"scope"`
+		DummySchema bool   `json:"dummySchema"`
+	} `json:"crd"`
+}
+
+func (m CoreProperties) _private() {}
+func (m CoreProperties) Common() CommonProperties {
+	return m.CommonProperties
+}
+
+// CustomProperties represents the static properties in the definition of a
+// Custom kind that are representable with basic Go types. This
+// excludes Thema schemas.
+type CustomProperties struct {
+	CommonProperties
+	CurrentVersion thema.SyntacticVersion `json:"currentVersion"`
+	IsCRD          bool                   `json:"isCRD"`
+	Group          string                 `json:"group"`
+	CRD            struct {
+		Group         string  `json:"group"`
+		Scope         string  `json:"scope"`
+		GroupOverride *string `json:"groupOverride"`
+	} `json:"crd"`
+	Codegen struct {
+		Frontend bool `json:"frontend"`
+		Backend  bool `json:"backend"`
+	} `json:"codegen"`
+}
+
+func (m CustomProperties) _private() {}
+func (m CustomProperties) Common() CommonProperties {
+	return m.CommonProperties
+}
+
+// SomeKindProperties is an interface type to abstract over the different kind
+// property struct types: [CoreProperties], [CustomProperties]
+//
+// It is the traditional interface counterpart to the generic type constraint
+// KindProperties.
+type SomeKindProperties interface {
+	_private()
+	Common() CommonProperties
+}
+
+// KindProperties is a type parameter that comprises the base possible set of
+// kind metadata configurations.
+type KindProperties interface {
+	CoreProperties | CustomProperties
+}

--- a/kindsys/somedef.go
+++ b/kindsys/somedef.go
@@ -1,0 +1,65 @@
+package kindsys
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"github.com/grafana/thema"
+)
+
+// SomeDef represents a single kind definition, having been loaded and
+// validated by a func such as [LoadCoreKindDef].
+//
+// The underlying type of the Properties field indicates the category of kind.
+type SomeDef struct {
+	// V is the cue.Value containing the entire Kind definition.
+	V cue.Value
+	// Properties contains the kind's declarative non-schema properties.
+	Properties SomeKindProperties
+}
+
+// BindKindLineage binds the lineage for the kind definition.
+//
+// For kinds with a corresponding Go type, it is left to the caller to associate
+// that Go type with the lineage returned from this function by a call to
+// [thema.BindType].
+func (def SomeDef) BindKindLineage(rt *thema.Runtime, opts ...thema.BindOption) (thema.Lineage, error) {
+	if rt == nil {
+		return nil, fmt.Errorf("nil thema.Runtime")
+	}
+	return thema.BindLineage(def.V.LookupPath(cue.MakePath(cue.Str("lineage"))), rt, opts...)
+}
+
+// IsCore indicates whether the represented kind is a core kind.
+func (def SomeDef) IsCore() bool {
+	_, is := def.Properties.(CoreProperties)
+	return is
+}
+
+// IsCustom indicates whether the represented kind is a custom kind.
+func (def SomeDef) IsCustom() bool {
+	_, is := def.Properties.(CustomProperties)
+	return is
+}
+
+// Def represents a single kind definition, having been loaded and validated by
+// a func such as [LoadCoreKindDef].
+//
+// Its type parameter indicates the category of kind.
+//
+// Thema lineages in the contained definition have not yet necessarily been
+// validated.
+type Def[T KindProperties] struct {
+	// V is the cue.Value containing the entire Kind definition.
+	V cue.Value
+	// Properties contains the kind's declarative non-schema properties.
+	Properties T
+}
+
+// Some converts the typed Def to the equivalent typeless SomeDef.
+func (def Def[T]) Some() SomeDef {
+	return SomeDef{
+		V:          def.V,
+		Properties: any(def.Properties).(SomeKindProperties),
+	}
+}

--- a/kindsys/util.go
+++ b/kindsys/util.go
@@ -1,0 +1,24 @@
+package kindsys
+
+// Ptr returns a pointer to a value of an arbitrary type.
+//
+// This function is provided to compensate for Grafana's Go code generation that
+// represents optional fields using pointers.
+//
+// Pointers are the only technically [correct, non-ambiguous] way of
+// representing an optional field in Go's type system. However, Go does not
+// allow taking the address of certain primitive types inline. That is,
+// this is invalid Go code:
+//
+//	var str *string
+//	str = &"colorless green ideas sleep furiously"
+//
+// This func allows making such declarations in a single line:
+//
+//	var str *string
+//	str = kindsys.Ptr("colorless green ideas sleep furiously")
+//
+// [correct, non-ambiguous]: https://github.com/grafana/grok/issues/1
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This moves a copy of kindsys from the currently used branch directly into this repository, and removes as much unused stuff as possible.

This will break the coupling to kindsys -- and focus on more generic k8s resource shapes.