### PR TITLE
Fix codegen for admission webhooks

### DIFF
--- a/cmd/grafana-app-sdk/templates/local/generated/operator.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/operator.yaml
@@ -47,6 +47,7 @@ spec:
       labels:
         name: {{.PluginID}}-operator
     spec:
+      serviceAccount: operator
       containers:
         - image: {{.OperatorImage}}
           imagePullPolicy: IfNotPresent
@@ -60,9 +61,18 @@ spec:
               value: grpc
             - name: OTEL_SERVICE_NAME
               value: "{{.PluginID}}-operator"
+{{ if .WebhookProperties.Enabled }}
+            - name: WEBHOOK_PORT
+              value: "{{ .WebhookProperties.Port }}"
+            - name: WEBHOOK_CERT_PATH
+              value: /run/secrets/tls/tls.crt
+            - name: WEBHOOK_KEY_PATH
+              value: /run/secrets/tls/tls.key
+{{ end }}
           ports:
             - containerPort: 9090
-              name: metrics{{ if .WebhookProperties.Enabled }}
+              name: metrics
+{{ if .WebhookProperties.Enabled }}
             - containerPort: {{ .WebhookProperties.Port }}
               name: webhook-api
           volumeMounts:
@@ -72,8 +82,8 @@ spec:
       volumes:
         - name: webhook-certs
           secret:
-            secretName: webhook-tls-certs{{ end }}
-      serviceAccount: operator
+            secretName: webhook-tls-certs
+{{ end }}
 ---
 apiVersion: v1
 kind: Service
@@ -84,9 +94,12 @@ spec:
   selector:
     name: {{.PluginID}}-operator
   ports:
-    - port: 9090
-      targetPort: metrics{{ if .WebhookProperties.Enabled }}
-    - port: 443
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+{{ if .WebhookProperties.Enabled }}
+    - name: webhook-api
+      port: 443
       targetPort: webhook-api
 {{ if ne .WebhookProperties.Mutating "" }}
 ---
@@ -111,7 +124,7 @@ webhooks:
           - {{.}}{{end}}
         resources: ["{{.PluralMachineName}}"]{{end}}
 {{ end }}
-  {{ if ne .WebhookProperties.Mutating "" }}
+{{ if ne .WebhookProperties.Validating "" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/codegen/templates/operator/config.tmpl
+++ b/codegen/templates/operator/config.tmpl
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -13,7 +14,8 @@ const (
 )
 
 type Config struct {
-	OTelConfig OpenTelemetryConfig
+	OTelConfig    OpenTelemetryConfig
+	WebhookServer WebhookServerConfig
 }
 
 type OpenTelemetryConfig struct {
@@ -21,6 +23,12 @@ type OpenTelemetryConfig struct {
 	Port        int
 	ConnType    string
 	ServiceName string
+}
+
+type WebhookServerConfig struct {
+	Port        int
+	TLSCertPath string
+	TLSKeyPath  string
 }
 
 func LoadConfigFromEnv() (*Config, error) {
@@ -54,5 +62,20 @@ func LoadConfigFromEnv() (*Config, error) {
 			return nil, fmt.Errorf("invalid OTEL_PORT '%s': %w", portStr, err)
 		}
 	}
+
+	whPortStr := os.Getenv("WEBHOOK_PORT")
+	if whPortStr == "" {
+		cfg.WebhookServer.Port = 8443
+	} else {
+		var err error
+		cfg.WebhookServer.Port, err = strconv.Atoi(whPortStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid WEBHOOK_PORT '%s': %w", whPortStr, err)
+		}
+	}
+
+	cfg.WebhookServer.TLSCertPath = os.Getenv("WEBHOOK_CERT_PATH")
+	cfg.WebhookServer.TLSKeyPath = os.Getenv("WEBHOOK_KEY_PATH")
+
 	return &cfg, nil
 }


### PR DESCRIPTION
### What

This PR makes a few small fixes for codegen when handling admission webhooks:

- `ValidatingWebhookConfiguration` generation is now checking whether validating (not mutating) webhook is enabled
- If webhooks are enabled codegen now provides env vars for the port and paths to TLS cert / key
- Operator config now parses webhook configuration (for now without checking if webhooks are enabled but if env vars are empty it doesn't fail)

### Why

To make it easier to write & test webhooks locally.
