### PR TITLE
[codegen] Consistent Generated Model Naming

### DIFF
--- a/codegen/jennies/gotypes.go
+++ b/codegen/jennies/gotypes.go
@@ -60,7 +60,7 @@ func (g *GoTypes) Generate(kind codegen.Kind) (codejen.Files, error) {
 		if ver == nil {
 			return nil, fmt.Errorf("version '%s' of kind '%s' does not exist", kind.Properties().Current, kind.Name())
 		}
-		return g.generateFiles(ver, kind.Properties().MachineName, kind.Properties().MachineName, kind.Properties().MachineName)
+		return g.generateFiles(ver, kind.Name(), kind.Properties().MachineName, kind.Properties().MachineName, kind.Properties().MachineName)
 	}
 
 	files := make(codejen.Files, 0)
@@ -71,7 +71,7 @@ func (g *GoTypes) Generate(kind codegen.Kind) (codejen.Files, error) {
 			continue
 		}
 
-		generated, err := g.generateFiles(&ver, kind.Properties().MachineName, ToPackageName(ver.Version), filepath.Join(kind.Properties().MachineName, ToPackageName(ver.Version)))
+		generated, err := g.generateFiles(&ver, kind.Name(), kind.Properties().MachineName, ToPackageName(ver.Version), filepath.Join(kind.Properties().MachineName, ToPackageName(ver.Version)))
 		if err != nil {
 			return nil, err
 		}
@@ -81,14 +81,14 @@ func (g *GoTypes) Generate(kind codegen.Kind) (codejen.Files, error) {
 	return files, nil
 }
 
-func (g *GoTypes) generateFiles(version *codegen.KindVersion, machineName string, packageName string, pathPrefix string) (codejen.Files, error) {
+func (g *GoTypes) generateFiles(version *codegen.KindVersion, name string, machineName string, packageName string, pathPrefix string) (codejen.Files, error) {
 	if g.Depth > 0 {
 		return g.generateFilesAtDepth(version.Schema, version, 0, machineName, packageName, pathPrefix)
 	}
 
 	goBytes, err := GoTypesFromCUE(version.Schema, CUEGoConfig{
 		PackageName: packageName,
-		Name:        exportField(machineName),
+		Name:        exportField(sanitizeLabelString(name)),
 		Version:     version.Version,
 	}, 0)
 	if err != nil {

--- a/codegen/testing/golden_generated/customkind2/customkind2_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind2/customkind2_gen.go.txt
@@ -4,19 +4,19 @@ import (
 	"time"
 )
 
-// Defines values for Customkind2Enum.
+// Defines values for CustomKind2Enum.
 const (
-	Customkind2EnumDefault Customkind2Enum = "default"
-	Customkind2EnumVal1    Customkind2Enum = "val1"
-	Customkind2EnumVal2    Customkind2Enum = "val2"
-	Customkind2EnumVal3    Customkind2Enum = "val3"
-	Customkind2EnumVal4    Customkind2Enum = "val4"
+	CustomKind2EnumDefault CustomKind2Enum = "default"
+	CustomKind2EnumVal1    CustomKind2Enum = "val1"
+	CustomKind2EnumVal2    CustomKind2Enum = "val2"
+	CustomKind2EnumVal3    CustomKind2Enum = "val3"
+	CustomKind2EnumVal4    CustomKind2Enum = "val4"
 )
 
-// Customkind2 defines model for Customkind2.
-type Customkind2 struct {
+// CustomKind2 defines model for CustomKind2.
+type CustomKind2 struct {
 	BoolField  bool             `json:"boolField"`
-	Enum       Customkind2Enum  `json:"enum"`
+	Enum       CustomKind2Enum  `json:"enum"`
 	Field1     string           `json:"field1"`
 	FloatField float64          `json:"floatField"`
 	I32        int              `json:"i32"`
@@ -27,8 +27,8 @@ type Customkind2 struct {
 	Union      interface{}      `json:"union"`
 }
 
-// Customkind2Enum defines model for Customkind2.Enum.
-type Customkind2Enum string
+// CustomKind2Enum defines model for CustomKind2.Enum.
+type CustomKind2Enum string
 
 // InnerObject1 defines model for InnerObject1.
 type InnerObject1 struct {

--- a/codegen/thema/jennies/wrappedtype.go
+++ b/codegen/thema/jennies/wrappedtype.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
+	"strings"
 
 	"github.com/grafana/codejen"
-
 	"github.com/grafana/grafana-app-sdk/codegen"
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )
@@ -20,7 +20,7 @@ func (*ModelsFunctionsGenerator) JennyName() string {
 
 func (s *ModelsFunctionsGenerator) Generate(kind codegen.Kind) (*codejen.File, error) {
 	meta := kind.Properties()
-	typeName := exportField(meta.Kind)
+	typeName := exportField(sanitizeLabelString(meta.Kind))
 	md := templates.WrappedTypeMetadata{
 		Package:     meta.MachineName,
 		TypeName:    typeName,
@@ -37,4 +37,21 @@ func (s *ModelsFunctionsGenerator) Generate(kind codegen.Kind) (*codejen.File, e
 		return nil, err
 	}
 	return codejen.NewFile(fmt.Sprintf("%s/%s_marshal_gen.go", meta.MachineName, meta.MachineName), formatted, s), nil
+}
+
+func sanitizeLabelString(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			fallthrough
+		case r >= 'A' && r <= 'Z':
+			fallthrough
+		case r >= '0' && r <= '9':
+			fallthrough
+		case r == '_':
+			return r
+		default:
+			return -1
+		}
+	}, s)
 }


### PR DESCRIPTION
Use sanitized exported kind name as go type for models, instead of using exported machine name. This is consistent with the previous thema codegen for model types.