### PR TITLE
Update the go version used in the release action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
Go release action is currently failing due to using go 1.20 instead of 1.21.