### PR TITLE
Fix generated files' permissions

### DIFF
--- a/cmd/grafana-app-sdk/util.go
+++ b/cmd/grafana-app-sdk/util.go
@@ -36,7 +36,7 @@ func writeFile(path string, contents []byte) error {
 		}
 	}
 	fmt.Printf(" * Writing file %s\n", path)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0655)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func writeExecutableFile(path string, contents []byte) error {
 		}
 	}
 	fmt.Printf(" * Writing file %s\n", path)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When using `grafana-app-sdk project init` files are being created with the executable bit set in cases where it's not needed (e.g. some code, makefiles, etc). Given how there are two different functions, `writeFile` and `writeExecutableFile`, it's clear that this was not the intention.

Modify `writeFile` so that it creates files with the read/write bits set, but not the executuable one.

Modify both `writeFile` and `writeExecutableFile` so that the process' umask is respected (i.e. pass 0666 instead of 0644).