### PR TITLE
Respect the `--kindgrouping` flag in models go code generation

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -314,7 +314,7 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 		resourceFiles[i].RelativePath = filepath.Join(relativePath, f.RelativePath)
 	}
 	// Model
-	modelFiles, err := generator.FilteredGenerate(cuekind.ModelsGenerator(true), func(kind codegen.Kind) bool {
+	modelFiles, err := generator.FilteredGenerate(cuekind.ModelsGenerator(true, cfg.GroupKinds), func(kind codegen.Kind) bool {
 		return kind.Properties().APIResource == nil
 	}, selectors...)
 	if err != nil {

--- a/codegen/cuekind/generators.go
+++ b/codegen/cuekind/generators.go
@@ -54,11 +54,12 @@ func ResourceGenerator(versioned bool, groupKinds bool) *codejen.JennyList[codeg
 // or just generate code for the current version.
 // If `versioned` is true, the paths to the generated files will include the version, and
 // the package name will be the version, rather than the kind.
-func ModelsGenerator(versioned bool) *codejen.JennyList[codegen.Kind] {
+func ModelsGenerator(versioned bool, groupKinds bool) *codejen.JennyList[codegen.Kind] {
 	g := codejen.JennyListWithNamer(namerFunc)
 	g.Append(
 		&jennies.GoTypes{
 			GenerateOnlyCurrent: !versioned,
+			GroupByKind:         !groupKinds,
 		},
 	)
 	return g

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -75,7 +75,7 @@ func TestModelsGenerator(t *testing.T) {
 	fmt.Println(err)
 	require.Nil(t, err)
 
-	files, err := ModelsGenerator(false).Generate(kinds...)
+	files, err := ModelsGenerator(false, true).Generate(kinds...)
 	require.Nil(t, err)
 	// Check number of files generated
 	// 1 -> just the go type


### PR DESCRIPTION
Go model type generator's GoTypes jenny was missing the boolean in its configuration telling it how to group kinds, which defaults to `false` (group by `group`). Updated the generator to take an argument to set this, like the Resource type generator, and supply the value from the CLI flag `--kindgrouping`, the same as with resource types.