### PR TITLE
[resource] Stores Update() methods update CommonMetadata.UpdateTimestamp

### DIFF
--- a/resource/simplestore.go
+++ b/resource/simplestore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 )
 
 // SimpleStoreResource is a type used by SimpleStore to return concrete data, rather than an Object.
@@ -153,6 +154,7 @@ func (s *SimpleStore[T]) Update(ctx context.Context, identifier Identifier, obj 
 	if object.CommonMeta.ResourceVersion != "" {
 		updateOptions.ResourceVersion = object.CommonMeta.ResourceVersion
 	}
+	object.CommonMeta.UpdateTimestamp = time.Now().UTC()
 	ret, err := s.client.Update(ctx, identifier, &object, updateOptions)
 	if err != nil {
 		return nil, err

--- a/resource/store.go
+++ b/resource/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // TODO: rewrite the godocs, this is all copied from crd/store.go
@@ -122,6 +123,10 @@ func (s *Store) Update(ctx context.Context, obj Object) (Object, error) {
 		return nil, fmt.Errorf("obj.StaticMetadata().Name must not be empty")
 	}
 
+	md := obj.CommonMetadata()
+	md.UpdateTimestamp = time.Now().UTC()
+	obj.SetCommonMetadata(md)
+
 	client, err := s.getClient(obj.StaticMetadata().Kind)
 	if err != nil {
 		return nil, err
@@ -194,6 +199,9 @@ func (s *Store) Upsert(ctx context.Context, obj Object) (Object, error) {
 	}
 
 	if resp != nil {
+		md := obj.CommonMetadata()
+		md.UpdateTimestamp = time.Now().UTC()
+		obj.SetCommonMetadata(md)
 		return client.Update(ctx, Identifier{
 			Namespace: obj.StaticMetadata().Namespace,
 			Name:      obj.StaticMetadata().Name,


### PR DESCRIPTION
Have resource-package Stores Update() methods update CommonMetadata.UpdateTimestamp in the object they're updating. This is a semi-temporary measure to prevent needing admission control to update the UpdateTimestamp, but also keep the kubernetes client from taking on what should be business logic.