### PR TITLE
Don't marshal the updateTimestamp into annotations if it's a zero time

### DIFF
--- a/k8s/translation.go
+++ b/k8s/translation.go
@@ -294,7 +294,10 @@ func getV1ObjectMeta(obj resource.Object, cfg ClientConfig) metav1.ObjectMeta {
 	// Common metadata which isn't a part of kubernetes metadata
 	meta.Annotations[annotationPrefix+"createdBy"] = cMeta.CreatedBy
 	meta.Annotations[annotationPrefix+"updatedBy"] = cMeta.UpdatedBy
-	meta.Annotations[annotationPrefix+"updateTimestamp"] = cMeta.UpdateTimestamp.Format(time.RFC3339Nano)
+	// Only set the UpdateTimestamp metadata if it's non-zero
+	if !cMeta.UpdateTimestamp.IsZero() {
+		meta.Annotations[annotationPrefix+"updateTimestamp"] = cMeta.UpdateTimestamp.Format(time.RFC3339Nano)
+	}
 
 	// The non-common metadata needs to be converted into annotations
 	for k, v := range obj.CustomMetadata().MapFields() {

--- a/k8s/translation_test.go
+++ b/k8s/translation_test.go
@@ -285,6 +285,19 @@ func TestMarshalJSON(t *testing.T) {
 		Status: complexObject.Status,
 	})
 
+	emptyObject := TestResourceObject{}
+	emptyBytes, _ := json.Marshal(testKubernetesObject{
+		Metadata: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				fmt.Sprintf("%screatedBy", annotationPrefix): "",
+				fmt.Sprintf("%supdatedBy", annotationPrefix): "",
+				// No updateTimestamp when it's a zero (empty) time
+				fmt.Sprintf("%scustomField1", annotationPrefix): "",
+				fmt.Sprintf("%scustomField2", annotationPrefix): "",
+			},
+		},
+	})
+
 	tests := []struct {
 		name          string
 		obj           resource.Object
@@ -307,6 +320,14 @@ func TestMarshalJSON(t *testing.T) {
 			extraLabels:   nil,
 			config:        ClientConfig{},
 			expectedJSON:  complexBytes,
+			expectedError: nil,
+		},
+		{
+			name:          "empty object",
+			obj:           &emptyObject,
+			extraLabels:   nil,
+			config:        ClientConfig{},
+			expectedJSON:  emptyBytes,
 			expectedError: nil,
 		},
 	}


### PR DESCRIPTION
Don't marshal the updateTimestamp into annotations if it's a zero time, allowing it to unmarshal into the creationTimestamp on later unmarshal if unset.