### PR TITLE
Fix calls to local scripts

### DIFF
--- a/cmd/grafana-app-sdk/templates/Makefile.tmpl
+++ b/cmd/grafana-app-sdk/templates/Makefile.tmpl
@@ -62,7 +62,7 @@ generate:
 
 .PHONY: local/up
 local/up: local/generate
-	@sh local/scripts/cluster.sh create "local/generated/k3d-config.json"
+	@local/scripts/cluster.sh create "local/generated/k3d-config.json"
 	@cd local && tilt up
 
 .PHONY: local/generate
@@ -83,11 +83,11 @@ local/deploy_plugin:
 local/push_operator:
 	# Tag the docker image as part of localhost, which is what the generated k8s uses to avoid confusion with the real operator image
 	@docker tag "$(OPERATOR_DOCKERIMAGE):latest" "localhost/$(OPERATOR_DOCKERIMAGE):latest"
-	@sh local/scripts/push_image.sh "localhost/$(OPERATOR_DOCKERIMAGE):latest"
+	@local/scripts/push_image.sh "localhost/$(OPERATOR_DOCKERIMAGE):latest"
 
 .PHONY: local/clean
 local/clean: local/down
-	@sh local/scripts/cluster.sh delete
+	@local/scripts/cluster.sh delete
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The scripts correctly declare that they expect bash (by using `#!/usr/bin/env bash`), but the generated makefile is calling these scripts as `sh local/scripts/...`, which basically discards the shebang and assumes that `sh` is `bash`.

Remove `sh` from the Makefile to fix this.