### PR TITLE
Remove now-unnecessary replace directive from project codegen

### DIFF
--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -191,7 +191,7 @@ func projectInit(cmd *cobra.Command, args []string) error {
 func projectWriteGoModule(path, moduleName string, overwrite bool) (string, error) {
 	goModPath := filepath.Join(path, "go.mod")
 	goSumPath := filepath.Join(path, "go.sum")
-	goModContents := []byte(fmt.Sprintf("module %s\n\ngo 1.21\n\n// Required as the project does not inherit the replace directive from grafana-app-sdk and grafana-plugin-sdk-go\nreplace github.com/getkin/kin-openapi => github.com/getkin/kin-openapi v0.120.0\n", moduleName))
+	goModContents := []byte(fmt.Sprintf("module %s\n\ngo 1.21\n", moduleName))
 
 	// If we weren't instructed to overwrite without prompting, let's check if the go.mod file already exists
 	if _, err := os.Stat(goModPath); err == nil && !overwrite {

--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -191,7 +191,7 @@ func projectInit(cmd *cobra.Command, args []string) error {
 func projectWriteGoModule(path, moduleName string, overwrite bool) (string, error) {
 	goModPath := filepath.Join(path, "go.mod")
 	goSumPath := filepath.Join(path, "go.sum")
-	goModContents := []byte(fmt.Sprintf("module %s\n\ngo 1.21\n", moduleName))
+	goModContents := []byte(fmt.Sprintf("module %s\n\ngo 1.22\n", moduleName))
 
 	// If we weren't instructed to overwrite without prompting, let's check if the go.mod file already exists
 	if _, err := os.Stat(goModPath); err == nil && !overwrite {

--- a/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
+++ b/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/grafana/grafana-app-sdk
 
-go 1.21
-toolchain go1.22.2
+go 1.22.2
 
 // Required for compatibility with grafana/grafana-plugin-sdk-go & grafana/thema
 replace github.com/getkin/kin-openapi => github.com/getkin/kin-openapi v0.120.0


### PR DESCRIPTION
### What

This reverts https://github.com/grafana/grafana-app-sdk/pull/197 and upgrades the SDK and generated content to 1.22.

### Why

After #248 was merged, the replace directive is obsolete an in fact prevents the build from succeeding.
