### PR TITLE
Fix backend plugin codegen

### DIFF
--- a/codegen/templates/plugin/handler_resource.tmpl
+++ b/codegen/templates/plugin/handler_resource.tmpl
@@ -17,7 +17,7 @@ import (
 )
 
 type {{.Kind}}Service interface {
-	List(ctx context.Context, resource.StoreListOptions) (*resource.TypedList[*{{.MachineName}}.{{.Kind}}], error)
+	List(ctx context.Context, opts resource.StoreListOptions) (*resource.TypedList[*{{.MachineName}}.{{.Kind}}], error)
 	Get(ctx context.Context, id resource.Identifier) (*{{.MachineName}}.{{.Kind}}, error)
 	Add(ctx context.Context, obj *{{.MachineName}}.{{.Kind}}) (*{{.MachineName}}.{{.Kind}}, error)
 	Update(ctx context.Context, id resource.Identifier, obj *{{.MachineName}}.{{.Kind}}) (*{{.MachineName}}.{{.Kind}}, error)


### PR DESCRIPTION
### WHAT

This commit fixes codegen for backend plugin router by ensuring that router service interface uses consistent interface method signatures.

### WHY

To make sure that the codegen works again and produces valid Go code.