### PR TITLE
[docs] Add Migration Notes Section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This directory is a collection of documentation about the SDK library, CLI, and concepts.
 
+If you are looking for documentation for migrating your code when you upgrade SDK versions, see [migrations](./migrations/README.md).
+
 The easiest way to get a handle on the SDK is to run through the [sample project: issue tracker tutorial](./tutorials/issue-tracker/README.md). 
 Docs in this directory will help further your understanding of the concepts touched on in the tutorial.
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,12 @@
+# Migrations
+
+As the grafana-app-sdk is still both pre-1.0 and _experimental_, breaking changes may be introduced on minor version upgrades. 
+This directory contains notes on the breaking changes (which are also typically in release notes on the first patch version 
+of the minor version bump, for example, see [the v0.15.0 release notes](https://github.com/grafana/grafana-app-sdk/releases/tag/v0.15.0)), 
+and instructions on what to do to migrate your project to the new version. Scripts may be included for more complex upgrades, if and when they occur. 
+
+Minor version upgrades without a migration doc have no breaking changes or changes which are wholly handled by the `grafana-app-sdk generate` command.
+
+## Index
+
+* [v0.14.x → v0.15.x](v0.15.md)

--- a/docs/migrations/v0.15.md
+++ b/docs/migrations/v0.15.md
@@ -2,7 +2,9 @@
 
 [Release notes](https://github.com/grafana/grafana-app-sdk/releases/tag/v0.15.0)
 
-## What Changed
+*Upgrading from*: v0.14.x
+
+## What Changed from 0.14
 
 This version contains major upgrades to how kinds are structured, mostly centered around the `resource.Object` interface and introduction of 
 `resource.Kind`. Marshal and Unmarshal logic was removed from `resource.Object` and moved into wire-encoding specific `resource.Codec` implementations 

--- a/docs/migrations/v0.15.md
+++ b/docs/migrations/v0.15.md
@@ -1,0 +1,28 @@
+# v0.15
+
+[Release notes](https://github.com/grafana/grafana-app-sdk/releases/tag/v0.15.0)
+
+## What Changed
+
+This version contains major upgrades to how kinds are structured, mostly centered around the `resource.Object` interface and introduction of 
+`resource.Kind`. Marshal and Unmarshal logic was removed from `resource.Object` and moved into wire-encoding specific `resource.Codec` implementations 
+contained in the newly-introduced `resource.Kind` (which also implements and embeds `resource.Schema`). `resource.Object` was further updated 
+to explicitly implement kubernetes interfaces `runtime.Object`, `meta/v1.Object`, and `schema.ObjectKind`, making it fully compatible with all 
+kubernetes go libraries. `resource.List` was also similarly updated.
+
+Pre-built generic and typed implementations of `resource.Object` were replaced with `resource.UntypedObject`, `resource.TypedObject`, `resource.TypedSpecObject`, and `resource.TypedSpecStatusObject`. The various stores have been updated to work with these objects where appropriate.
+
+Other packages, such as `operator` and `simple` have minor changes to work with `resource.Kind` instead of `resource.Schema` where codec information is required.
+
+## Migration Steps
+
+Most of the migration is handled by the codegen, as the bulk of the changes are to the `resource.Object` interface and introduction of `resource.Kind`. Go through the following steps to ensure your project will build and run with `v0.15`:
+
+1. Download, install, or build the v0.15.x version of the grafana-app-sdk CLI
+2. Run `grafana-app-sdk generate` (with any appropriate flags for your project) to generate new kinds
+3. Run `go get github.com/grafana/grafana-app-sdk@v0.15.0` (or later patch versions) to update the version you use in your project
+4. Any place in your code that uses `<kindversionpackage>.Object`, replace it with `<kindversionpackage>.<kind name>`
+5. Any place in your code that uses `<kindversionpackage>.Schema()`, update to use `<kindversionpackage>.Kind()`. Some places will not require this change, but `resource.Kind` (produced by `Kind()`) implements `resource.Schema` (produced by `Schema()`), so this will still work for functions that consume `resource.Schema`.
+6. Any place that uses `resource.SimpleObject[T]`, replace it with `resource.TypedSpecObject[T]`
+7. Any place that uses `resource.SimpleList[T]`, replace it with `resource.TypedList[T]`
+8. Any places that uses `resource.SimpleStoreResource[T]` (this is for values returned by `resource.SimpleStore`), replace it with `resource.TypedObject[T, resource.MapSubresourceCatalog]` (this is the new type returned by `resource.SimpleStore`).


### PR DESCRIPTION
Add new docs section for migrations, include migration notes for 0.14x -> 0.15.x