### PR TITLE
Update main/release GH workflows to use go 1.21.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.21"
 
     - name: Build
       run: go build -v cmd/grafana-app-sdk/*.go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.21"
 
     - name: Build
       run: go build -v cmd/grafana-app-sdk/*.go


### PR DESCRIPTION
Update main/release GH workflows to use go 1.21.