### PR TITLE
[CLI/bugfix] Fix CRD File Generation from CLI

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -349,7 +349,7 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 		if cfg.CRDEncoding == "yaml" {
 			encFunc = yaml.Marshal
 		}
-		crdFiles, err := generator.FilteredGenerate(cuekind.CRDGenerator(encFunc, cfg.CRDEncoding), func(kind codegen.Kind) bool {
+		crdFiles, err = generator.FilteredGenerate(cuekind.CRDGenerator(encFunc, cfg.CRDEncoding), func(kind codegen.Kind) bool {
 			return kind.Properties().APIResource != nil
 		}, selectors...)
 		if err != nil {


### PR DESCRIPTION
Don't shadow the crdFiles variable, as that was causing the generated CRD files to never get added to the full list of files to write to disk.