### PR TITLE
Expose subrouter's current path

### DIFF
--- a/plugin/router/router.go
+++ b/plugin/router/router.go
@@ -69,6 +69,10 @@ type Subrouter struct {
 	path         string
 }
 
+func (r *Subrouter) Path() string {
+	return r.path
+}
+
 // Subrouter creates and returns a Subrouter for the given path prefix.
 // All handlers registered with the Subrouter will have the prefix added implicitly.
 func (r *Router) Subrouter(path string) *Subrouter {


### PR DESCRIPTION
To be used when creating an OpenAPI spec programatically 
As we're working with subrouters, we need to keep track of the current subpath 
By exposing it, we don't have to duplicate that information