### PR TITLE
[bugfix][codegen] Fix flipped arguments in time.Time getters.

### DIFF
--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -62,7 +62,7 @@ var (
 			return fmt.Sprintf("%s = %s.Format(time.RFC3339)", setToVarName, inputVarName)
 		},
 		GetFuncTemplate: func(varName string) string {
-			return fmt.Sprintf("parsed, _ := time.Parse(%s, time.RFC3339)\nreturn parsed", varName)
+			return fmt.Sprintf("parsed, _ := time.Parse(time.RFC3339, %s)\nreturn parsed", varName)
 		},
 		AdditionalImports: []string{"time"},
 	}

--- a/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_object_gen.go.txt
@@ -214,7 +214,7 @@ func (o *CustomKind) GetUpdateTimestamp() time.Time {
 		o.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	parsed, _ := time.Parse(o.ObjectMeta.Annotations["grafana.com/updateTimestamp"], time.RFC3339)
+	parsed, _ := time.Parse(time.RFC3339, o.ObjectMeta.Annotations["grafana.com/updateTimestamp"])
 	return parsed
 }
 

--- a/codegen/testing/golden_generated/customkind/customkind_thema_codec_gen.go.txt
+++ b/codegen/testing/golden_generated/customkind/customkind_thema_codec_gen.go.txt
@@ -98,7 +98,7 @@ func extractOtherMetadataField(annotations map[string]string) string {
 }
 func extractUpdateTimestamp(annotations map[string]string) time.Time {
 
-	parsed, _ := time.Parse(annotations["updateTimestamp"], time.RFC3339)
+	parsed, _ := time.Parse(time.RFC3339, annotations["updateTimestamp"])
 	return parsed
 }
 func extractUpdatedBy(annotations map[string]string) string {


### PR DESCRIPTION
codegen: Fix flipped arguments in time.Time getters, resulting in a bug where `GetUpdateTimestamp()` always returned a zero time in generated `resource.Object` implementations (this also caused `GetCommonMetadata().UpdateTimestamp` to be a zero time as well as that function used `GetUpdateTimestamp()` to fetch the update timestamp).