### PR TITLE
[codegen/operator] Update OpenTelemetry init in the operator codegen

### DIFF
--- a/codegen/templates/operator/telemetry.tmpl
+++ b/codegen/templates/operator/telemetry.tmpl
@@ -42,12 +42,11 @@ func SetTraceProvider(cfg OpenTelemetryConfig) error {
 	}
 
 	// Ensure default SDK resources and the required service name are set.
-	r, err := otelResource.Merge(
-		otelResource.Default(),
-		otelResource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(cfg.ServiceName),
-		),
+	r, err := otelResource.New(
+		context.Background(),
+		otelResource.WithAttributes(semconv.ServiceName(cfg.ServiceName)),
+		otelResource.WithProcessRuntimeDescription(),
+		otelResource.WithTelemetrySDK(),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Update codegen for otel resource init so it doesn't try to merge with default and have problems every time the schema version gets updated.

Unblocks https://github.com/grafana/grafana-app-sdk/pull/81 and https://github.com/grafana/grafana-app-sdk/pull/82