### PR TITLE
Add convenience methods for GVR and GVK in resource.Kind.

### DIFF
--- a/resource/kind.go
+++ b/resource/kind.go
@@ -7,6 +7,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // KindEncoding is the wire encoding of the Kind objects.
@@ -70,6 +71,31 @@ func (k *Kind) Write(obj Object, out io.Writer, encoding KindEncoding) error {
 	return codec.Write(out, obj)
 }
 
+// GroupVersionKind is a convenience method that assembles a schema.GroupVersionKind from Group(), Version(), and Kind()
+func (k *Kind) GroupVersionKind() schema.GroupVersionKind {
+	if k.Schema == nil {
+		return schema.GroupVersionKind{}
+	}
+	return schema.GroupVersionKind{
+		Group:   k.Group(),
+		Version: k.Version(),
+		Kind:    k.Kind(),
+	}
+}
+
+// GroupVersionResource is a convenience method that assembles a schema.GroupVersionResource from Group(), Version(), and Plural()
+func (k *Kind) GroupVersionResource() schema.GroupVersionResource {
+	if k.Schema == nil {
+		return schema.GroupVersionResource{}
+	}
+	return schema.GroupVersionResource{
+		Group:    k.Group(),
+		Version:  k.Version(),
+		Resource: k.Plural(),
+	}
+}
+
+// NewJSONCodec returns a pointer to a new JSONCodec instance
 func NewJSONCodec() *JSONCodec {
 	return &JSONCodec{}
 }

--- a/resource/kind_test.go
+++ b/resource/kind_test.go
@@ -9,7 +9,38 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestKind_GroupVersionKind(t *testing.T) {
+	// nil Schema
+	k := Kind{}
+	gvk := k.GroupVersionKind()
+	assert.Equal(t, schema.GroupVersionKind{}, gvk)
+	// Values
+	k.Schema = NewSimpleSchema("group", "version", &UntypedObject{}, &UntypedList{}, WithKind("kind"))
+	gvk = k.GroupVersionKind()
+	assert.Equal(t, schema.GroupVersionKind{
+		Group:   k.Schema.Group(),
+		Version: k.Schema.Version(),
+		Kind:    k.Schema.Kind(),
+	}, gvk)
+}
+
+func TestKind_GroupVersionResource(t *testing.T) {
+	// nil Schema
+	k := Kind{}
+	gvr := k.GroupVersionResource()
+	assert.Equal(t, schema.GroupVersionResource{}, gvr)
+	// Values
+	k.Schema = NewSimpleSchema("group", "version", &UntypedObject{}, &UntypedList{}, WithPlural("plural"))
+	gvr = k.GroupVersionResource()
+	assert.Equal(t, schema.GroupVersionResource{
+		Group:    k.Schema.Group(),
+		Version:  k.Schema.Version(),
+		Resource: k.Schema.Plural(),
+	}, gvr)
+}
 
 func TestJSONCodec_Read(t *testing.T) {
 	emptyJSONErr := json.NewDecoder(&bytes.Buffer{}).Decode(&struct{}{})


### PR DESCRIPTION
Add convenience methods for getting a `schema.GroupVersionResource` and `schema.GroupVersionKind` in `resource.Kind`, to avoid the need to assemble these two types each time a user needs them when interacting with kubernetes code.