### PR TITLE
Add a separate dependabot group for CUE dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,18 @@ updates:
   schedule:
     interval: daily
   groups:
-    all:
+    cue:
       patterns:
-        - "*"
+      - "*cue*"
+      - "*thema*"
+      - "*codejen*"
+    all:
+      exclude-patterns:
+      - "*cue*"
+      - "*thema*"
+      - "*codejen*"
+      patterns:
+      - "*"
   labels:
   - "type/dependabot"
 


### PR DESCRIPTION
### What

Add a separate dependabot group for CUE dependencies alongside with the current catch-all group.

### Why

CUE version are known to break compatibility between updates and we don't want to block other dependencies from being updated.
