### PR TITLE
Implement New resource.Kind and resource.Object in Other Packages

### DIFF
--- a/examples/operator/basic/basic.go
+++ b/examples/operator/basic/basic.go
@@ -33,7 +33,11 @@ func main() {
 	kubeConfig.APIPath = "/apis" // Don't know why this isn't set correctly by default, but it isn't
 
 	// Create a schema to use
-	schema := resource.NewSimpleSchema("example.grafana.com", "v1", &resource.SimpleObject[BasicModel]{}, resource.WithKind("BasicCustomResource"))
+	schema := resource.NewSimpleSchema("example.grafana.com", "v1", &resource.TypedSpecObject[BasicModel]{}, resource.WithKind("BasicCustomResource"))
+	kind := resource.Kind{
+		Schema: schema,
+		Codecs: map[resource.KindEncoding]resource.Codec{resource.KindEncodingJSON: resource.NewJSONCodec()},
+	}
 
 	// Register the schema (if it doesn't already exist)
 	manager, err := k8s.NewManager(*kubeConfig)
@@ -52,7 +56,7 @@ func main() {
 
 	// Get a client for our schema
 	clientGenerator := k8s.NewClientRegistry(*kubeConfig, k8s.ClientConfig{})
-	client, err := clientGenerator.ClientFor(schema)
+	client, err := clientGenerator.ClientFor(kind)
 	if err != nil {
 		panic(fmt.Errorf("error creating client for schema: %w", err))
 	}

--- a/examples/operator/opinionated/opinionated.go
+++ b/examples/operator/opinionated/opinionated.go
@@ -43,7 +43,11 @@ func main() {
 	kubeConfig.APIPath = "/apis" // Don't know why this isn't set correctly by default, but it isn't
 
 	// Create a schema to use
-	schema := resource.NewSimpleSchema("example.grafana.com", "v1", &resource.SimpleObject[OpinionatedModel]{}, resource.WithKind("OpinionatedCustomResource"))
+	schema := resource.NewSimpleSchema("example.grafana.com", "v1", &resource.TypedSpecObject[OpinionatedModel]{}, resource.WithKind("OpinionatedCustomResource"))
+	kind := resource.Kind{
+		Schema: schema,
+		Codecs: map[resource.KindEncoding]resource.Codec{resource.KindEncodingJSON: resource.NewJSONCodec()},
+	}
 
 	// Register the schema (if it doesn't already exist)
 	manager, err := k8s.NewManager(*kubeConfig)
@@ -62,7 +66,7 @@ func main() {
 
 	// Get a client for our schema
 	clientGenerator := k8s.NewClientRegistry(*kubeConfig, k8s.ClientConfig{})
-	client, err := clientGenerator.ClientFor(schema)
+	client, err := clientGenerator.ClientFor(kind)
 	if err != nil {
 		panic(fmt.Errorf("error creating client for schema: %w", err))
 	}

--- a/k8s/admission.go
+++ b/k8s/admission.go
@@ -71,7 +71,7 @@ func (o *OpinionatedMutatingAdmissionController) Mutate(ctx context.Context, req
 	}
 
 	// Get the CommonMetadata, so we can update it
-	cmd := resp.UpdatedObject.CommonMetadata()
+	cmd := resp.UpdatedObject.GetCommonMetadata()
 
 	if cmd.Labels == nil {
 		cmd.Labels = make(map[string]string)
@@ -119,30 +119,30 @@ func (o *OpinionatedValidatingAdmissionController) Validate(ctx context.Context,
 	case resource.AdmissionActionCreate:
 		// Not allowed to set createdBy, updatedBy, or updateTimestamp
 		// createdBy can be set, but only to the username of the request
-		if request.Object.CommonMetadata().CreatedBy != "" && request.Object.CommonMetadata().CreatedBy != request.UserInfo.Username {
+		if request.Object.GetCommonMetadata().CreatedBy != "" && request.Object.GetCommonMetadata().CreatedBy != request.UserInfo.Username {
 			return NewAdmissionError(makeAnnotationError(annotationCreatedBy), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 		// updatedBy can be set, but only to the username of the request
-		if request.Object.CommonMetadata().UpdatedBy != "" && request.Object.CommonMetadata().UpdatedBy != request.UserInfo.Username {
+		if request.Object.GetCommonMetadata().UpdatedBy != "" && request.Object.GetCommonMetadata().UpdatedBy != request.UserInfo.Username {
 			return NewAdmissionError(makeAnnotationError(annotationUpdatedBy), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 		emptyTime := time.Time{}
 		// updateTimestamp cannot be set
-		if request.Object.CommonMetadata().UpdateTimestamp != emptyTime {
+		if request.Object.GetCommonMetadata().UpdateTimestamp != emptyTime {
 			return NewAdmissionError(makeAnnotationError(annotationUpdateTimestamp), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 	case resource.AdmissionActionUpdate:
 		// Not allowed to set createdBy, updatedBy, or updateTimestamp
 		// createdBy can be set, but only to the username of the request
-		if request.Object.CommonMetadata().CreatedBy != request.OldObject.CommonMetadata().CreatedBy {
+		if request.Object.GetCommonMetadata().CreatedBy != request.OldObject.GetCommonMetadata().CreatedBy {
 			return NewAdmissionError(makeAnnotationError(annotationCreatedBy), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 		// updatedBy can be set, but only to the username of the request
-		if request.Object.CommonMetadata().UpdatedBy != request.OldObject.CommonMetadata().UpdatedBy && request.Object.CommonMetadata().UpdatedBy != request.UserInfo.Username {
+		if request.Object.GetCommonMetadata().UpdatedBy != request.OldObject.GetCommonMetadata().UpdatedBy && request.Object.GetCommonMetadata().UpdatedBy != request.UserInfo.Username {
 			return NewAdmissionError(makeAnnotationError(annotationUpdatedBy), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 		// updateTimestamp cannot be set
-		if request.Object.CommonMetadata().UpdateTimestamp != request.OldObject.CommonMetadata().UpdateTimestamp {
+		if request.Object.GetCommonMetadata().UpdateTimestamp != request.OldObject.GetCommonMetadata().UpdateTimestamp {
 			return NewAdmissionError(makeAnnotationError(annotationUpdateTimestamp), http.StatusBadRequest, ErrReasonFieldNotAllowed)
 		}
 	default:

--- a/k8s/admission_test.go
+++ b/k8s/admission_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewOpinionatedMutatingAdmissionController(t *testing.T) {
@@ -48,23 +49,21 @@ func TestOpinionatedMutatingAdmissionController_Mutate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-						},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
 					},
 				},
 			},
 			expected: &resource.MutatingResponse{
 				UpdatedObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
-							UpdateTimestamp:   cTimestamp,
-							Labels: map[string]string{
-								versionLabel: "v1-0",
-							},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy:       "me",
+							resource.AnnotationUpdateTimestamp: cTimestamp.Format(time.RFC3339),
+						},
+						Labels: map[string]string{
+							versionLabel: "v1-0",
 						},
 					},
 				},
@@ -80,27 +79,25 @@ func TestOpinionatedMutatingAdmissionController_Mutate(t *testing.T) {
 					Username: "you",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							Labels: map[string]string{
-								"foo": "bar",
-							},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Labels: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},
 			},
 			expected: &resource.MutatingResponse{
 				UpdatedObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							UpdateTimestamp:   now(),
-							UpdatedBy:         "you",
-							Labels: map[string]string{
-								"foo":        "bar",
-								versionLabel: "v1-1",
-							},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationUpdatedBy:       "you",
+							resource.AnnotationUpdateTimestamp: cTimestamp.Format(time.RFC3339),
+						},
+						Labels: map[string]string{
+							"foo":        "bar",
+							versionLabel: "v1-1",
 						},
 					},
 				},
@@ -156,10 +153,10 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "someone",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "someone",
 						},
 					},
 				},
@@ -176,11 +173,11 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
-							UpdatedBy:         "someone else",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
+							resource.AnnotationUpdatedBy: "someone else",
 						},
 					},
 				},
@@ -197,10 +194,10 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							UpdateTimestamp:   time.Now(),
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationUpdateTimestamp: time.Now().Format(time.RFC3339),
 						},
 					},
 				},
@@ -219,10 +216,8 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-						},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
 					},
 				},
 			},
@@ -240,10 +235,8 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-						},
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
 					},
 				},
 			},
@@ -259,18 +252,18 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "someone",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "someone",
 						},
 					},
 				},
 				OldObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
@@ -287,19 +280,19 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
-							UpdatedBy:         "someone else",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
+							resource.AnnotationUpdatedBy: "someone else",
 						},
 					},
 				},
 				OldObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
@@ -316,20 +309,20 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
-							UpdateTimestamp:   time.Now(),
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy:       "someone",
+							resource.AnnotationUpdateTimestamp: time.Now().Format(time.RFC3339),
 						},
 					},
 				},
 				OldObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							UpdateTimestamp:   time.Time{},
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy:       "someone",
+							resource.AnnotationUpdateTimestamp: time.Time{}.Format(time.RFC3339),
 						},
 					},
 				},
@@ -348,18 +341,18 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
 				OldObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
@@ -378,18 +371,18 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 					Username: "me",
 				},
 				Object: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
 				OldObject: &TestResourceObject{
-					Metadata: TestResourceObjectMetadata{
-						CommonMetadata: resource.CommonMetadata{
-							CreationTimestamp: cTimestamp,
-							CreatedBy:         "me",
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.NewTime(cTimestamp),
+						Annotations: map[string]string{
+							resource.AnnotationCreatedBy: "me",
 						},
 					},
 				},
@@ -403,6 +396,7 @@ func TestOpinionatedValidatingAdmissionController_Validate(t *testing.T) {
 			err := NewOpinionatedValidatingAdmissionController(&testValidatingAdmissionController{
 				ValidateFunc: test.validateFunc,
 			}).Validate(context.Background(), &test.request)
+			fmt.Println(err)
 			assert.Equal(t, test.expected, err)
 		})
 	}

--- a/k8s/manager.go
+++ b/k8s/manager.go
@@ -182,11 +182,11 @@ func toVersion(schema resource.Schema) CustomResourceDefinitionSpecVersion {
 	schemaProperties := map[string]any{
 		"spec": map[string]any{
 			"type":       openAPITypeObject,
-			"properties": toOpenAPIV3(reflect.TypeOf(obj.SpecObject())),
+			"properties": toOpenAPIV3(reflect.TypeOf(obj.GetSpec())),
 		},
 	}
 	// Check for status, scale subresources
-	if status, ok := obj.Subresources()["status"]; ok {
+	if status, ok := obj.GetSubresources()["status"]; ok {
 		schemaProperties["status"] = map[string]any{
 			"type":       openAPITypeObject,
 			"properties": toOpenAPIV3(reflect.TypeOf(status)),
@@ -194,7 +194,7 @@ func toVersion(schema resource.Schema) CustomResourceDefinitionSpecVersion {
 		// Add the subresource as an empty struct (this signals kubernetes to use the one supplied in the schema)
 		version.Subresources["status"] = struct{}{}
 	}
-	if scale, ok := obj.Subresources()["scale"]; ok {
+	if scale, ok := obj.GetSubresources()["scale"]; ok {
 		schemaProperties["scale"] = map[string]any{
 			"type":       openAPITypeObject,
 			"properties": toOpenAPIV3(reflect.TypeOf(scale)),

--- a/k8s/negotiator.go
+++ b/k8s/negotiator.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -98,3 +97,118 @@ func (*GenericJSONDecoder) Encode(obj runtime.Object, w io.Writer) error {
 func (*GenericJSONDecoder) Identifier() runtime.Identifier {
 	return "generic-json-decoder"
 }
+
+/*
+type KindNegotiatedSerializer struct {
+	Kind resource.Kind
+}
+
+// SupportedMediaTypes returns the JSON supported media type with a GenericJSONDecoder and kubernetes JSON Framer.
+func (k *KindNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	supported := make([]runtime.SerializerInfo, 0)
+	for encoding, codec := range k.Kind.Codecs {
+		serializer := &CodecDecoder{
+			Codec: codec,
+		}
+		info := runtime.SerializerInfo{
+			MediaType:  string(encoding),
+			Serializer: serializer,
+		}
+
+		// Framer is used for the stream serializer
+		switch encoding {
+		case resource.KindEncodingJSON:
+			info.StreamSerializer = &runtime.StreamSerializerInfo{
+				Serializer: serializer,
+				Framer:     jsonserializer.Framer,
+			}
+			//case resource.KindEncodingYAML:
+			// TODO: YAML framer
+			//	framer = yamlserializer.Framer
+		}
+		supported = append(supported, info)
+	}
+
+	return supported
+}
+
+// EncoderForVersion returns the `serializer` input
+func (*KindNegotiatedSerializer) EncoderForVersion(serializer runtime.Encoder,
+	_ runtime.GroupVersioner) runtime.Encoder {
+	return serializer
+}
+
+// DecoderToVersion returns a GenericJSONDecoder
+func (*KindNegotiatedSerializer) DecoderToVersion(_ runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return &GenericJSONDecoder{}
+}
+
+// GenericJSONDecoder implements runtime.Serializer and works with Untyped* objects to implement runtime.Object
+type CodecDecoder struct {
+	SampleObject resource.Object
+	Codec        resource.Codec
+}
+
+// Decode decodes the provided data into UntypedWatchObject or UntypedObjectWrapper
+//
+//nolint:gocritic,revive
+func (c *CodecDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (
+	runtime.Object, *schema.GroupVersionKind, error) {
+	type check struct {
+		metav1.TypeMeta `json:",inline"`
+		Type            string          `json:"type"`
+		Kind            string          `json:"kind"`
+		Items           []interface{}   `json:"items,omitempty"`
+		Object          json.RawMessage `json:"object"`
+	}
+	if into != nil {
+		// We shouldn't encounter this
+		// TODO: make better
+		err := json.Unmarshal(data, into)
+		return into, defaults, err
+	}
+
+	// Determine what kind of object we have the raw bytes for
+	// We do this by unmarshalling into a superset of a few possible types, then narrowing down
+	// TODO: this seems very naive, check how apimachinery does it typically
+	chk := check{}
+	err := json.Unmarshal(data, &chk)
+	if chk.Type != "" {
+		// Watch response
+		w := &UntypedWatchObject{}
+		err = json.Unmarshal(data, w)
+		obj := c.SampleObject.Copy()
+		c.Codec.Read(bytes.NewReader(check.Object), obj)
+		into = &watch.Event{
+			Type:   watch.EventType(chk.Type),
+			Object: obj,
+		}
+		into = w
+	} else if chk.Items != nil {
+		// List
+		// TODO
+	} else if chk.Kind != "" {
+		o := &UntypedObjectWrapper{}
+		err = json.Unmarshal(data, o)
+		o.object = data
+		into = o
+	}
+	return into, defaults, err
+}
+
+// Encode json-encodes the provided object
+func (*CodecDecoder) Encode(obj runtime.Object, w io.Writer) error {
+	// TODO: check compliance with resource.Object and use marshalJSON in that case
+	b, e := json.Marshal(obj)
+	if e != nil {
+		return e
+	}
+	_, e = w.Write(b)
+	return e
+}
+
+// Identifier returns "generic-json-decoder"
+func (*CodecDecoder) Identifier() runtime.Identifier {
+	return "generic-json-decoder"
+}
+*/

--- a/k8s/schemaless_test.go
+++ b/k8s/schemaless_test.go
@@ -63,9 +63,9 @@ func TestSchemalessClient_Get(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 		}
 
-		into := resource.SimpleObject[any]{}
+		into := resource.TypedSpecObject[any]{}
 		err := client.Get(ctx, id2, &into)
-		assert.Equal(t, resource.SimpleObject[any]{}, into)
+		assert.Equal(t, resource.TypedSpecObject[any]{}, into)
 		require.NotNil(t, err)
 		cast, ok := err.(*ServerResponseError)
 		require.True(t, ok)
@@ -79,13 +79,13 @@ func TestSchemalessClient_Get(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id1.Namespace, fmt.Sprintf("%ss", id1.Kind), id1.Name), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Get(ctx, id1, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
 		assert.Equal(t, responseObj.Spec, into.Spec)
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 
 	t.Run("success, id2", func(t *testing.T) {
@@ -95,13 +95,13 @@ func TestSchemalessClient_Get(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id2.Namespace, id2.Plural, id2.Name), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Get(ctx, id2, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
 		assert.Equal(t, responseObj.Spec, into.Spec)
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 }
 
@@ -140,7 +140,7 @@ func TestSchemalessClient_Create(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 		}
 
-		err := client.Create(ctx, id, getTestObject(), resource.CreateOptions{}, &resource.SimpleObject[any]{})
+		err := client.Create(ctx, id, getTestObject(), resource.CreateOptions{}, &resource.TypedSpecObject[any]{})
 		require.NotNil(t, err)
 		cast, ok := err.(*ServerResponseError)
 		require.True(t, ok)
@@ -162,13 +162,13 @@ func TestSchemalessClient_Create(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s", id.Namespace, fmt.Sprintf("%ss", id.Kind)), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Create(ctx, id, getTestObject(), resource.CreateOptions{}, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), into.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), into.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 }
 
@@ -229,15 +229,15 @@ func TestSchemalessClient_Update(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id.Namespace, fmt.Sprintf("%ss", id.Kind), id.Name), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Update(ctx, id, getTestObject(), resource.UpdateOptions{
-			ResourceVersion: responseObj.CommonMeta.ResourceVersion,
+			ResourceVersion: responseObj.GetCommonMetadata().ResourceVersion,
 		}, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), into.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), into.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 
 	t.Run("success, no RV", func(t *testing.T) {
@@ -261,13 +261,13 @@ func TestSchemalessClient_Update(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id.Namespace, fmt.Sprintf("%ss", id.Kind), id.Name), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Update(ctx, id, getTestObject(), resource.UpdateOptions{}, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), into.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), into.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 
 	t.Run("success, subresource", func(t *testing.T) {
@@ -286,16 +286,16 @@ func TestSchemalessClient_Update(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s/status", id.Namespace, fmt.Sprintf("%ss", id.Kind), id.Name), r.URL.Path)
 		}
 
-		into := resource.SimpleObject[testSpec]{}
+		into := resource.TypedSpecObject[testSpec]{}
 		err := client.Update(ctx, id, getTestObject(), resource.UpdateOptions{
-			ResourceVersion: responseObj.CommonMeta.ResourceVersion,
+			ResourceVersion: responseObj.GetCommonMetadata().ResourceVersion,
 			Subresource:     "status",
 		}, &into)
 		assert.Nil(t, err)
-		assert.Equal(t, responseObj.StaticMetadata(), into.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), into.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), into.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), into.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), into.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), into.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), into.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), into.GetSubresources())
 	})
 }
 
@@ -349,7 +349,7 @@ func TestSchemalessClient_List(t *testing.T) {
 	ctx := context.TODO()
 	listResp := testList{
 		TypeMeta: metav1.TypeMeta{
-			Kind: responseObj.StaticMeta.Kind,
+			Kind: responseObj.GetStaticMetadata().Kind,
 		},
 		Metadata: metav1.ListMeta{},
 		Items: []submittedObj{{
@@ -364,8 +364,8 @@ func TestSchemalessClient_List(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 		}
 
-		into := resource.SimpleList[*resource.SimpleObject[testSpec]]{}
-		err := client.List(ctx, id, resource.ListOptions{}, &into, &resource.SimpleObject[testSpec]{})
+		into := resource.TypedList[*resource.TypedSpecObject[testSpec]]{}
+		err := client.List(ctx, id, resource.ListOptions{}, &into, &resource.TypedSpecObject[testSpec]{})
 		require.NotNil(t, err)
 		cast, ok := err.(*ServerResponseError)
 		require.True(t, ok)
@@ -382,16 +382,16 @@ func TestSchemalessClient_List(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s", id.Namespace, fmt.Sprintf("%ss", id.Kind)), r.URL.Path)
 		}
 
-		into := resource.SimpleList[*resource.SimpleObject[testSpec]]{}
-		err := client.List(ctx, id, resource.ListOptions{}, &into, &resource.SimpleObject[testSpec]{})
+		into := resource.TypedList[*resource.TypedSpecObject[testSpec]]{}
+		err := client.List(ctx, id, resource.ListOptions{}, &into, &resource.TypedSpecObject[testSpec]{})
 		assert.Nil(t, err)
-		assert.Len(t, into.ListItems(), 1)
-		item, ok := into.ListItems()[0].(*resource.SimpleObject[testSpec])
+		assert.Len(t, into.GetItems(), 1)
+		item, ok := into.GetItems()[0].(*resource.TypedSpecObject[testSpec])
 		assert.True(t, ok)
-		assert.Equal(t, responseObj.StaticMetadata(), item.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), item.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), item.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), item.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), item.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), item.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), item.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), item.GetSubresources())
 	})
 
 	t.Run("success, with filters", func(t *testing.T) {
@@ -406,18 +406,18 @@ func TestSchemalessClient_List(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s", id.Namespace, fmt.Sprintf("%ss", id.Kind)), r.URL.Path)
 		}
 
-		into := resource.SimpleList[*resource.SimpleObject[testSpec]]{}
+		into := resource.TypedList[*resource.TypedSpecObject[testSpec]]{}
 		err := client.List(ctx, id, resource.ListOptions{
 			LabelFilters: []string{"a", "b"},
-		}, &into, &resource.SimpleObject[testSpec]{})
+		}, &into, &resource.TypedSpecObject[testSpec]{})
 		assert.Nil(t, err)
-		assert.Len(t, into.ListItems(), 1)
-		item, ok := into.ListItems()[0].(*resource.SimpleObject[testSpec])
+		assert.Len(t, into.GetItems(), 1)
+		item, ok := into.GetItems()[0].(*resource.TypedSpecObject[testSpec])
 		assert.True(t, ok)
-		assert.Equal(t, responseObj.StaticMetadata(), item.StaticMetadata())
-		assert.Equal(t, responseObj.CommonMetadata(), item.CommonMetadata())
-		assert.Equal(t, responseObj.SpecObject(), item.SpecObject())
-		assert.Equal(t, responseObj.Subresources(), item.Subresources())
+		assert.Equal(t, responseObj.GetStaticMetadata(), item.GetStaticMetadata())
+		assert.Equal(t, responseObj.GetCommonMetadata(), item.GetCommonMetadata())
+		assert.Equal(t, responseObj.GetSpec(), item.GetSpec())
+		assert.Equal(t, responseObj.GetSubresources(), item.GetSubresources())
 	})
 }
 

--- a/k8s/translation.go
+++ b/k8s/translation.go
@@ -1,132 +1,21 @@
 package k8s
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
-
-	admission "k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana-app-sdk/resource"
+	admission "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-type k8sObject struct {
-	metav1.TypeMeta `json:",inline"`
-	ObjectMetadata  metav1.ObjectMeta `json:"metadata"`
-	Spec            json.RawMessage   `json:"spec"`
-	Status          json.RawMessage   `json:"status"`
-	Scale           json.RawMessage   `json:"scale"`
-}
 
 type k8sListWithItems struct {
 	metav1.TypeMeta `json:",inline"`
 	Metadata        metav1.ListMeta   `json:"metadata"`
 	Items           []json.RawMessage `json:"items"`
-}
-
-// this is janky
-//
-// nolint:funlen
-func rawToObject(raw []byte, into resource.Object) error {
-	if into == nil {
-		return fmt.Errorf("into cannot be nil")
-	}
-	// Parse the bytes into parts we can handle (spec, status, scale, metadata)
-	kubeObject := k8sObject{}
-	err := json.Unmarshal(raw, &kubeObject)
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal the spec and subresources into the object
-	subresources := make(map[string][]byte)
-	if kubeObject.Status != nil && len(kubeObject.Status) > 0 {
-		subresources["status"] = kubeObject.Status
-	}
-	if kubeObject.Scale != nil && len(kubeObject.Scale) > 0 {
-		subresources["scale"] = kubeObject.Scale
-	}
-	// Metadata from annotations
-	meta := make(map[string]any)
-	for k, v := range kubeObject.ObjectMetadata.Annotations {
-		if len(k) > len(AnnotationPrefix) && k[:len(AnnotationPrefix)] == AnnotationPrefix {
-			meta[k[len(AnnotationPrefix):]] = v
-		}
-	}
-	// All the (required) CommonMetadata fields--thema parse gets mad otherwise
-	// TODO: overhaul this whole thing so we can just set everything in the metadata without a two-step process
-	if _, ok := meta[annotationUpdateTimestamp]; !ok {
-		meta[annotationUpdateTimestamp] = kubeObject.ObjectMetadata.CreationTimestamp.Format(time.RFC3339Nano)
-	}
-	if _, ok := meta[annotationCreatedBy]; !ok {
-		meta[annotationCreatedBy] = ""
-	}
-	if _, ok := meta[annotationUpdatedBy]; !ok {
-		meta[annotationUpdatedBy] = ""
-	}
-	meta["resourceVersion"] = kubeObject.ObjectMetadata.ResourceVersion
-	meta["generation"] = kubeObject.ObjectMetadata.Generation
-	meta["uid"] = kubeObject.ObjectMetadata.UID
-	meta["creationTimestamp"] = kubeObject.ObjectMetadata.CreationTimestamp
-
-	amd, err := json.Marshal(meta)
-	if err != nil {
-		return err
-	}
-	err = into.Unmarshal(resource.ObjectBytes{
-		Spec:         kubeObject.Spec,
-		Subresources: subresources,
-		Metadata:     amd,
-	}, resource.UnmarshalConfig{
-		WireFormat:  resource.WireFormatJSON,
-		VersionHint: kubeObject.ObjectMetadata.Labels[versionLabel],
-	})
-	if err != nil {
-		return err
-	}
-
-	// Set the static metadata
-	into.SetStaticMetadata(resource.StaticMetadata{
-		Namespace: kubeObject.ObjectMetadata.Namespace,
-		Name:      kubeObject.ObjectMetadata.Name,
-		Group:     kubeObject.TypeMeta.GroupVersionKind().Group,
-		Version:   kubeObject.TypeMeta.GroupVersionKind().Version,
-		Kind:      kubeObject.TypeMeta.Kind,
-	})
-
-	// Set the object metadata
-	cmd := into.CommonMetadata()
-	cmd.ResourceVersion = kubeObject.ObjectMetadata.ResourceVersion
-	cmd.Generation = kubeObject.ObjectMetadata.Generation
-	cmd.Labels = kubeObject.ObjectMetadata.Labels
-	cmd.UID = string(kubeObject.ObjectMetadata.UID)
-	if cmd.ExtraFields == nil {
-		cmd.ExtraFields = make(map[string]any)
-	}
-	cmd.Finalizers = kubeObject.ObjectMetadata.Finalizers
-	if len(kubeObject.ObjectMetadata.OwnerReferences) > 0 {
-		cmd.ExtraFields["ownerReferences"] = kubeObject.ObjectMetadata.OwnerReferences
-	}
-	if len(kubeObject.ObjectMetadata.ManagedFields) > 0 {
-		cmd.ExtraFields["managedFields"] = kubeObject.ObjectMetadata.ManagedFields
-	}
-	if len(kubeObject.ObjectMetadata.Annotations) > 0 {
-		cmd.ExtraFields["annotations"] = kubeObject.ObjectMetadata.Annotations
-	}
-	cmd.CreationTimestamp = kubeObject.ObjectMetadata.CreationTimestamp.Time
-	if kubeObject.ObjectMetadata.DeletionTimestamp != nil {
-		t := kubeObject.ObjectMetadata.DeletionTimestamp.Time
-		cmd.DeletionTimestamp = &t
-	}
-
-	into.SetCommonMetadata(cmd)
-
-	return nil
 }
 
 func rawToListWithParser(raw []byte, into resource.ListObject, itemParser func([]byte) (resource.Object, error)) error {
@@ -145,11 +34,11 @@ func rawToListWithParser(raw []byte, into resource.ListObject, itemParser func([
 		}
 		items = append(items, parsed)
 	}
-	into.SetListMetadata(resource.ListMetadata{
-		ResourceVersion:    um.Metadata.ResourceVersion,
-		Continue:           um.Metadata.Continue,
-		RemainingItemCount: um.Metadata.RemainingItemCount,
-	})
+	into.SetResourceVersion(um.Metadata.ResourceVersion)
+	into.SetGroupVersionKind(um.GroupVersionKind())
+	into.SetSelfLink(um.Metadata.SelfLink)
+	into.SetContinue(um.Metadata.Continue)
+	into.SetRemainingItemCount(um.Metadata.GetRemainingItemCount())
 	into.SetItems(items)
 	return nil
 }
@@ -160,40 +49,6 @@ type convertedObject struct {
 	Spec            any               `json:"spec"`
 	Status          any               `json:"status,omitempty"`
 	Scale           any               `json:"scale,omitempty"`
-}
-
-func marshalJSON(obj resource.Object, extraLabels map[string]string, cfg ClientConfig) ([]byte, error) {
-	if obj == nil {
-		return nil, fmt.Errorf("obj cannot be nil")
-	}
-
-	co := convertedObject{
-		TypeMeta: metav1.TypeMeta{
-			Kind: obj.StaticMetadata().Kind,
-			APIVersion: schema.GroupVersion{
-				Group:   obj.StaticMetadata().Group,
-				Version: obj.StaticMetadata().Version,
-			}.Identifier(),
-		},
-		Metadata: getV1ObjectMeta(obj, cfg),
-		Spec:     obj.SpecObject(),
-	}
-	if co.Metadata.Labels == nil {
-		co.Metadata.Labels = make(map[string]string)
-	}
-	for k, v := range extraLabels {
-		co.Metadata.Labels[k] = v
-	}
-
-	// Status and Scale subresources, if applicable
-	if status, ok := obj.Subresources()[string(resource.SubresourceStatus)]; ok {
-		co.Status = status
-	}
-	if scale, ok := obj.Subresources()[string(resource.SubresourceScale)]; ok {
-		co.Scale = scale
-	}
-
-	return json.Marshal(co)
 }
 
 var metaV1Fields = getV1ObjectMetaFields()
@@ -259,74 +114,6 @@ func getV1ObjectMetaFields() map[string]struct{} {
 	return fields
 }
 
-func getV1ObjectMeta(obj resource.Object, cfg ClientConfig) metav1.ObjectMeta {
-	cMeta := obj.CommonMetadata()
-	meta := metav1.ObjectMeta{
-		Name:              obj.StaticMetadata().Name,
-		Namespace:         obj.StaticMetadata().Namespace,
-		UID:               types.UID(cMeta.UID),
-		ResourceVersion:   cMeta.ResourceVersion,
-		Generation:        cMeta.Generation,
-		CreationTimestamp: metav1.NewTime(cMeta.CreationTimestamp),
-		Labels:            cMeta.Labels,
-		Finalizers:        cMeta.Finalizers,
-		Annotations:       make(map[string]string),
-	}
-	// Rest of the metadata in ExtraFields
-	for k, v := range cMeta.ExtraFields {
-		switch strings.ToLower(k) {
-		case "ownerReferences":
-			if o, ok := v.([]metav1.OwnerReference); ok {
-				meta.OwnerReferences = o
-			}
-		case "managedFields":
-			if m, ok := v.([]metav1.ManagedFieldsEntry); ok {
-				meta.ManagedFields = m
-			}
-		case "annotations":
-			if a, ok := v.(map[string]string); ok {
-				for key, val := range a {
-					meta.Annotations[key] = val
-				}
-			}
-		}
-	}
-	// Common metadata which isn't a part of kubernetes metadata
-	meta.Annotations[AnnotationPrefix+annotationCreatedBy] = cMeta.CreatedBy
-	meta.Annotations[AnnotationPrefix+annotationUpdatedBy] = cMeta.UpdatedBy
-	// Only set the UpdateTimestamp metadata if it's non-zero
-	if !cMeta.UpdateTimestamp.IsZero() {
-		meta.Annotations[AnnotationPrefix+annotationUpdateTimestamp] = cMeta.UpdateTimestamp.Format(time.RFC3339Nano)
-	}
-
-	// The non-common metadata needs to be converted into annotations
-	for k, v := range obj.CustomMetadata().MapFields() {
-		if cfg.CustomMetadataIsAnyType {
-			meta.Annotations[AnnotationPrefix+k] = toString(v)
-		} else {
-			meta.Annotations[AnnotationPrefix+k] = v.(string) // nolint: revive
-		}
-	}
-
-	return meta
-}
-
-func toString(t any) string {
-	v := reflect.ValueOf(t)
-	for v.Kind() == reflect.Ptr {
-		v = v.Elem()
-	}
-	switch v.Kind() {
-	case reflect.String, reflect.Int, reflect.Int32, reflect.Int64, reflect.Float32, reflect.Float64, reflect.Bool:
-		return fmt.Sprintf("%v", v.Interface())
-	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
-		return "" // Invalid kind to encode
-	default:
-		bytes, _ := json.Marshal(t)
-		return string(bytes)
-	}
-}
-
 func unmarshalKubernetesAdmissionReview(bytes []byte, format resource.WireFormat) (*admission.AdmissionReview, error) {
 	if format != resource.WireFormatJSON {
 		return nil, fmt.Errorf("unsupported WireFormat '%s'", fmt.Sprint(format))
@@ -340,19 +127,18 @@ func unmarshalKubernetesAdmissionReview(bytes []byte, format resource.WireFormat
 	return &rev, nil
 }
 
-func translateKubernetesAdmissionRequest(req *admission.AdmissionRequest, sch resource.Schema) (*resource.AdmissionRequest, error) {
+func translateKubernetesAdmissionRequest(req *admission.AdmissionRequest, sch resource.Kind) (*resource.AdmissionRequest, error) {
+	var err error
 	var obj, old resource.Object
 
 	if len(req.Object.Raw) > 0 {
-		obj = sch.ZeroValue()
-		err := rawToObject(req.Object.Raw, obj)
+		obj, err = sch.Read(bytes.NewReader(req.Object.Raw), resource.KindEncodingJSON)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(req.OldObject.Raw) > 0 {
-		old = sch.ZeroValue()
-		err := rawToObject(req.OldObject.Raw, old)
+		old, err = sch.Read(bytes.NewReader(req.OldObject.Raw), resource.KindEncodingJSON)
 		if err != nil {
 			return nil, err
 		}

--- a/k8s/translation_test.go
+++ b/k8s/translation_test.go
@@ -3,13 +3,15 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -17,156 +19,6 @@ var _ resource.Object = &TestResourceObject{}
 
 var createdTime = time.Now().Truncate(time.Second)
 var updatedTime = time.Now()
-
-// complexObject is a fully-filled-out TestResourceObject
-var complexObject = TestResourceObject{
-	StaticMeta: resource.StaticMetadata{
-		Kind:      "complex",
-		Group:     "grafana.com",
-		Version:   "v1",
-		Namespace: "ns",
-		Name:      "foo",
-	},
-	Metadata: TestResourceObjectMetadata{
-		CommonMetadata: resource.CommonMetadata{
-			UID:               "abc",
-			ResourceVersion:   "12345",
-			Generation:        1,
-			Labels:            map[string]string{"foo": "bar"},
-			CreationTimestamp: createdTime,
-			Finalizers:        []string{"finalizer"},
-			UpdateTimestamp:   updatedTime,
-			CreatedBy:         "me",
-			UpdatedBy:         "you",
-			ExtraFields: map[string]any{
-				"annotations": map[string]string{
-					fmt.Sprintf("%screatedBy", AnnotationPrefix):       "me",
-					fmt.Sprintf("%supdatedBy", AnnotationPrefix):       "you",
-					fmt.Sprintf("%supdateTimestamp", AnnotationPrefix): updatedTime.Format(time.RFC3339Nano),
-					fmt.Sprintf("%scustomField1", AnnotationPrefix):    "foo",
-					fmt.Sprintf("%scustomField2", AnnotationPrefix):    "bar",
-				},
-			},
-		},
-		CustomField1: "foo",
-		CustomField2: "bar",
-	},
-	Spec: TestResourceSpec{
-		StringField: "a string",
-		IntField:    64,
-		FloatField:  6.4,
-		ObjectSlice: []TestResourceSpecInner{
-			{
-				Foo: "first",
-				Bar: map[string]string{
-					"key": "value",
-				},
-			},
-			{
-				Foo: "second",
-				Bar: map[string]string{
-					"key2": "value2",
-				},
-			},
-		},
-	},
-}
-
-func TestRawToObject(t *testing.T) {
-	badJSON := []byte("not json")
-	nilJSONErr := json.Unmarshal(nil, &struct{}{})
-	emptyJSONErr := json.Unmarshal([]byte{}, &struct{}{})
-	badJSONErr := json.Unmarshal(badJSON, &struct{}{})
-
-	// complexJSON is JSON generated from a kubernetes version of complexObject,
-	// so we can source the raw JSON from kubernetes' libraries, and ensure that the process
-	// returns a TestResourceObject identical to complexObject
-	complexJSON, _ := json.Marshal(testKubernetesObject{
-		TypeMeta: metav1.TypeMeta{
-			Kind: complexObject.StaticMeta.Kind,
-			APIVersion: metav1.GroupVersion{
-				Group:   complexObject.StaticMeta.Group,
-				Version: complexObject.StaticMeta.Version,
-			}.String(),
-		},
-		Metadata: metav1.ObjectMeta{
-			Name:              complexObject.StaticMeta.Name,
-			Namespace:         complexObject.StaticMeta.Namespace,
-			UID:               types.UID(complexObject.Metadata.UID),
-			ResourceVersion:   complexObject.Metadata.ResourceVersion,
-			Labels:            complexObject.Metadata.Labels,
-			CreationTimestamp: metav1.Time{complexObject.Metadata.CreationTimestamp},
-			Finalizers:        complexObject.Metadata.Finalizers,
-			Generation:        complexObject.Metadata.Generation,
-			Annotations: map[string]string{
-				fmt.Sprintf("%screatedBy", AnnotationPrefix):       complexObject.Metadata.CreatedBy,
-				fmt.Sprintf("%supdatedBy", AnnotationPrefix):       complexObject.Metadata.UpdatedBy,
-				fmt.Sprintf("%supdateTimestamp", AnnotationPrefix): complexObject.Metadata.UpdateTimestamp.Format(time.RFC3339Nano),
-				fmt.Sprintf("%scustomField1", AnnotationPrefix):    complexObject.Metadata.CustomField1,
-				fmt.Sprintf("%scustomField2", AnnotationPrefix):    complexObject.Metadata.CustomField2,
-			},
-		},
-		Spec:   complexObject.Spec,
-		Status: complexObject.Status,
-	})
-
-	tests := []struct {
-		name        string
-		raw         []byte
-		into        resource.Object
-		expectedObj resource.Object
-		expectedErr error
-	}{
-		{
-			name:        "nil bytes",
-			raw:         nil,
-			into:        &TestResourceObject{},
-			expectedObj: &TestResourceObject{},
-			expectedErr: nilJSONErr,
-		},
-		{
-			name:        "empty bytes",
-			raw:         nil,
-			into:        &TestResourceObject{},
-			expectedObj: &TestResourceObject{},
-			expectedErr: emptyJSONErr,
-		},
-		{
-			name:        "bad JSON",
-			raw:         badJSON,
-			into:        &TestResourceObject{},
-			expectedObj: &TestResourceObject{},
-			expectedErr: badJSONErr,
-		},
-		{
-			name:        "nil into",
-			raw:         []byte("{}"),
-			into:        nil,
-			expectedObj: nil,
-			expectedErr: fmt.Errorf("into cannot be nil"),
-		},
-		{
-			name:        "full object",
-			raw:         complexJSON,
-			into:        &TestResourceObject{},
-			expectedObj: &complexObject,
-			expectedErr: nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := rawToObject(test.raw, test.into)
-			assert.Equal(t, test.expectedErr, err)
-			// convert to JSON and compare, because otherwise time comparisons are tricky
-			expected, err := json.Marshal(test.expectedObj)
-			require.Nil(t, err)
-			actual, err := json.Marshal(test.into)
-			require.Nil(t, err)
-			assert.JSONEq(t, string(expected), string(actual))
-		})
-	}
-}
 
 func TestRawToListWithParser(t *testing.T) {
 	ric := int64(2)
@@ -193,37 +45,37 @@ func TestRawToListWithParser(t *testing.T) {
 		{
 			name: "parser error",
 			raw:  completeListJSON,
-			into: &listImpl{},
+			into: &resource.UntypedList{},
 			parser: func(bytes []byte) (resource.Object, error) {
 				return nil, fmt.Errorf("I AM ERROR")
 			},
-			expectedList:  &listImpl{},
+			expectedList:  &resource.UntypedList{},
 			expectedError: fmt.Errorf("I AM ERROR"),
 		},
 		{
 			name: "success",
 			raw:  completeListJSON,
-			into: &listImpl{},
+			into: &resource.UntypedList{},
 			parser: func(bytes []byte) (resource.Object, error) {
 				// We're not testing the unmarshal of the objects, so let's just put the raw bytes of the list item
 				// into the spec of a simpleobject. We can check against a SimpleObject with a spec of the bytes
 				// in our expectedList.Items
-				return &resource.SimpleObject[[]byte]{
+				return &resource.TypedSpecObject[[]byte]{
 					Spec: bytes,
 				}, nil
 			},
-			expectedList: &listImpl{
-				lmd: resource.ListMetadata{
+			expectedList: &resource.UntypedList{
+				ListMeta: metav1.ListMeta{
 					ResourceVersion:    completeList.Metadata.ResourceVersion,
 					Continue:           completeList.Metadata.Continue,
 					RemainingItemCount: completeList.Metadata.RemainingItemCount,
 				},
-				items: []resource.Object{
-					&resource.SimpleObject[[]byte]{
+				Items: []resource.Object{
+					&resource.TypedSpecObject[[]byte]{
 						Spec: []byte(`["a"]`),
-					}, &resource.SimpleObject[[]byte]{
+					}, &resource.TypedSpecObject[[]byte]{
 						Spec: []byte(`["b"]`),
-					}, &resource.SimpleObject[[]byte]{
+					}, &resource.TypedSpecObject[[]byte]{
 						Spec: []byte(`["c"]`),
 					},
 				},
@@ -236,10 +88,14 @@ func TestRawToListWithParser(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := rawToListWithParser(test.raw, test.into, test.parser)
 			assert.Equal(t, test.expectedError, err)
-			assert.Equal(t, test.expectedList.ListMetadata(), test.into.ListMetadata())
+			assert.Equal(t, test.expectedList.GetSelfLink(), test.into.GetSelfLink())
+			assert.Equal(t, test.expectedList.GetContinue(), test.into.GetContinue())
+			assert.Equal(t, test.expectedList.GetRemainingItemCount(), test.into.GetRemainingItemCount())
+			assert.Equal(t, test.expectedList.GetResourceVersion(), test.into.GetResourceVersion())
+			assert.Equal(t, test.expectedList.GetObjectKind().GroupVersionKind(), test.into.GetObjectKind().GroupVersionKind())
 			// Compare list items as JSON, as the lists are slices of pointers and will be unequal
-			expectedJSON, _ := json.Marshal(test.expectedList.ListItems())
-			actualJSON, _ := json.Marshal(test.into.ListItems())
+			expectedJSON, _ := json.Marshal(test.expectedList.GetItems())
+			actualJSON, _ := json.Marshal(test.into.GetItems())
 			assert.JSONEq(t, string(expectedJSON), string(actualJSON))
 		})
 	}
@@ -250,99 +106,6 @@ type testKubernetesObject struct {
 	Metadata        metav1.ObjectMeta  `json:"metadata"`
 	Spec            TestResourceSpec   `json:"spec"`
 	Status          TestResourceStatus `json:"status"`
-}
-
-func TestMarshalJSON(t *testing.T) {
-	// To ensure that possible kubernetes meta changes don't break us, we convert a kubernetes object to bytes to use.
-	// This makes sure that the marshalJSON converts object bytes into the equivalent kubernetes object bytes
-	complexBytes, _ := json.Marshal(testKubernetesObject{
-		TypeMeta: metav1.TypeMeta{
-			Kind: complexObject.StaticMeta.Kind,
-			APIVersion: metav1.GroupVersion{
-				Group:   complexObject.StaticMeta.Group,
-				Version: complexObject.StaticMeta.Version,
-			}.String(),
-		},
-		Metadata: metav1.ObjectMeta{
-			Name:              complexObject.StaticMeta.Name,
-			Namespace:         complexObject.StaticMeta.Namespace,
-			UID:               types.UID(complexObject.Metadata.UID),
-			ResourceVersion:   complexObject.Metadata.ResourceVersion,
-			CreationTimestamp: metav1.NewTime(complexObject.Metadata.CreationTimestamp),
-			Labels:            complexObject.Metadata.Labels,
-			//CreationTimestamp: metav1.Time{complexObject.Metadata.CreationTimestamp},
-			Finalizers: complexObject.Metadata.Finalizers,
-			Generation: complexObject.Metadata.Generation,
-			Annotations: map[string]string{
-				fmt.Sprintf("%screatedBy", AnnotationPrefix):       complexObject.Metadata.CreatedBy,
-				fmt.Sprintf("%supdatedBy", AnnotationPrefix):       complexObject.Metadata.UpdatedBy,
-				fmt.Sprintf("%supdateTimestamp", AnnotationPrefix): complexObject.Metadata.UpdateTimestamp.Format(time.RFC3339Nano),
-				fmt.Sprintf("%scustomField1", AnnotationPrefix):    complexObject.Metadata.CustomField1,
-				fmt.Sprintf("%scustomField2", AnnotationPrefix):    complexObject.Metadata.CustomField2,
-			},
-		},
-		Spec:   complexObject.Spec,
-		Status: complexObject.Status,
-	})
-
-	emptyObject := TestResourceObject{}
-	emptyBytes, _ := json.Marshal(testKubernetesObject{
-		Metadata: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				fmt.Sprintf("%screatedBy", AnnotationPrefix): "",
-				fmt.Sprintf("%supdatedBy", AnnotationPrefix): "",
-				// No updateTimestamp when it's a zero (empty) time
-				fmt.Sprintf("%scustomField1", AnnotationPrefix): "",
-				fmt.Sprintf("%scustomField2", AnnotationPrefix): "",
-			},
-		},
-	})
-
-	tests := []struct {
-		name          string
-		obj           resource.Object
-		extraLabels   map[string]string
-		config        ClientConfig
-		expectedJSON  []byte
-		expectedError error
-	}{
-		{
-			name:          "nil obj",
-			obj:           nil,
-			extraLabels:   nil,
-			config:        ClientConfig{},
-			expectedJSON:  nil,
-			expectedError: fmt.Errorf("obj cannot be nil"),
-		},
-		{
-			name:          "complex object",
-			obj:           &complexObject,
-			extraLabels:   nil,
-			config:        ClientConfig{},
-			expectedJSON:  complexBytes,
-			expectedError: nil,
-		},
-		{
-			name:          "empty object",
-			obj:           &emptyObject,
-			extraLabels:   nil,
-			config:        ClientConfig{},
-			expectedJSON:  emptyBytes,
-			expectedError: nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			bytes, err := marshalJSON(test.obj, test.extraLabels, test.config)
-			assert.Equal(t, test.expectedError, err)
-			if test.expectedJSON != nil {
-				assert.JSONEq(t, string(test.expectedJSON), string(bytes))
-			} else {
-				assert.Nil(t, bytes)
-			}
-		})
-	}
 }
 
 func TestMarshalJSONPatch(t *testing.T) {
@@ -467,12 +230,30 @@ func TestMarshalJSONPatch(t *testing.T) {
 	}
 }
 
+type TestCodec struct {
+	ReadFunc  func(reader io.Reader, object resource.Object) error
+	WriteFunc func(writer io.Writer, object resource.Object) error
+}
+
+func (tc *TestCodec) Read(reader io.Reader, object resource.Object) error {
+	if tc.ReadFunc != nil {
+		return tc.ReadFunc(reader, object)
+	}
+	return nil
+}
+
+func (tc *TestCodec) Write(writer io.Writer, object resource.Object) error {
+	if tc.WriteFunc != nil {
+		return tc.WriteFunc(writer, object)
+	}
+	return nil
+}
+
 type TestResourceObject struct {
-	StaticMeta    resource.StaticMetadata
-	Metadata      TestResourceObjectMetadata
-	Spec          TestResourceSpec
-	Status        TestResourceStatus
-	UnmarshalFunc func(self *TestResourceObject, bytes resource.ObjectBytes, config resource.UnmarshalConfig) error `json:"-"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              TestResourceSpec   `json:"spec"`
+	Status            TestResourceStatus `json:"status"`
 }
 
 type TestResourceObjectMetadata struct {
@@ -496,60 +277,155 @@ type TestResourceSpecInner struct {
 type TestResourceStatus struct {
 }
 
-func (tro *TestResourceObject) StaticMetadata() resource.StaticMetadata {
-	return tro.StaticMeta
-}
-
-func (tro *TestResourceObject) SetStaticMetadata(in resource.StaticMetadata) {
-	tro.StaticMeta = in
-}
-
-func (tro *TestResourceObject) CommonMetadata() resource.CommonMetadata {
-	return tro.Metadata.CommonMetadata
-}
-
-func (tro *TestResourceObject) SetCommonMetadata(in resource.CommonMetadata) {
-	tro.Metadata.CommonMetadata = in
-}
-
-func (tro *TestResourceObject) CustomMetadata() resource.CustomMetadata {
-	return resource.SimpleCustomMetadata{
-		"customField1": tro.Metadata.CustomField1,
-		"customField2": tro.Metadata.CustomField2,
+func (tro *TestResourceObject) GetStaticMetadata() resource.StaticMetadata {
+	return resource.StaticMetadata{
+		Name:      tro.GetName(),
+		Namespace: tro.GetNamespace(),
+		Group:     tro.GroupVersionKind().Group,
+		Version:   tro.GroupVersionKind().Version,
+		Kind:      tro.GroupVersionKind().Kind,
 	}
 }
 
-func (tro *TestResourceObject) SpecObject() any {
+func (tro *TestResourceObject) SetStaticMetadata(metadata resource.StaticMetadata) {
+	tro.Name = metadata.Name
+	tro.Namespace = metadata.Namespace
+	tro.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   metadata.Group,
+		Version: metadata.Version,
+		Kind:    metadata.Kind,
+	})
+}
+
+func (tro *TestResourceObject) GetCommonMetadata() resource.CommonMetadata {
+	var err error
+	dt := tro.DeletionTimestamp
+	var deletionTimestamp *time.Time
+	if dt != nil {
+		deletionTimestamp = &dt.Time
+	}
+	updt := time.Time{}
+	createdBy := ""
+	updatedBy := ""
+	if tro.Annotations != nil {
+		strUpdt, ok := tro.Annotations[resource.AnnotationUpdateTimestamp]
+		if ok {
+			updt, err = time.Parse(time.RFC3339, strUpdt)
+			if err != nil {
+				// HMMMM
+			}
+		}
+		createdBy = tro.Annotations[resource.AnnotationCreatedBy]
+		updatedBy = tro.Annotations[resource.AnnotationUpdatedBy]
+	}
+	return resource.CommonMetadata{
+		UID:               string(tro.UID),
+		ResourceVersion:   tro.ResourceVersion,
+		Generation:        tro.Generation,
+		Labels:            tro.Labels,
+		CreationTimestamp: tro.CreationTimestamp.Time,
+		DeletionTimestamp: deletionTimestamp,
+		Finalizers:        tro.Finalizers,
+		UpdateTimestamp:   updt,
+		CreatedBy:         createdBy,
+		UpdatedBy:         updatedBy,
+		// TODO: populate ExtraFields in UntypedObject?
+	}
+}
+
+func (tro *TestResourceObject) SetCommonMetadata(metadata resource.CommonMetadata) {
+	tro.UID = types.UID(metadata.UID)
+	tro.ResourceVersion = metadata.ResourceVersion
+	tro.Generation = metadata.Generation
+	tro.Labels = metadata.Labels
+	tro.CreationTimestamp = metav1.NewTime(metadata.CreationTimestamp)
+	if metadata.DeletionTimestamp != nil {
+		dt := metav1.NewTime(*metadata.DeletionTimestamp)
+		tro.DeletionTimestamp = &dt
+	} else {
+		tro.DeletionTimestamp = nil
+	}
+	tro.Finalizers = metadata.Finalizers
+	if tro.Annotations == nil {
+		tro.Annotations = make(map[string]string)
+	}
+	if !metadata.UpdateTimestamp.IsZero() {
+		tro.Annotations[resource.AnnotationUpdateTimestamp] = metadata.UpdateTimestamp.Format(time.RFC3339)
+	}
+	if metadata.CreatedBy != "" {
+		tro.Annotations[resource.AnnotationCreatedBy] = metadata.CreatedBy
+	}
+	if metadata.UpdatedBy != "" {
+		tro.Annotations[resource.AnnotationUpdatedBy] = metadata.UpdatedBy
+	}
+}
+
+func (tro *TestResourceObject) GetCustomField1() string {
+	if tro.ObjectMeta.Annotations == nil {
+		return ""
+	}
+	return tro.ObjectMeta.Annotations["customField1"]
+}
+
+func (tro *TestResourceObject) SetCustomField1(val string) {
+	if tro.ObjectMeta.Annotations == nil {
+		tro.ObjectMeta.Annotations = make(map[string]string)
+	}
+	tro.ObjectMeta.Annotations["customField1"] = val
+}
+
+func (tro *TestResourceObject) GetCustomField2() string {
+	if tro.ObjectMeta.Annotations == nil {
+		return ""
+	}
+	return tro.ObjectMeta.Annotations["customField2"]
+}
+
+func (tro *TestResourceObject) SetCustomField2(val string) {
+	if tro.ObjectMeta.Annotations == nil {
+		tro.ObjectMeta.Annotations = make(map[string]string)
+	}
+	tro.ObjectMeta.Annotations["customField2"] = val
+}
+
+func (tro *TestResourceObject) GetSpec() any {
 	return tro.Spec
 }
 
-func (tro *TestResourceObject) Subresources() map[string]any {
-	return map[string]any{
-		"status": TestResourceStatus{},
+func (tro *TestResourceObject) SetSpec(spec any) error {
+	if cast, ok := spec.(TestResourceSpec); ok {
+		tro.Spec = cast
 	}
+	return fmt.Errorf("wrong type for spec")
+}
+
+func (tro *TestResourceObject) GetSubresources() map[string]any {
+	return map[string]any{
+		"status": tro.Status,
+	}
+}
+
+func (tro *TestResourceObject) GetSubresource(name string) (any, bool) {
+	if name == "status" {
+		return tro.Status, true
+	}
+	return nil, false
+}
+
+func (tro *TestResourceObject) SetSubresource(name string, value any) error {
+	if name != "status" {
+		return fmt.Errorf("unknown subresource")
+	}
+	if cast, ok := value.(TestResourceStatus); ok {
+		tro.Status = cast
+	}
+	return fmt.Errorf("wrong type for spec")
 }
 
 func (tro *TestResourceObject) Copy() resource.Object {
 	return resource.CopyObject(tro)
 }
 
-func (tro *TestResourceObject) Unmarshal(b resource.ObjectBytes, cfg resource.UnmarshalConfig) error {
-	if tro.UnmarshalFunc != nil {
-		return tro.UnmarshalFunc(tro, b, cfg)
-	}
-	err := json.Unmarshal(b.Spec, &tro.Spec)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(b.Metadata, &tro.Metadata)
-	if err != nil {
-		return err
-	}
-	if statusBytes, ok := b.Subresources["status"]; ok {
-		err = json.Unmarshal(statusBytes, &tro.Status)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (tro *TestResourceObject) DeepCopyObject() runtime.Object {
+	return tro.Copy()
 }

--- a/k8s/wrappers.go
+++ b/k8s/wrappers.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 
@@ -65,8 +66,8 @@ func (o *UntypedObjectWrapper) DeepCopyObject() runtime.Object {
 
 // Into unmarshals the wrapped object bytes into the provided resource.Object, using the same unmarshal logic
 // that Client and SchemalessClient use
-func (o *UntypedObjectWrapper) Into(into resource.Object) error {
-	return rawToObject(o.object, into)
+func (o *UntypedObjectWrapper) Into(into resource.Object, codec resource.Codec) error {
+	return codec.Read(bytes.NewReader(o.object), into)
 }
 
 // UntypedWatchObject implements runtime.Object, and keeps the Object part of a kubernetes watch event as bytes
@@ -79,8 +80,8 @@ type UntypedWatchObject struct {
 
 // Into unmarshals the wrapped object bytes into the provided resource.Object, using the same unmarshal logic
 // that Client and SchemalessClient use
-func (w *UntypedWatchObject) Into(into resource.Object) error {
-	return rawToObject(w.Object, into)
+func (w *UntypedWatchObject) Into(into resource.Object, codec resource.Codec) error {
+	return codec.Read(bytes.NewReader(w.Object), into)
 }
 
 // DeepCopyObject copies the object
@@ -100,7 +101,7 @@ func (w *UntypedWatchObject) DeepCopyObject() runtime.Object {
 }
 
 type intoObject interface {
-	Into(object resource.Object) error
+	Into(object resource.Object, codec resource.Codec) error
 }
 
 type wrappedObject interface {

--- a/operator/informer_controller_test.go
+++ b/operator/informer_controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInformerController_AddWatcher(t *testing.T) {
@@ -1043,23 +1044,15 @@ func TestOpinionatedRetryDequeuePolicy(t *testing.T) {
 		{
 			name:      "same generations, shouldn't dequeue",
 			newAction: ResourceActionUpdate,
-			newObject: &resource.SimpleObject[string]{
-				BasicMetadataObject: resource.BasicMetadataObject{
-					CommonMeta: resource.CommonMetadata{
-						ExtraFields: map[string]any{
-							"generation": int64(1),
-						},
-					},
+			newObject: &resource.TypedSpecObject[string]{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
 				},
 			},
 			retryAction: ResourceActionCreate,
-			retryObject: &resource.SimpleObject[string]{
-				BasicMetadataObject: resource.BasicMetadataObject{
-					CommonMeta: resource.CommonMetadata{
-						ExtraFields: map[string]any{
-							"generation": int64(1),
-						},
-					},
+			retryObject: &resource.TypedSpecObject[string]{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
 				},
 			},
 			retryError: nil,
@@ -1068,23 +1061,15 @@ func TestOpinionatedRetryDequeuePolicy(t *testing.T) {
 		{
 			name:      "different generations, should dequeue",
 			newAction: ResourceActionUpdate,
-			newObject: &resource.SimpleObject[string]{
-				BasicMetadataObject: resource.BasicMetadataObject{
-					CommonMeta: resource.CommonMetadata{
-						ExtraFields: map[string]any{
-							"generation": int64(1),
-						},
-					},
+			newObject: &resource.TypedSpecObject[string]{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
 				},
 			},
 			retryAction: ResourceActionCreate,
-			retryObject: &resource.SimpleObject[string]{
-				BasicMetadataObject: resource.BasicMetadataObject{
-					CommonMeta: resource.CommonMetadata{
-						ExtraFields: map[string]any{
-							"generation": int64(2),
-						},
-					},
+			retryObject: &resource.TypedSpecObject[string]{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
 				},
 			},
 			retryError: nil,
@@ -1154,4 +1139,4 @@ func (ti *testInformer) FireDelete(ctx context.Context, object resource.Object) 
 	}
 }
 
-var emptyObject = &resource.SimpleObject[string]{}
+var emptyObject = &resource.TypedSpecObject[string]{}

--- a/operator/simplewatcher_test.go
+++ b/operator/simplewatcher_test.go
@@ -13,7 +13,7 @@ import (
 func TestFakeWatcher_Add(t *testing.T) {
 	w := SimpleWatcher{}
 	c := context.TODO()
-	obj := &resource.SimpleObject[string]{
+	obj := &resource.TypedSpecObject[string]{
 		Spec: "foo",
 	}
 
@@ -47,10 +47,10 @@ func TestFakeWatcher_Add(t *testing.T) {
 func TestFakeWatcher_Update(t *testing.T) {
 	w := SimpleWatcher{}
 	c := context.TODO()
-	old := &resource.SimpleObject[string]{
+	old := &resource.TypedSpecObject[string]{
 		Spec: "foo",
 	}
-	new := &resource.SimpleObject[string]{
+	new := &resource.TypedSpecObject[string]{
 		Spec: "bar",
 	}
 
@@ -86,7 +86,7 @@ func TestFakeWatcher_Update(t *testing.T) {
 func TestFakeWatcher_Delete(t *testing.T) {
 	w := SimpleWatcher{}
 	c := context.TODO()
-	obj := &resource.SimpleObject[string]{
+	obj := &resource.TypedSpecObject[string]{
 		Spec: "foo",
 	}
 

--- a/plugin/router/resourcegroup_router.go
+++ b/plugin/router/resourcegroup_router.go
@@ -22,7 +22,7 @@ type Store interface {
 // ResourceGroupRouter is a Router which exposes generic CRUD routes for every resource contained in a given group.
 type ResourceGroupRouter struct {
 	*JSONRouter
-	resourceGroup resource.SchemaGroup
+	resourceGroup resource.KindCollection
 	namespace     string
 	store         Store
 }
@@ -30,7 +30,7 @@ type ResourceGroupRouter struct {
 // NewResourceGroupRouter returns a new ResourceGroupRouter,
 // exposing CRUD routes to manipulate resources in given group.
 func NewResourceGroupRouter(
-	resourceGroup resource.SchemaGroup,
+	resourceGroup resource.KindCollection,
 	namespace string,
 	clientGenerator resource.ClientGenerator,
 ) (*ResourceGroupRouter, error) {
@@ -41,7 +41,7 @@ func NewResourceGroupRouter(
 
 // NewResourceGroupRouterWithStore returns a new ResourceGroupRouter with pre-configured Store.
 func NewResourceGroupRouterWithStore(
-	resourceGroup resource.SchemaGroup,
+	resourceGroup resource.KindCollection,
 	namespace string,
 	store Store,
 ) (*ResourceGroupRouter, error) {
@@ -52,7 +52,7 @@ func NewResourceGroupRouterWithStore(
 		namespace:     namespace,
 	}
 
-	for _, schema := range router.resourceGroup.Schemas() {
+	for _, schema := range router.resourceGroup.Kinds() {
 		// TODO: all possible versions for each kind should be handled, address this with SchemaGroup in codegen?
 		baseRoute := fmt.Sprintf(
 			"%s/%s/%s",
@@ -90,7 +90,7 @@ func (router *ResourceGroupRouter) createResource(cr resource.Schema) JSONHandle
 		}
 		// The only bit of static metadata the user can specify here is the name
 		toBeInserted.SetStaticMetadata(resource.StaticMetadata{
-			Name:      toBeInserted.StaticMetadata().Name,
+			Name:      toBeInserted.GetName(),
 			Namespace: router.namespace,
 			Group:     cr.Group(),
 			Version:   cr.Version(),
@@ -148,7 +148,7 @@ func (router *ResourceGroupRouter) updateResource(cr resource.Schema) JSONHandle
 		}
 		// The only bit of static metadata the user can specify here is the name
 		updatedResource.SetStaticMetadata(resource.StaticMetadata{
-			Name:      updatedResource.StaticMetadata().Name,
+			Name:      updatedResource.GetName(),
 			Namespace: router.namespace,
 			Group:     cr.Group(),
 			Version:   cr.Version(),

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -40,10 +40,10 @@ type WebhookConfig struct {
 	DefaultMutator resource.MutatingAdmissionController
 	// Validators is an optional map of schema => ValidatingAdmissionController to use for the schema on admission.
 	// This can be empty or nil and specific ValidatingAdmissionControllers can be set later with Operator.ValidateKind
-	Validators map[resource.Schema]resource.ValidatingAdmissionController
+	Validators map[*resource.Kind]resource.ValidatingAdmissionController
 	// Mutators is an optional map of schema => MutatingAdmissionController to use for the schema on admission.
 	// This can be empty or nil and specific MutatingAdmissionControllers can be set later with Operator.MutateKind
-	Mutators map[resource.Schema]resource.MutatingAdmissionController
+	Mutators map[*resource.Kind]resource.MutatingAdmissionController
 	// Converters is an optional map of GroupKind => Converter to use for CRD version conversion requests.
 	// This can be empty or nil and specific MutatingAdmissionControllers can be set later with Operator.MutateKind
 	Converters map[metav1.GroupKind]k8s.Converter
@@ -179,25 +179,25 @@ func (o *Operator) RegisterMetricsCollectors(collectors ...prometheus.Collector)
 
 // WatchKind will watch the specified kind (schema) with opinionated logic, passing the relevant events on to the SyncWatcher.
 // You can configure the query used for watching the kind using ListWatchOptions.
-func (o *Operator) WatchKind(schema resource.Schema, watcher SyncWatcher, options ListWatchOptions) error {
-	client, err := o.clientGen.ClientFor(schema)
+func (o *Operator) WatchKind(kind resource.Kind, watcher SyncWatcher, options ListWatchOptions) error {
+	client, err := o.clientGen.ClientFor(kind)
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformerWithFilters(schema, client, options.Namespace, options.LabelFilters)
+	inf, err := operator.NewKubernetesBasedInformerWithFilters(kind, client, options.Namespace, options.LabelFilters)
 	if err != nil {
 		return err
 	}
-	kindStr := o.label(schema, options)
+	kindStr := o.label(kind, options)
 	err = o.controller.AddInformer(inf, kindStr)
 	if err != nil {
 		return err
 	}
-	ow, err := operator.NewOpinionatedWatcherWithFinalizer(schema, client, func(sch resource.Schema) string {
+	ow, err := operator.NewOpinionatedWatcherWithFinalizer(kind, client, func(sch resource.Schema) string {
 		if o.Name != "" {
-			return fmt.Sprintf("%s-%s-finalizer", o.Name, schema.Plural())
+			return fmt.Sprintf("%s-%s-finalizer", o.Name, kind.Plural())
 		}
-		return fmt.Sprintf("%s-finalizer", schema.Plural())
+		return fmt.Sprintf("%s-finalizer", kind.Plural())
 	})
 	if err != nil {
 		return err
@@ -209,23 +209,23 @@ func (o *Operator) WatchKind(schema resource.Schema, watcher SyncWatcher, option
 
 // ReconcileKind will watch the specified kind (schema) with opinionated logic, passing the events on to the provided Reconciler.
 // You can configure the query used for watching the kind using ListWatchOptions.
-func (o *Operator) ReconcileKind(schema resource.Schema, reconciler operator.Reconciler, options ListWatchOptions) error {
-	client, err := o.clientGen.ClientFor(schema)
+func (o *Operator) ReconcileKind(kind resource.Kind, reconciler operator.Reconciler, options ListWatchOptions) error {
+	client, err := o.clientGen.ClientFor(kind)
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformerWithFilters(schema, client, options.Namespace, options.LabelFilters)
+	inf, err := operator.NewKubernetesBasedInformerWithFilters(kind, client, options.Namespace, options.LabelFilters)
 	if err != nil {
 		return err
 	}
-	kindStr := o.label(schema, options)
+	kindStr := o.label(kind, options)
 	err = o.controller.AddInformer(inf, kindStr)
 	if err != nil {
 		return err
 	}
-	finalizer := fmt.Sprintf("%s-finalizer", schema.Plural())
+	finalizer := fmt.Sprintf("%s-finalizer", kind.Plural())
 	if o.Name != "" {
-		finalizer = fmt.Sprintf("%s-%s-finalizer", o.Name, schema.Plural())
+		finalizer = fmt.Sprintf("%s-%s-finalizer", o.Name, kind.Plural())
 	}
 	or, err := operator.NewOpinionatedReconciler(client, finalizer)
 	or.Reconciler = reconciler
@@ -237,21 +237,21 @@ func (o *Operator) ReconcileKind(schema resource.Schema, reconciler operator.Rec
 
 // ValidateKind provides a validation path for the provided kind (schema) in the validating webhook,
 // using the provided ValidatingAdmissionController for the validation logic.
-func (o *Operator) ValidateKind(schema resource.Schema, controller resource.ValidatingAdmissionController) error {
+func (o *Operator) ValidateKind(kind resource.Kind, controller resource.ValidatingAdmissionController) error {
 	if o.admission == nil {
 		return fmt.Errorf("webhooks are not enabled")
 	}
-	o.admission.AddValidatingAdmissionController(controller, schema)
+	o.admission.AddValidatingAdmissionController(controller, kind)
 	return nil
 }
 
 // MutateKind provides a mutation path for the provided kind (schema) in the mutating webhook,
 // using the provided MutatingAdmissionController for the mutation logic.
-func (o *Operator) MutateKind(schema resource.Schema, controller resource.MutatingAdmissionController) error {
+func (o *Operator) MutateKind(kind resource.Kind, controller resource.MutatingAdmissionController) error {
 	if o.admission == nil {
 		return fmt.Errorf("webhooks are not enabled")
 	}
-	o.admission.AddMutatingAdmissionController(controller, schema)
+	o.admission.AddMutatingAdmissionController(controller, kind)
 	return nil
 }
 


### PR DESCRIPTION
Implement the changes to the `resource` package in all other packages. This PR does _not_ include updates to codegen, this will be a subsequent PR.

A final PR will be made after codegen changes with any fixes that come up in more extensive local kubernetes testing.