### PR TITLE
Exclude dependabot from workspace check GH action.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,9 @@ jobs:
   check:
     name: Go Workspace Check
     runs-on: ubuntu-latest
+    # Exlude dependabot from this check--it can't run make update-workspace, 
+    # We'll just force the next PR author to do it instead for now
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Per [depndabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#common-dependabot-automations), dependabot-specific steps can be run with the check `github.actor == 'dependabot[bot]'`. Use `github.actor != 'dependabot[bot]'` to instead not run the workspace check on dependabot PRs.