### PR TITLE
[docs] Update Resource Objects doc with v0.15+ changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,23 +11,23 @@ Godocs on exported library package code (such as `resource`, `operator`, `plugin
 
 ### Table of Contents
 
-| Document | Description |
-|----------|-------------|
-| [Resource Objects](./resource-objects.md) | Describes the function and usage of the `resource.Object` interface |
-| [Resource Stores](./resource-stores.md) | Describes the various "Store" types in the `resource` package, and why you may want to use one or another |
-| [Design Patterns](./design-patterns.md) | The typical design patterns of an app built with the SDK |
-| [Operators & Event-Based Design](./operators.md) | A brief primer on what operators/controllers are and working with event-based code |
-| [Custom Kinds](./custom-kinds/README.md) | What are kinds, how to write them, and how to use them |
-| [Code Generation](./code-generation.md) | How to use CUE and the CLI for code generation. |
+| Document                                              | Description |
+|-------------------------------------------------------|-------------|
+| [Application Design](./application-design/README.md)  | The typical design patterns of an app built with the SDK |
+| [Custom Kinds](./custom-kinds/README.md)              | What are kinds, how to write them, and how to use them |
+| [Resource Objects](./resource-objects.md)             | Describes the function and usage of the `resource.Object` interface |
+| [Resource Stores](./resource-stores.md)               | Describes the various "Store" types in the `resource` package, and why you may want to use one or another |
+| [Operators & Event-Based Design](./operators.md)      | A brief primer on what operators/controllers are and working with event-based code |
+| [Code Generation](./code-generation.md)               | How to use CUE and the CLI for code generation. |
 | [Local Dev Environment Setup](./local-development.md) | How to use the CLI to set up a local development & testing environment |
-| [Kubernetes Concepts](./kubernetes.md) | A primer on some kubernetes concepts which are relevant to using the SDK backed by a kubernetes API server |
-| [Admission Control](./admission-control.md) | How to set up admission control on your kinds for an API server |
+| [Kubernetes Concepts](./kubernetes.md)                | A primer on some kubernetes concepts which are relevant to using the SDK backed by a kubernetes API server |
+| [Admission Control](./admission-control.md)           | How to set up admission control on your kinds for an API server |
 
 ## Base Concepts of the SDK
 
-The kernel at the center of most of what the SDK can be used for is a Kind, expressed in-code using the `resource.Object` and `resource.Schema` interfaces, and typically written in CUE as a kindsys.Custom kind. 
+The kernel at the center of most of what the SDK can be used for is a [Kind](custom-kinds/README.md), expressed in-code using the `resource.Object` interface and `resource.Kind` type, and typically written in CUE as a source-of-truth. 
 
-Instances of a kind, referred to as "resources" or "objects," are then stored in a storage system. The pre-built solution the SDK gives you currently is a kubernetes API server, 
+Instances of a kind, referred to as "resources" or "objects," are then stored in an API server. The pre-built solution the SDK gives you currently is a kubernetes API server, 
 but importantly, all of the tooling outside of the `k8s` package is actually implementation-agnostic.
 
 To work directly with resources, you can use an instance of a `resource.Client`, or one of the [Store](./resource-stores.md)-type objects which simplifies interactions by allowing you to treat the system as a key-value store.
@@ -35,11 +35,10 @@ To work directly with resources, you can use an instance of a `resource.Client`,
 An important component of the SDK is the use of the operator pattern. Using the `operator` package, you can set up an operator to watch for changes to one or more kinds, and take actions based on the nature of those changes. This allows behavior to be decoupled from the actual input API, which is especially useful in the context of an API server which has multiple paths for a user to enter, modify, or delete resources. For more details on this, see [Design Patterns](./design-patterns.md).
 
 Finally, there is also layering on top of the grafana backend plugin SDK, allowing you to create a REST API backend which can tie into your kinds, 
-so that front-end code does not need to be able to interact directly with the underlying storage layer. APIs exposed this way can also just be to provide synchronous endpoints, 
-or do more complex data manipulation before returning data to the front-end. Plugin backend wrapping is contained in the `plugin` package, 
-and also includes helpers for extacting kubernetes configuration from the secure JSON data.
+to create a proxy to the back-end API server. This package will eventually become deprecated in favor of direct API server access from the front-end, 
+and the use of a custom API server if additional non-standard routes are needed (see [Applications with Custom APIs](./application-design/README.md#applications-with-custom-apis)).
 
 ## Documentation Improvements
 
-If you notice places where documentation is lacking, confusing, or is out of date, please do not hesistate to create an [issue](https://github.com/grafana/grafana-app-sdk/issues) in this repository noting the specifics of what you found, and we will work to improve it. We also welcome documentation contributions as [Pull Requests](https://github.com/grafana/grafana-app-sdk/pulls).
+If you notice places where documentation is lacking, confusing, or is out of date, please do not hesitate to create an [issue](https://github.com/grafana/grafana-app-sdk/issues) in this repository noting the specifics of what you found, and we will work to improve it. We also welcome documentation contributions as [Pull Requests](https://github.com/grafana/grafana-app-sdk/pulls).
 

--- a/docs/resource-objects.md
+++ b/docs/resource-objects.md
@@ -1,33 +1,35 @@
 # Resource Objects
 
-The core kernel of working with the SDK's storage API is the `resource.Object` interface. 
-An instance of `Object` represents a distinct resource in the storage system, and it what is used in all core which interacts with the storage, 
-including stores, operators, and clients. An Object is considered to have three main components:
-1. Spec - this is the main body of the objects, and where all user-editable data is stored
-2. Subresources - currently, the only supported subresource when using the kubernetes client is `Status`. Subresources are non-spec, non-metadata top-level objects that are returned on reads, but must be written separately from a write to Spec.
-3. Metadata - this is split into three distinct kinds of metadata:
-    * Static Metadata - metadata which is immutable and can be used to uniquely identify the resource.
-    * Common Metadata - metadata which is common across all resources of all kinds
-    * Custom Metadata - metadata which is unique to this kind or even this specific kind version
+The core kernel of working with the SDK's libraries is the `resource.Object` interface. An instance `resource.Object` 
+(henceforth referred to as `Object` for simplicity) represents an instance of a [Kind](./custom-kinds/README.md), 
+and is typically populated with data for that instance. An `Object` implementation is composed of three main components:
+1. Spec - this is the main body of the object, and where all user-editable data is stored. Read more about `spec` in [Kinds](./custom-kinds/README.md).
+2. Subresources - these are additional sub-objects which are typically only mutated by operators. The clearest example of this is the `status` subresource, typically used to track operator state when handling the object. Currently, when using CRDs with a [frontend-only](./application-design/README.md#frontend-only-applications) or [operator-based](./application-design/README.md#operator-based-applications), only `status` and `scale` subresources are supported.
+3. Metadata - these are fields that always exist for all objects, such as `name` or `labels`. Metadata can be accessed on a per-field basis, or in SDK-specific groupings:
+    * Static Metadata - metadata which is immutable upon creation of the object and can be used to uniquely identify the resource
+    * Common Metadata - a subset of general metadata that _also_ includes non-kubernetes, app-platform specific metadata, such as `updateTimestamp` and `createdBy`. These additional metadata fields are normally encoded in `annotations` in the kubernetes metadata.
 
-The `resource.Object` interface defines methods used for interacting with these components. 
-Additionally, it defines a function used to unmarshal byte payloads for each of these components into the Object itself.
+The `Object` interface defines methods for accessing and all standard kubernetes metadata, accessing and setting the StaticMetadata and CommonMetadata objects, 
+and accessing and setting `spec` and subresources.
 
 ## Implementing resource.Object
 
 ### Using the CLI
 
-By far the easiest way to implment `resource.Object` for your project(s) is to use the CLI's `generate` command, 
+By far the easiest way to implement `resource.Object` for your project(s) is to use the CLI's `generate` command, 
 which takes in a kind written in CUE and outputs all the go code you'll need in your project, as well as CRD file(s) you can use to define the resource(s) in kubernetes. 
+For more information on writing kinds in CUE for codegen, see [Writing Kinds](./custom-kinds/writing-kinds.md).
 
-See [Code Generation](code-generation.md) for more details on using the CLI for codegen.
+A generated `Object` implementation will also contain extra getters and setters for all "custom" metadata defined in your CUE kind, 
+and getters and setters for app platform non-kubernetes metadata (such as `updateTimestamp`), which will properly encode the custom metadata 
+into the kubernetes annotations metadata.
 
 ### By Hand
 
 You can implement the interface by hand if you like, but keep in mind a few things:
-* `Unmarshal` must be able to handle any valid `WireFormat` and any valid version of the resource that can be stored.
-* `SpecObject()` and all resources in the map returned by `Subresources()` are marshaled as-is to the storage layer, 
-    so they should be shaped in a way that they will be accepted (this will hopefully change soon).
+* There are a _lot_ of getters/setters for metadata--the easiest way to implement these is to embed `k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta` and `k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta` at the root of your struct.
+* If your `Object` implementation doesn't easily convert to kubernetes JSON with `json.Marshal`/`json.Unmarshal`, you'll need to define your own `resource.Codec` to use in a `resource.Kind` for marshal/unmarshal process.
+* `resource.TypedObject` and `resource.UntypedObject` may serve your needs if you're just trying to handle runtime-provided spec or subresource information
 
 As this SDK is still **experimental**, the `resource.Object` interface may go through further evolutions, 
-so it's generally advisable to use the codegen, which will always generate compliant code. 
+so it's generally advisable to use the codegen (or `resource.TypedObject`/`resource.UntypedObject`), which will always generate compliant code. 


### PR DESCRIPTION
Update docs/resource-objects.md based on the changes from v0.15, and update the docs/README to fix some dead links and note temporary nature of the plugin package.

Resolves https://github.com/grafana/grafana-app-sdk/issues/253