### PR TITLE
[kind-object-refactor] Codegen Object using Kind Name

### DIFF
--- a/codegen/templates/operator/watcher.tmpl
+++ b/codegen/templates/operator/watcher.tmpl
@@ -21,13 +21,13 @@ func New{{.Kind}}Watcher() (*{{.Kind}}Watcher, error) {
 	return &{{.Kind}}Watcher{}, nil
 }
 
-// Add handles add events for {{.MachineName}}.Object resources.
+// Add handles add events for {{.MachineName}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Add(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-add")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.Object)
+    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.Object (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 
@@ -36,19 +36,19 @@ func (s *{{.Kind}}Watcher) Add(ctx context.Context, rObj resource.Object) error 
 	return nil
 }
 
-// Update handles update events for {{.MachineName}}.Object resources.
+// Update handles update events for {{.MachineName}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Update(ctx context.Context, rOld resource.Object, rNew resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-update")
 	defer span.End()
-    oldObject, ok := rOld.(*{{.MachineName}}.Object)
+    oldObject, ok := rOld.(*{{.MachineName}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.Object (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rOld.GetStaticMetadata().Name, rOld.GetStaticMetadata().Namespace, rOld.GetStaticMetadata().Kind)
     }
 
-    _, ok = rNew.(*{{.MachineName}}.Object)
+    _, ok = rNew.(*{{.MachineName}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.Object (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rNew.GetStaticMetadata().Name, rNew.GetStaticMetadata().Namespace, rNew.GetStaticMetadata().Kind)
     }
 
@@ -57,13 +57,13 @@ func (s *{{.Kind}}Watcher) Update(ctx context.Context, rOld resource.Object, rNe
 	return nil
 }
 
-// Delete handles delete events for {{.MachineName}}.Object resources.
+// Delete handles delete events for {{.MachineName}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Delete(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-delete")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.Object)
+    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.Object (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 
@@ -77,9 +77,9 @@ func (s *{{.Kind}}Watcher) Delete(ctx context.Context, rObj resource.Object) err
 func (s *{{.Kind}}Watcher) Sync(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-sync")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.Object)
+    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.Object (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 

--- a/codegen/templates/plugin/handler_resource.tmpl
+++ b/codegen/templates/plugin/handler_resource.tmpl
@@ -17,10 +17,10 @@ import (
 )
 
 type {{.Kind}}Service interface {
-	List(ctx context.Context, namespace string, filters ...string) (*resource.TypedList[*{{.MachineName}}.Object], error)
-	Get(ctx context.Context, id resource.Identifier) (*{{.MachineName}}.Object, error)
-	Add(ctx context.Context, obj *{{.MachineName}}.Object) (*{{.MachineName}}.Object, error)
-	Update(ctx context.Context, id resource.Identifier, obj *{{.MachineName}}.Object) (*{{.MachineName}}.Object, error)
+	List(ctx context.Context, namespace string, filters ...string) (*resource.TypedList[*{{.MachineName}}.{{.Kind}}], error)
+	Get(ctx context.Context, id resource.Identifier) (*{{.MachineName}}.{{.Kind}}, error)
+	Add(ctx context.Context, obj *{{.MachineName}}.{{.Kind}}) (*{{.MachineName}}.{{.Kind}}, error)
+	Update(ctx context.Context, id resource.Identifier, obj *{{.MachineName}}.{{.Kind}}) (*{{.MachineName}}.{{.Kind}}, error)
 	Delete(ctx context.Context, id resource.Identifier) error
 }
 
@@ -70,7 +70,7 @@ func (p *Plugin) handle{{.Kind}}Create(ctx context.Context, req router.JSONReque
 		return nil, plugin.NewError(http.StatusBadRequest, err.Error())
 	}
 
-	t := {{.MachineName}}.Object{}
+	t := {{.MachineName}}.{{.Kind}}{}
 	// TODO: this should eventually be unmarshalled via a method in the Object itself, so Thema can handle it
 	err = json.Unmarshal(body, &t)
 	if err != nil {
@@ -102,7 +102,7 @@ func (p *Plugin) handle{{.Kind}}Update(ctx context.Context, req router.JSONReque
 		return nil, plugin.NewError(http.StatusBadRequest, err.Error())
 	}
 
-	t := {{.MachineName}}.Object{}
+	t := {{.MachineName}}.{{.Kind}}{}
 	// TODO: this should eventually be unmarshalled via a method in the Object itself, so Thema can handle it
 	err = json.Unmarshal(body, &t)
 	if err != nil {

--- a/codegen/templates/plugin/main.tmpl
+++ b/codegen/templates/plugin/main.tmpl
@@ -96,7 +96,7 @@ func newInstanceFactory(logger logging.Logger) app.InstanceFactoryFunc {
         svc := PluginService{}
 
 		// Create stores for each Kind{{ range .Resources }}
-        {{ .MachineName }}Store, err := resource.NewTypedStore[*{{ .MachineName }}.Object]({{ .MachineName }}.Kind(), clientGenerator)
+        {{ .MachineName }}Store, err := resource.NewTypedStore[*{{ .MachineName }}.{{ .Kind }}]({{ .MachineName }}.Kind(), clientGenerator)
         if err != nil {
             logger.Error("failed to create {{ .Kind }} store", "err", err)
             return nil, fmt.Errorf("failed to create {{ .Kind }} store: %w", err)

--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -14,7 +14,8 @@ import ({{ range .CustomMetadataFields }}{{ range $imp := .GoType.AdditionalImpo
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type {{.ObjectTypeName}} struct {
+// +k8s:openapi-gen=true
+type {{.TypeName}} struct {
     metav1.TypeMeta `json:",inline"`
     metav1.ObjectMeta `json:"metadata"`
     Spec       {{.SpecTypeName}} `json:"spec"`{{ range .Subresources }}{{ if ne .Comment "" }}
@@ -22,12 +23,12 @@ type {{.ObjectTypeName}} struct {
         {{ .TypeName }} {{.TypeName}} `json:"{{.JSONName}}"`{{ end }}
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetSpec() any {
+func ({{.ObjectShortName}} *{{.TypeName}}) GetSpec() any {
     return {{.ObjectShortName}}.Spec
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetSpec(spec any) error {
-    cast, ok := spec.(Spec)
+func ({{.ObjectShortName}} *{{.TypeName}}) SetSpec(spec any) error {
+    cast, ok := spec.({{.SpecTypeName}})
     if !ok {
         return fmt.Errorf("cannot set spec type %#v, not of type Spec", spec)
     }
@@ -35,13 +36,13 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetSpec(spec any) error {
     return nil
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetSubresources() map[string]any {
+func ({{.ObjectShortName}} *{{.TypeName}}) GetSubresources() map[string]any {
     return map[string]any{ {{ range .Subresources }}
         "{{.JSONName}}": {{$root.ObjectShortName}}.{{.TypeName}},
     {{ end }} }
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetSubresource(name string) (any,bool) {
+func ({{.ObjectShortName}} *{{.TypeName}}) GetSubresource(name string) (any,bool) {
     switch name { {{ range .Subresources }}
     case"{{ .JSONName }}":
         return {{$root.ObjectShortName}}.{{.TypeName}}, true
@@ -50,7 +51,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetSubresource(name string) (an
     }
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetSubresource(name string, value any) error {
+func ({{.ObjectShortName}} *{{.TypeName}}) SetSubresource(name string, value any) error {
     switch name { {{ range .Subresources }}
     case"{{ .JSONName }}":
         cast, ok := value.({{.TypeName}})
@@ -64,7 +65,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetSubresource(name string, val
     }
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetStaticMetadata() resource.StaticMetadata {
+func ({{.ObjectShortName}} *{{.TypeName}}) GetStaticMetadata() resource.StaticMetadata {
     return resource.StaticMetadata{
         Name:      {{.ObjectShortName}}.ObjectMeta.Name,
     	Namespace: {{.ObjectShortName}}.ObjectMeta.Namespace,
@@ -74,7 +75,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetStaticMetadata() resource.St
     }
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetStaticMetadata(metadata resource.StaticMetadata) {
+func ({{.ObjectShortName}} *{{.TypeName}}) SetStaticMetadata(metadata resource.StaticMetadata) {
     {{.ObjectShortName}}.Name = metadata.Name
     {{.ObjectShortName}}.Namespace = metadata.Namespace
     {{.ObjectShortName}}.SetGroupVersionKind(schema.GroupVersionKind{
@@ -84,7 +85,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetStaticMetadata(metadata reso
     })
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetCommonMetadata() resource.CommonMetadata {
+func ({{.ObjectShortName}} *{{.TypeName}}) GetCommonMetadata() resource.CommonMetadata {
     dt := {{.ObjectShortName}}.DeletionTimestamp
 	var deletionTimestamp *time.Time
 	if dt != nil {
@@ -116,7 +117,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) GetCommonMetadata() resource.Co
 	}
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetCommonMetadata(metadata resource.CommonMetadata) {
+func ({{.ObjectShortName}} *{{.TypeName}}) SetCommonMetadata(metadata resource.CommonMetadata) {
     {{.ObjectShortName}}.UID = types.UID(metadata.UID)
     {{.ObjectShortName}}.ResourceVersion = metadata.ResourceVersion
     {{.ObjectShortName}}.Generation = metadata.Generation
@@ -161,7 +162,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetCommonMetadata(metadata reso
     }
 }
 
-{{range .CustomMetadataFields}}func ({{$root.ObjectShortName}} *{{$root.ObjectTypeName}}) Get{{.FieldName}}() {{.GoType.GoType}} {
+{{range .CustomMetadataFields}}func ({{$root.ObjectShortName}} *{{$root.TypeName}}) Get{{.FieldName}}() {{.GoType.GoType}} {
     if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
         {{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
     }
@@ -170,7 +171,7 @@ func ({{.ObjectShortName}} *{{.ObjectTypeName}}) SetCommonMetadata(metadata reso
     {{ $ret }}
 }
 
-func ({{$root.ObjectShortName}} *{{$root.ObjectTypeName}}) Set{{.FieldName}}({{.JSONName}} {{.GoType.GoType}}) {
+func ({{$root.ObjectShortName}} *{{$root.TypeName}}) Set{{.FieldName}}({{.JSONName}} {{.GoType.GoType}}) {
     if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
         {{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
     }
@@ -181,13 +182,56 @@ func ({{$root.ObjectShortName}} *{{$root.ObjectTypeName}}) Set{{.FieldName}}({{.
 
 {{end}}
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) Copy() resource.Object {
+func ({{.ObjectShortName}} *{{.TypeName}}) Copy() resource.Object {
     return resource.CopyObject({{.ObjectShortName}})
 }
 
-func ({{.ObjectShortName}} *{{.ObjectTypeName}}) DeepCopyObject() runtime.Object {
+func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopyObject() runtime.Object {
     return {{.ObjectShortName}}.Copy()
 }
 
 // Interface compliance compile-time check
-var _ resource.Object = &Object{}
+var _ resource.Object = &{{.TypeName}}{}
+
+// +k8s:openapi-gen=true
+type {{.TypeName}}List struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []{{.TypeName}} `json:"items"`
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopyObject() runtime.Object {
+	return {{.ObjectShortName}}.Copy()
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}List) Copy() resource.ListObject {
+	cpy := &{{.TypeName}}List{
+		TypeMeta: {{.ObjectShortName}}.TypeMeta,
+		Items:    make([]{{.TypeName}}, len({{.ObjectShortName}}.Items)),
+	}
+	{{.ObjectShortName}}.ListMeta.DeepCopyInto(&cpy.ListMeta)
+	for i := 0; i < len({{.ObjectShortName}}.Items); i++ {
+        if item, ok := o.Items[i].Copy().(*{{.TypeName}}); ok {
+			cpy.Items[i] = *item
+		}
+	}
+	return cpy
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}List) GetItems() []resource.Object {
+	items := make([]resource.Object, len(o.Items))
+	for i := 0; i < len(o.Items); i++ {
+		items[i] = &o.Items[i]
+	}
+	return items
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}List) SetItems(items []resource.Object) {
+    o.Items = make([]{{.TypeName}}, len(items))
+	for i := 0; i < len(items); i++ {
+		o.Items[i] = *items[i].(*{{.TypeName}})
+	}
+}
+
+// Interface compliance compile-time check
+var _ resource.ListObject = &{{.TypeName}}List{}

--- a/codegen/templates/schema.tmpl
+++ b/codegen/templates/schema.tmpl
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-    kindSchema = resource.NewSimpleSchema("{{.Group}}", "{{.Version}}", &Object{}, resource.WithKind("{{.Kind}}"),
+    kindSchema = resource.NewSimpleSchema("{{.Group}}", "{{.Version}}", &{{.Kind}}{}, resource.WithKind("{{.Kind}}"),
         resource.WithPlural("{{.Plural}}"), resource.WithScope(resource.{{.Scope}}Scope))
     kind = resource.Kind{
         Schema: kindSchema,

--- a/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
@@ -14,18 +14,19 @@ import (
 	"time"
 )
 
-type Object struct {
+// +k8s:openapi-gen=true
+type CustomKind struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 	Spec              Spec   `json:"spec"`
 	Status            Status `json:"status"`
 }
 
-func (o *Object) GetSpec() any {
+func (o *CustomKind) GetSpec() any {
 	return o.Spec
 }
 
-func (o *Object) SetSpec(spec any) error {
+func (o *CustomKind) SetSpec(spec any) error {
 	cast, ok := spec.(Spec)
 	if !ok {
 		return fmt.Errorf("cannot set spec type %#v, not of type Spec", spec)
@@ -34,13 +35,13 @@ func (o *Object) SetSpec(spec any) error {
 	return nil
 }
 
-func (o *Object) GetSubresources() map[string]any {
+func (o *CustomKind) GetSubresources() map[string]any {
 	return map[string]any{
 		"status": o.Status,
 	}
 }
 
-func (o *Object) GetSubresource(name string) (any, bool) {
+func (o *CustomKind) GetSubresource(name string) (any, bool) {
 	switch name {
 	case "status":
 		return o.Status, true
@@ -49,7 +50,7 @@ func (o *Object) GetSubresource(name string) (any, bool) {
 	}
 }
 
-func (o *Object) SetSubresource(name string, value any) error {
+func (o *CustomKind) SetSubresource(name string, value any) error {
 	switch name {
 	case "status":
 		cast, ok := value.(Status)
@@ -63,7 +64,7 @@ func (o *Object) SetSubresource(name string, value any) error {
 	}
 }
 
-func (o *Object) GetStaticMetadata() resource.StaticMetadata {
+func (o *CustomKind) GetStaticMetadata() resource.StaticMetadata {
 	return resource.StaticMetadata{
 		Name:      o.ObjectMeta.Name,
 		Namespace: o.ObjectMeta.Namespace,
@@ -73,7 +74,7 @@ func (o *Object) GetStaticMetadata() resource.StaticMetadata {
 	}
 }
 
-func (o *Object) SetStaticMetadata(metadata resource.StaticMetadata) {
+func (o *CustomKind) SetStaticMetadata(metadata resource.StaticMetadata) {
 	o.Name = metadata.Name
 	o.Namespace = metadata.Namespace
 	o.SetGroupVersionKind(schema.GroupVersionKind{
@@ -83,7 +84,7 @@ func (o *Object) SetStaticMetadata(metadata resource.StaticMetadata) {
 	})
 }
 
-func (o *Object) GetCommonMetadata() resource.CommonMetadata {
+func (o *CustomKind) GetCommonMetadata() resource.CommonMetadata {
 	dt := o.DeletionTimestamp
 	var deletionTimestamp *time.Time
 	if dt != nil {
@@ -115,7 +116,7 @@ func (o *Object) GetCommonMetadata() resource.CommonMetadata {
 	}
 }
 
-func (o *Object) SetCommonMetadata(metadata resource.CommonMetadata) {
+func (o *CustomKind) SetCommonMetadata(metadata resource.CommonMetadata) {
 	o.UID = types.UID(metadata.UID)
 	o.ResourceVersion = metadata.ResourceVersion
 	o.Generation = metadata.Generation
@@ -160,7 +161,7 @@ func (o *Object) SetCommonMetadata(metadata resource.CommonMetadata) {
 	}
 }
 
-func (o *Object) GetCreatedBy() string {
+func (o *CustomKind) GetCreatedBy() string {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -168,7 +169,7 @@ func (o *Object) GetCreatedBy() string {
 	return o.ObjectMeta.Annotations["grafana.com/createdBy"]
 }
 
-func (o *Object) SetCreatedBy(createdBy string) {
+func (o *CustomKind) SetCreatedBy(createdBy string) {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -176,7 +177,7 @@ func (o *Object) SetCreatedBy(createdBy string) {
 	o.ObjectMeta.Annotations["grafana.com/createdBy"] = createdBy
 }
 
-func (o *Object) GetCustomMetadataField() string {
+func (o *CustomKind) GetCustomMetadataField() string {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -184,7 +185,7 @@ func (o *Object) GetCustomMetadataField() string {
 	return o.ObjectMeta.Annotations["grafana.com/customMetadataField"]
 }
 
-func (o *Object) SetCustomMetadataField(customMetadataField string) {
+func (o *CustomKind) SetCustomMetadataField(customMetadataField string) {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -192,7 +193,7 @@ func (o *Object) SetCustomMetadataField(customMetadataField string) {
 	o.ObjectMeta.Annotations["grafana.com/customMetadataField"] = customMetadataField
 }
 
-func (o *Object) GetOtherMetadataField() string {
+func (o *CustomKind) GetOtherMetadataField() string {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -200,7 +201,7 @@ func (o *Object) GetOtherMetadataField() string {
 	return o.ObjectMeta.Annotations["grafana.com/otherMetadataField"]
 }
 
-func (o *Object) SetOtherMetadataField(otherMetadataField string) {
+func (o *CustomKind) SetOtherMetadataField(otherMetadataField string) {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -208,7 +209,7 @@ func (o *Object) SetOtherMetadataField(otherMetadataField string) {
 	o.ObjectMeta.Annotations["grafana.com/otherMetadataField"] = otherMetadataField
 }
 
-func (o *Object) GetUpdateTimestamp() time.Time {
+func (o *CustomKind) GetUpdateTimestamp() time.Time {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -217,7 +218,7 @@ func (o *Object) GetUpdateTimestamp() time.Time {
 	return parsed
 }
 
-func (o *Object) SetUpdateTimestamp(updateTimestamp time.Time) {
+func (o *CustomKind) SetUpdateTimestamp(updateTimestamp time.Time) {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -225,7 +226,7 @@ func (o *Object) SetUpdateTimestamp(updateTimestamp time.Time) {
 	o.ObjectMeta.Annotations["grafana.com/updateTimestamp"] = updateTimestamp.Format(time.RFC3339)
 }
 
-func (o *Object) GetUpdatedBy() string {
+func (o *CustomKind) GetUpdatedBy() string {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -233,7 +234,7 @@ func (o *Object) GetUpdatedBy() string {
 	return o.ObjectMeta.Annotations["grafana.com/updatedBy"]
 }
 
-func (o *Object) SetUpdatedBy(updatedBy string) {
+func (o *CustomKind) SetUpdatedBy(updatedBy string) {
 	if o.ObjectMeta.Annotations == nil {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
@@ -241,13 +242,56 @@ func (o *Object) SetUpdatedBy(updatedBy string) {
 	o.ObjectMeta.Annotations["grafana.com/updatedBy"] = updatedBy
 }
 
-func (o *Object) Copy() resource.Object {
+func (o *CustomKind) Copy() resource.Object {
 	return resource.CopyObject(o)
 }
 
-func (o *Object) DeepCopyObject() runtime.Object {
+func (o *CustomKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
 // Interface compliance compile-time check
-var _ resource.Object = &Object{}
+var _ resource.Object = &CustomKind{}
+
+// +k8s:openapi-gen=true
+type CustomKindList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []CustomKind `json:"items"`
+}
+
+func (o *CustomKindList) DeepCopyObject() runtime.Object {
+	return o.Copy()
+}
+
+func (o *CustomKindList) Copy() resource.ListObject {
+	cpy := &CustomKindList{
+		TypeMeta: o.TypeMeta,
+		Items:    make([]CustomKind, len(o.Items)),
+	}
+	o.ListMeta.DeepCopyInto(&cpy.ListMeta)
+	for i := 0; i < len(o.Items); i++ {
+		if item, ok := o.Items[i].Copy().(*CustomKind); ok {
+			cpy.Items[i] = *item
+		}
+	}
+	return cpy
+}
+
+func (o *CustomKindList) GetItems() []resource.Object {
+	items := make([]resource.Object, len(o.Items))
+	for i := 0; i < len(o.Items); i++ {
+		items[i] = &o.Items[i]
+	}
+	return items
+}
+
+func (o *CustomKindList) SetItems(items []resource.Object) {
+	o.Items = make([]CustomKind, len(items))
+	for i := 0; i < len(items); i++ {
+		o.Items[i] = *items[i].(*CustomKind)
+	}
+}
+
+// Interface compliance compile-time check
+var _ resource.ListObject = &CustomKindList{}

--- a/codegen/testing/golden_generated/customkind/customkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	kindSchema = resource.NewSimpleSchema("custom.ext.grafana.com", "v0-0", &Object{}, resource.WithKind("CustomKind"),
+	kindSchema = resource.NewSimpleSchema("custom.ext.grafana.com", "v0-0", &CustomKind{}, resource.WithKind("CustomKind"),
 		resource.WithPlural("customkinds"), resource.WithScope(resource.NamespacedScope))
 	kind = resource.Kind{
 		Schema: kindSchema,

--- a/codegen/testing/golden_generated/customkind/customkind_thema_codec_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_thema_codec_gen.go.txt
@@ -18,9 +18,9 @@ type JSONCodec struct{}
 
 // Read reads JSON-encoded bytes from `reader` and unmarshals them into `into`
 func (*JSONCodec) Read(reader io.Reader, into resource.Object) error {
-	cast, ok := into.(*Object)
+	cast, ok := into.(*CustomKind)
 	if !ok {
-		return fmt.Errorf("can only read into type *customkind.Object")
+		return fmt.Errorf("can only read into type *customkind.CustomKind")
 	}
 
 	temp := &resource.TypedSpecStatusObject[json.RawMessage, json.RawMessage]{}

--- a/codegen/thema/jennies/codec.go
+++ b/codegen/thema/jennies/codec.go
@@ -129,7 +129,7 @@ func (*CodecGenerator) generateObjectFile(kind codegen.Kind, version *codegen.Ki
 		Package:              pkg,
 		TypeName:             meta.Kind,
 		SpecTypeName:         "Spec",
-		ObjectTypeName:       "Object", // Package is the machine name of the object, so this makes it machinename.Object
+		ObjectTypeName:       meta.Kind,
 		ObjectShortName:      "o",
 		Subresources:         make([]templates.SubresourceMetadata, 0),
 		CustomMetadataFields: customMetadataFields,


### PR DESCRIPTION
Update generated resource.Object-implementation code to use the Kind as the type name, rather than Object. This is a breaking change we're rolling into this branch's release as it will be required for the apiserver work.