### PR TITLE
[CustomCacheInformer] Fix startup race condition between controller and processor

### DIFF
--- a/operator/informer_customcache_test.go
+++ b/operator/informer_customcache_test.go
@@ -44,6 +44,7 @@ func TestCustomCacheInformer_Run(t *testing.T) {
 
 func TestCustomCacheInformer_Run_DistributeEvents(t *testing.T) {
 	events := make(chan watch.Event)
+	defer close(events)
 	inf := NewCustomCacheInformer(newUnsafeCache(), &mockListWatcher{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return &resource.UntypedList{}, nil
@@ -92,6 +93,7 @@ func TestCustomCacheInformer_Run_DistributeEvents(t *testing.T) {
 	}
 
 	stopCh := make(chan struct{})
+	defer close(stopCh)
 	go inf.Run(stopCh)
 
 	// Add
@@ -117,12 +119,12 @@ func TestCustomCacheInformer_Run_DistributeEvents(t *testing.T) {
 		Object: addObj,
 	}
 	assert.True(t, waitOrTimeout(&wg, time.Second*10), "event was not distributed to all handlers within 10 seconds")
-	close(stopCh)
 }
 
 func TestCustomCacheInformer_Run_ManyEvents(t *testing.T) {
 	numEvents := 1000
 	events := make(chan watch.Event, numEvents)
+	defer close(events)
 	inf := NewCustomCacheInformer(newUnsafeCache(), &mockListWatcher{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return &resource.UntypedList{}, nil
@@ -154,6 +156,7 @@ func TestCustomCacheInformer_Run_ManyEvents(t *testing.T) {
 		})
 	}
 	stopCh := make(chan struct{})
+	defer close(stopCh)
 	go inf.Run(stopCh)
 	for i := 0; i < numEvents; i++ {
 		etype := watch.Added
@@ -181,11 +184,11 @@ func TestCustomCacheInformer_Run_ManyEvents(t *testing.T) {
 	assert.True(t, waitOrTimeout(&addWG, time.Second*10), "all add events were not distributed within 10 seconds")
 	assert.True(t, waitOrTimeout(&updateWG, time.Second*10), "all add events were not distributed within 10 seconds")
 	assert.True(t, waitOrTimeout(&deleteWG, time.Second*10), "all add events were not distributed within 10 seconds")
-	close(stopCh)
 }
 
 func TestCustomCacheInformer_Run_CacheState(t *testing.T) {
 	events := make(chan watch.Event)
+	defer close(events)
 	store := newUnsafeCache()
 	inf := NewCustomCacheInformer(store, &mockListWatcher{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/operator/informer_processor.go
+++ b/operator/informer_processor.go
@@ -5,11 +5,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/grafana-app-sdk/logging"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/buffer"
+
+	"github.com/grafana/grafana-app-sdk/logging"
 )
 
 /*

--- a/operator/informer_processor.go
+++ b/operator/informer_processor.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -38,6 +39,7 @@ type informerProcessor struct {
 	listenersMux sync.RWMutex
 	wg           wait.Group
 	started      bool
+	startedCh    chan struct{}
 }
 
 func newInformerProcessor() *informerProcessor {
@@ -53,6 +55,13 @@ func (p *informerProcessor) addListener(l *informerProcessorListener) {
 }
 
 func (p *informerProcessor) distribute(event any) {
+	if !p.started {
+		// Drop events if we're not started to prevent us from not being able to start if listener.push() blocks
+		if logging.DefaultLogger != nil {
+			logging.DefaultLogger.Warn("Received event for informer distribution while processor is not started, dropping event")
+		}
+		return
+	}
 	p.listenersMux.RLock()
 	defer p.listenersMux.RUnlock()
 	for listener := range p.listeners {
@@ -69,6 +78,12 @@ func (p *informerProcessor) run(stopCh <-chan struct{}) {
 	}
 	p.started = true
 	p.listenersMux.Unlock()
+	if p.startedCh != nil {
+		// Run in a goroutine to prevent blocking if the channel buffer is full
+		go func() {
+			p.startedCh <- struct{}{}
+		}()
+	}
 	<-stopCh
 	p.listenersMux.Lock()
 	p.started = false

--- a/operator/informer_processor.go
+++ b/operator/informer_processor.go
@@ -72,9 +72,7 @@ func (p *informerProcessor) distribute(event any) {
 func (p *informerProcessor) run(stopCh <-chan struct{}) {
 	p.listenersMux.Lock()
 	for listener := range p.listeners {
-		go func(l *informerProcessorListener) {
-			p.wg.Start(l.run)
-		}(listener)
+		p.wg.Start(listener.run)
 	}
 	p.started = true
 	p.listenersMux.Unlock()


### PR DESCRIPTION
`CustomCacheInformer` uses an `operator.informerProcessor` to distribute events to all listeners (ResourceWatchers added by users). When the reflector submits a list/watch event, it goes through the On<X> method in the Informer, then hits `informerProcessor.distribute`, which writes the event to every listener to process in its own queue. `informerProcessor.distribute` calls `informerProcessorListener.push` on each listener, which pushes the event to a channel which should be constantly being pulled from by `informerProcessorListener.pop`, which is started by `informerProcessorListener.run` (which distributes the events popped off the channel by pop to the ResourceWatcher for the listener), which, for each listener is started by `informerProcessor.run`. However, if `distribute` gets called before `pop` is running, the channel in a listener can fill up and `distribute` can block. This actually prevents `informerProcessor.run` from starting the listeners, because it needs to lock on `informerProcessor.listenersMux`, and `distribute` already has the lock (and is stuck).

In somewhat infrequent race conditions, the `CustomCacheInformer.controller` may begin attempting to distribute events before `CustomCacheInformer.processor` has begun running. This is due to the startup of `CustomCacheInformer` is done in a goroutine, so there are no sequential guarantees. This causes intermittent test failures, and could cause an operator to fail to function properly (simply locking up and doing nothing without any information provided to the user) in production (though a restart would likely fix it).

To fix this, `informerProcessor` now has an optional field `startedCh`, which, if non-nil, it will send an empty struct to when `run` has completed its startup process (all listeners are started), which can ensure that the controller run call is made after the processor has started.

As an additional safety measure, `informerProcessor.distribute` will also drop any event it receives prior to `informerProcessor.started` being true, to ensure that it cannot get stuck with the `listenersMux` locked (it will warn to the default logger if this happens).