### PR TITLE
Add `make install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,11 @@ clean:
 .PHONY: build
 build:
 	@go build -ldflags="-X 'main.version=dev-$(BRANCH)' -X 'main.source=$(HOST)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(shell date -u "+%FT%TZ")'" -o "$(BIN_DIR)/grafana-app-sdk" cmd/grafana-app-sdk/*.go
+
+.PHONY: install
+install: build
+ifndef GOPATH
+	@echo "GOPATH is not defined"
+	exit 1
+endif
+	@cp "$(BIN_DIR)/grafana-app-sdk" "${GOPATH}/bin/grafana-app-sdk"


### PR DESCRIPTION
Add  target to install the binary built with all flags from local, just to simplify the process from running:
```shell
make build && cp target/grafana-app-sdk $GOPATH/bin/grafana-app-sdk
```
into
```shell
make install
```

Will error if `GOPATH` is not set.