### PR TITLE
Add a second entry in dependabot for the plugin submodule.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,11 @@ updates:
       - "*"
   labels:
   - "type/dependabot"
-
+- package-ecosystem: gomod
+  directory: "/plugin/"
+  schedule:
+    interval: daily
+  groups:
+    all:
+      patterns:
+      - "*"


### PR DESCRIPTION
It looks like dependabot isn't processing submodules correctly (as `grafana-plugin-sdk-go` is now several versions behind), added a second entry to dependabot's config explicitly for the `plugin` module to see if that resolves it.