### PR TITLE
[bugfix] Local CRD Generation with Webhook Conversion Strategy

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -421,6 +421,11 @@ func generateKubernetesYAML(crdGenFunc func() (codejen.Files, error), pluginID s
 					},
 				},
 			}
+			rawCRD["spec"] = spec
+			f.Data, err = yaml.Marshal(rawCRD)
+			if err != nil {
+				return nil, fmt.Errorf("unable to re-marshal CRD YAML after added conversion strategy: %w", err)
+			}
 		}
 
 		output.Write(append(f.Data, []byte("\n---\n")...))


### PR DESCRIPTION
When configured with `webhooks.converting: true` in `local/config.yaml`, the generated CRD(s) were not being updated with the webhook conversion strategy in the `dev-bundle.yaml` file, only in-memory. This PR writes the in-memory change back to the YAML before it is written out to `dev-bundle.yaml`.