### PR TITLE
[docs] Update code-generation doc

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -18,7 +18,7 @@ This command scans the `cuepath` for CUE files, and parses all top-level fields 
 * kind TypeScript code will be written to `tsgenpath`, with a folder for each unique kind-version combination
 * kind CRD files will be written to `crdpath`, encoded as JSON or YAML based on `crdencoding`, with a CRD file per kind
 
-> ![IMPORTANT]
+> [!IMPORTANT]
 > Because the interfaces that the grafana-app-sdk libraries use can change, be sure to run kind code generation using a version of the `grafana-app-sdk` CLI that matches the version of the dependency you use in your project. Whenever you update the dependency, make sure you re-run the kind code generation as well.
 
 Please see [Writing Kinds](./custom-kinds/writing-kinds.md) for a more detailed look at kind code generation from CUE.

--- a/docs/custom-kinds/writing-kinds.md
+++ b/docs/custom-kinds/writing-kinds.md
@@ -148,6 +148,47 @@ Additional `types.x.gen.ts` files will be generated for each subresource in your
 
 The `definitions` directory holds a JSON (or YAML, depending on CLI flags) Custom Resource Definition (CRD) file for each of your kinds. These files can be applied to a kubernetes API server to generate CRDs for your kinds, which you can then use the other generated code to interface with. For more about CRDs see [Kubernetes Concepts](../kubernetes.md).
 
+### Toggling Frontend/Backend Codegen
+
+You can turn on or off code generation for front-end (TypeScript) and/or back-end (go) using the `codegen` property in your kind or version(s) in your CUE kind. The `codegen` field by default looks like:
+```cue
+codegen: {
+    frontend: true
+    backend: true
+}
+```
+And can be overwritten at either the kind level, or the version level (version level will take precedence over the kind level declaration). For example, if we wanted to turn off front-end code from being generated for our kind, but keep it on for version `v2`, we could write a kind like this:
+```cue
+myKind: {
+    kind: "MyKind"
+    group: "mygroup"
+    current: "v2"
+    apiResource: {}
+    codegen: {
+        frontend: false // Turn off front-end codegen for this kind
+    }
+    versions: {
+        "v1": {
+            schema: {
+                spec: {
+                    foo: string
+                }
+            }
+        }
+        "v2": {
+            schema: {
+                spec: {
+                    foo: string
+                    bar: int64
+                }
+            }
+            codegen: frontend: true // Turn on front-end codegen for this version
+        }
+    }
+}
+```
+(Here we also introduce a convience of CUE: nested struct fields in one line using the `:` separator. We also have a second entry in `versions` in our kind, for more details on multiple versions in a kind see [Managing Multiple Kind Versions](./managing-multiple-versions.md))
+
 ## Complex Schemas
 
 ### Optional Fields


### PR DESCRIPTION
Update code-generation doc and moved some kind codegen info into writing kinds doc for consistency.

Resolves https://github.com/grafana/grafana-app-sdk/issues/252