### PR TITLE
Add Generation to CommonMetadata

### DIFF
--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -38,6 +38,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) CommonMetadata() resource.Commo
     return resource.CommonMetadata{
         UID: {{.ObjectShortName}}.Metadata.Uid,
         ResourceVersion: {{.ObjectShortName}}.Metadata.ResourceVersion,
+        Generation: {{.ObjectShortName}}.Metadata.Generation,
         Labels: {{.ObjectShortName}}.Metadata.Labels,
         CreationTimestamp: {{.ObjectShortName}}.Metadata.CreationTimestamp,
         UpdateTimestamp: {{.ObjectShortName}}.Metadata.UpdateTimestamp,
@@ -55,6 +56,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) CommonMetadata() resource.Commo
 func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetCommonMetadata(metadata resource.CommonMetadata) {
     {{.ObjectShortName}}.Metadata.Uid = metadata.UID
     {{.ObjectShortName}}.Metadata.ResourceVersion = metadata.ResourceVersion
+    {{.ObjectShortName}}.Metadata.Generation = metadata.Generation
     {{.ObjectShortName}}.Metadata.Labels = metadata.Labels
     {{.ObjectShortName}}.Metadata.CreationTimestamp = metadata.CreationTimestamp
     {{.ObjectShortName}}.Metadata.UpdateTimestamp = metadata.UpdateTimestamp

--- a/codegen/testing/golden_generated/customkind/customkind_lineage.cue.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_lineage.cue.txt
@@ -20,12 +20,13 @@ customkind: thema.#Lineage & {
 				}
 				finalizers: [...string]
 				resourceVersion: string
+				generation:      >=-9223372036854775808 & <=9223372036854775807 & int
 				labels: {
 					[string]: string
 				}
 			}
 			{
-				[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
+				[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|generation|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
 			}
 			updateTimestamp: time.Time & {
 				string

--- a/codegen/testing/golden_generated/customkind/customkind_metadata_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_metadata_gen.go.txt
@@ -14,6 +14,7 @@ type Metadata struct {
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
 	ExtraFields        map[string]interface{} `json:"extraFields"`
 	Finalizers         []string               `json:"finalizers"`
+	Generation         int64                  `json:"generation"`
 	Labels             map[string]string      `json:"labels"`
 	OtherMetadataField string                 `json:"otherMetadataField"`
 	ResourceVersion    string                 `json:"resourceVersion"`
@@ -29,6 +30,7 @@ type KubeObjectMetadata struct {
 	CreationTimestamp time.Time         `json:"creationTimestamp"`
 	DeletionTimestamp *time.Time        `json:"deletionTimestamp,omitempty"`
 	Finalizers        []string          `json:"finalizers"`
+	Generation        int64             `json:"generation"`
 	Labels            map[string]string `json:"labels"`
 	ResourceVersion   string            `json:"resourceVersion"`
 	Uid               string            `json:"uid"`

--- a/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
@@ -38,6 +38,7 @@ func (o *Object) CommonMetadata() resource.CommonMetadata {
 	return resource.CommonMetadata{
 		UID:               o.Metadata.Uid,
 		ResourceVersion:   o.Metadata.ResourceVersion,
+		Generation:        o.Metadata.Generation,
 		Labels:            o.Metadata.Labels,
 		CreationTimestamp: o.Metadata.CreationTimestamp,
 		UpdateTimestamp:   o.Metadata.UpdateTimestamp,
@@ -55,6 +56,7 @@ func (o *Object) CommonMetadata() resource.CommonMetadata {
 func (o *Object) SetCommonMetadata(metadata resource.CommonMetadata) {
 	o.Metadata.Uid = metadata.UID
 	o.Metadata.ResourceVersion = metadata.ResourceVersion
+	o.Metadata.Generation = metadata.Generation
 	o.Metadata.Labels = metadata.Labels
 	o.Metadata.CreationTimestamp = metadata.CreationTimestamp
 	o.Metadata.UpdateTimestamp = metadata.UpdateTimestamp

--- a/codegen/testing/golden_generated/customkind_types.gen.ts.txt
+++ b/codegen/testing/golden_generated/customkind_types.gen.ts.txt
@@ -52,6 +52,7 @@ export interface CustomKind {
     deletionTimestamp?: string;
     finalizers: string[];
     resourceVersion: string;
+    generation: number;
     /**
      * All extensions to this metadata need to have string values (for APIServer encoding-to-annotations purposes)
      * Can't use this as it's not yet enforced CUE:

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -629,13 +629,12 @@ func getTestObject() *resource.SimpleObject[testSpec] {
 			},
 			CommonMeta: resource.CommonMetadata{
 				ResourceVersion: "rev1",
+				Generation:      0,
 				Labels: map[string]string{
 					"foo":  "bar",
 					"test": "value",
 				},
-				ExtraFields: map[string]any{
-					"generation": int64(0),
-				},
+				ExtraFields: map[string]any{},
 			},
 		},
 		Spec: testSpec{

--- a/k8s/translation_test.go
+++ b/k8s/translation_test.go
@@ -31,6 +31,7 @@ var complexObject = TestResourceObject{
 		CommonMetadata: resource.CommonMetadata{
 			UID:               "abc",
 			ResourceVersion:   "12345",
+			Generation:        1,
 			Labels:            map[string]string{"foo": "bar"},
 			CreationTimestamp: createdTime,
 			Finalizers:        []string{"finalizer"},
@@ -38,7 +39,6 @@ var complexObject = TestResourceObject{
 			CreatedBy:         "me",
 			UpdatedBy:         "you",
 			ExtraFields: map[string]any{
-				"generation": int64(1),
 				"annotations": map[string]string{
 					fmt.Sprintf("%screatedBy", annotationPrefix):       "me",
 					fmt.Sprintf("%supdatedBy", annotationPrefix):       "you",
@@ -97,7 +97,7 @@ func TestRawToObject(t *testing.T) {
 			Labels:            complexObject.Metadata.Labels,
 			CreationTimestamp: metav1.Time{complexObject.Metadata.CreationTimestamp},
 			Finalizers:        complexObject.Metadata.Finalizers,
-			Generation:        complexObject.Metadata.ExtraFields["generation"].(int64),
+			Generation:        complexObject.Metadata.Generation,
 			Annotations: map[string]string{
 				fmt.Sprintf("%screatedBy", annotationPrefix):       complexObject.Metadata.CreatedBy,
 				fmt.Sprintf("%supdatedBy", annotationPrefix):       complexObject.Metadata.UpdatedBy,
@@ -272,7 +272,7 @@ func TestMarshalJSON(t *testing.T) {
 			Labels:            complexObject.Metadata.Labels,
 			//CreationTimestamp: metav1.Time{complexObject.Metadata.CreationTimestamp},
 			Finalizers: complexObject.Metadata.Finalizers,
-			Generation: complexObject.Metadata.ExtraFields["generation"].(int64),
+			Generation: complexObject.Metadata.Generation,
 			Annotations: map[string]string{
 				fmt.Sprintf("%screatedBy", annotationPrefix):       complexObject.Metadata.CreatedBy,
 				fmt.Sprintf("%supdatedBy", annotationPrefix):       complexObject.Metadata.UpdatedBy,

--- a/kindsys/kindcat_custom.cue
+++ b/kindsys/kindcat_custom.cue
@@ -15,6 +15,7 @@ _kubeObjectMetadata: {
     deletionTimestamp?: string & time.Time
     finalizers: [...string]
     resourceVersion: string
+	generation: int64
     labels: {
         [string]: string
     }
@@ -61,7 +62,7 @@ _crdSchema: {
 		// Can't use this as it's not yet enforced CUE:
 		//...string
 		// Have to do this gnarly regex instead
-		[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
+		[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|generation|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
 	}
 	spec: _
 

--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
 	"k8s.io/utils/strings/slices"
@@ -307,22 +306,5 @@ func (*OpinionatedWatcher) getFinalizers(object resource.Object) []string {
 }
 
 func getGeneration(object resource.Object) int64 {
-	g, ok := object.CommonMetadata().ExtraFields["generation"]
-	if !ok {
-		return 0
-	}
-	switch t := g.(type) {
-	case int64:
-		return t
-	case int:
-		return int64(t)
-	case string:
-		conv, err := strconv.Atoi(t)
-		if err != nil {
-			return 0
-		}
-		return int64(conv)
-	default:
-		return 0
-	}
+	return object.CommonMetadata().Generation
 }

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -267,9 +267,7 @@ func TestOpinionatedWatcher_Update(t *testing.T) {
 		old := schema.ZeroValue()
 		new := schema.ZeroValue()
 		md := old.CommonMetadata()
-		md.ExtraFields = map[string]any{
-			"generation": 1,
-		}
+		md.Generation = 1
 		old.SetCommonMetadata(md)
 		new.SetCommonMetadata(md)
 		err := o.Update(context.TODO(), old, new)

--- a/resource/object.go
+++ b/resource/object.go
@@ -154,6 +154,9 @@ type CommonMetadata struct {
 	// This can be used to block updates if a change has been made to the object between when the object was
 	// retrieved, and when the update was applied.
 	ResourceVersion string `json:"resourceVersion"`
+	// Generation is a number which is incremented every time the spec of the object changes.
+	// It is distinct from ResourceVersion, as it tracks only updates to the spec, and not subresources or metadata.
+	Generation int64 `json:"generation"`
 	// Labels are string key/value pairs attached to the object. They can be used for filtering,
 	// or as additional metadata
 	Labels map[string]string `json:"labels"`


### PR DESCRIPTION
Move the `generation` field from `resource.CommonMetadata.ExtraFields["generation"]` to `resource.CommonMetadata.Generation`. Ensure that generated code from the SDK handles this move properly, and that the translation code in the `k8s` package does as well.