### PR TITLE
[k8s] Properly parse the kubernetes' errors.StatusError type

### DIFF
--- a/k8s/gvclient.go
+++ b/k8s/gvclient.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -544,7 +544,7 @@ type k8sErrBody struct {
 // if the status code is a non-success (>= 300).
 func parseKubernetesError(responseBytes []byte, statusCode int, err error) error {
 	if err != nil {
-		statusErr := &errors2.StatusError{}
+		statusErr := &k8serrors.StatusError{}
 		if errors.As(err, &statusErr) {
 			if statusCode == 0 || (statusErr.ErrStatus.Code > 0 && statusCode != int(statusErr.ErrStatus.Code)) {
 				return NewServerResponseError(statusErr, int(statusErr.ErrStatus.Code))

--- a/k8s/gvclient_test.go
+++ b/k8s/gvclient_test.go
@@ -1,0 +1,88 @@
+package k8s
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseKubernetesError(t *testing.T) {
+	tests := []struct {
+		name        string
+		bytes       []byte
+		statusCode  int
+		err         error
+		expectedErr error
+	}{{
+		name:       "status error",
+		bytes:      nil,
+		statusCode: 0,
+		err: &errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+				Code:    http.StatusInternalServerError,
+			},
+		},
+		expectedErr: NewServerResponseError(&errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+				Code:    http.StatusInternalServerError,
+			},
+		}, http.StatusInternalServerError),
+	}, {
+		name:       "status error, code conflicts with returned response code",
+		bytes:      nil,
+		statusCode: http.StatusConflict,
+		err: &errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+				Code:    http.StatusInternalServerError,
+			},
+		},
+		expectedErr: NewServerResponseError(&errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+				Code:    http.StatusInternalServerError,
+			},
+		}, http.StatusInternalServerError),
+	}, {
+		name:       "status error, code conflicts with returned response code (status.Code 0)",
+		bytes:      nil,
+		statusCode: http.StatusConflict,
+		err: &errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+			},
+		},
+		expectedErr: NewServerResponseError(&errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Message: "I AM ERROR",
+			},
+		}, http.StatusConflict),
+	}, {
+		name:        "other error type, body JSON",
+		bytes:       []byte(`{"code":404,"message":"no way"}`),
+		err:         fmt.Errorf("no way"),
+		expectedErr: NewServerResponseError(fmt.Errorf("no way"), http.StatusNotFound),
+	}, {
+		name:        "other error type, body JSON, no status code",
+		bytes:       []byte(`{"message":"no way"}`),
+		err:         fmt.Errorf("no way 2"),
+		expectedErr: fmt.Errorf("no way"),
+	}, {
+		name:        "other error type, no body JSON",
+		err:         fmt.Errorf("nope"),
+		expectedErr: fmt.Errorf("nope"),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := parseKubernetesError(test.bytes, test.statusCode, test.err)
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
+}

--- a/k8s/gvclient_test.go
+++ b/k8s/gvclient_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,13 +21,13 @@ func TestParseKubernetesError(t *testing.T) {
 		name:       "status error",
 		bytes:      nil,
 		statusCode: 0,
-		err: &errors2.StatusError{
+		err: &k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 				Code:    http.StatusInternalServerError,
 			},
 		},
-		expectedErr: NewServerResponseError(&errors2.StatusError{
+		expectedErr: NewServerResponseError(&k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 				Code:    http.StatusInternalServerError,
@@ -37,13 +37,13 @@ func TestParseKubernetesError(t *testing.T) {
 		name:       "status error, code conflicts with returned response code",
 		bytes:      nil,
 		statusCode: http.StatusConflict,
-		err: &errors2.StatusError{
+		err: &k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 				Code:    http.StatusInternalServerError,
 			},
 		},
-		expectedErr: NewServerResponseError(&errors2.StatusError{
+		expectedErr: NewServerResponseError(&k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 				Code:    http.StatusInternalServerError,
@@ -53,12 +53,12 @@ func TestParseKubernetesError(t *testing.T) {
 		name:       "status error, code conflicts with returned response code (status.Code 0)",
 		bytes:      nil,
 		statusCode: http.StatusConflict,
-		err: &errors2.StatusError{
+		err: &k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 			},
 		},
-		expectedErr: NewServerResponseError(&errors2.StatusError{
+		expectedErr: NewServerResponseError(&k8serrors.StatusError{
 			ErrStatus: metav1.Status{
 				Message: "I AM ERROR",
 			},


### PR DESCRIPTION
Have the k8s package properly parse the kubernetes' errors.StatusError type if returned and return a `*k8s.ServerResponseError` wrapping it. Add tests for error parsing. Resolves https://github.com/grafana/grafana-app-sdk/issues/301