### PR TITLE
Have NewOpinionatedWatcher and NewOpinionatedReconciler error when finalizer exceeds max length

### DIFF
--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -68,7 +68,7 @@ func NewOpinionatedWatcherWithFinalizer(sch resource.Schema, client PatchClient,
 	}
 	finalizer := supplier(sch)
 	if len(finalizer) > 63 {
-		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars")
+		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars: %s", finalizer)
 	}
 	return &OpinionatedWatcher{
 		client:    client,

--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -66,10 +66,14 @@ func NewOpinionatedWatcherWithFinalizer(sch resource.Schema, client PatchClient,
 	if client == nil {
 		return nil, fmt.Errorf("client cannot be nil")
 	}
+	finalizer := supplier(sch)
+	if len(finalizer) > 63 {
+		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars")
+	}
 	return &OpinionatedWatcher{
 		client:    client,
 		schema:    sch,
-		finalizer: supplier(sch),
+		finalizer: finalizer,
 	}, nil
 }
 

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -43,6 +43,15 @@ func TestNewOpinionatedWatcher(t *testing.T) {
 		assert.NotNil(t, o)
 		assert.Equal(t, finalizer, o.finalizer)
 	})
+
+	t.Run("finalizer too long", func(t *testing.T) {
+		finalizer := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789"
+		o, err := NewOpinionatedWatcherWithFinalizer(schema, client, func(_ resource.Schema) string {
+			return finalizer
+		})
+		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars"), err)
+		assert.Nil(t, o)
+	})
 }
 
 func TestOpinionatedWatcher_Wrap(t *testing.T) {

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -49,7 +49,7 @@ func TestNewOpinionatedWatcher(t *testing.T) {
 		o, err := NewOpinionatedWatcherWithFinalizer(schema, client, func(_ resource.Schema) string {
 			return finalizer
 		})
-		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars"), err)
+		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars: %s", finalizer), err)
 		assert.Nil(t, o)
 	})
 }

--- a/operator/reconciler.go
+++ b/operator/reconciler.go
@@ -124,7 +124,7 @@ func NewOpinionatedReconciler(client PatchClient, finalizer string) (*Opinionate
 		return nil, fmt.Errorf("finalizer cannot be empty")
 	}
 	if len(finalizer) > 63 {
-		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars")
+		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars: %s", finalizer)
 	}
 	return &OpinionatedReconciler{
 		finalizer: finalizer,

--- a/operator/reconciler.go
+++ b/operator/reconciler.go
@@ -123,6 +123,9 @@ func NewOpinionatedReconciler(client PatchClient, finalizer string) (*Opinionate
 	if finalizer == "" {
 		return nil, fmt.Errorf("finalizer cannot be empty")
 	}
+	if len(finalizer) > 63 {
+		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars")
+	}
 	return &OpinionatedReconciler{
 		finalizer: finalizer,
 		client:    client,

--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -41,7 +41,7 @@ func TestNewOpinionatedReconciler(t *testing.T) {
 		finalizer := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789"
 		client := &mockPatchClient{}
 		op, err := NewOpinionatedReconciler(client, finalizer)
-		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars"), err)
+		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars: %s", finalizer), err)
 		assert.Nil(t, op)
 	})
 }

--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -36,6 +36,14 @@ func TestNewOpinionatedReconciler(t *testing.T) {
 		assert.Equal(t, finalizer, op.finalizer)
 		assert.Equal(t, client, op.client)
 	})
+
+	t.Run("finzlizer too long", func(t *testing.T) {
+		finalizer := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789"
+		client := &mockPatchClient{}
+		op, err := NewOpinionatedReconciler(client, finalizer)
+		assert.Equal(t, fmt.Errorf("finalizer length cannot exceed 63 chars"), err)
+		assert.Nil(t, op)
+	})
 }
 
 func TestOpinionatedReconciler_Reconcile(t *testing.T) {


### PR DESCRIPTION
Have NewOpinionatedWatcher and NewOpinionatedReconciler error on a finalizer which exceed the kubernetes finalizer max length. Allow a user to customize the finalizer generation function of simple.Operator.