### PR TITLE
Plugin.json: update schema reference URL

### DIFF
--- a/cmd/grafana-app-sdk/templates/plugin.json.tmpl
+++ b/cmd/grafana-app-sdk/templates/plugin.json.tmpl
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{.Name}}",
   "id": "{{.ID}}",


### PR DESCRIPTION
### What changed?

Updated the reference to the plugin.json schema (it was pointing to the old one).