### PR TITLE
Fix Integration Tests Workflow and Retract Bad Tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: './grafana-app-sdk/go.mod'
     # Install the CLI
     - name: Install the CLI
       run: cd cmd/grafana-app-sdk && go install && cd -

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/grafana/grafana-app-sdk
 
 go 1.23.0
 
+retract (
+	v0.18.3 // Tag was deleted and re-created with a new commit, causing GOPROXY conflicts
+	v0.18.4 // Errors in release pipeline didn't allow the binaries to be built for this release, which can break automated workflows that depend on them
+)
+
 require (
 	cuelang.org/go v0.5.0
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874

--- a/plugin/go.mod
+++ b/plugin/go.mod
@@ -2,6 +2,11 @@ module github.com/grafana/grafana-app-sdk/plugin
 
 go 1.23.0
 
+retract (
+	v0.18.3 // Tag was deleted and re-created with a new commit, causing GOPROXY conflicts
+	v0.18.4 // Errors in release pipeline didn't allow the binaries to be built for this release, which can break automated workflows that depend on them
+)
+
 require (
 	github.com/grafana/grafana-app-sdk v0.18.3
 	github.com/grafana/grafana-plugin-sdk-go v0.245.0


### PR DESCRIPTION
Fix the integration tests step in the release workflow by giving the adjusted path for the `go.mod` (tested [in this fork](https://github.com/IfSentient/grafana-app-sdk/actions/runs/10692236317)).

Also retract the release that tried to build with this error (no release binaries), and the previous release (v0.18.3) as that tag is mismatched between GOPROXY and here. [Retraction is the correct way to remove a tag per go](https://go.dev/ref/mod#go-mod-file-retract), so the v0.18.3 tag being deleted and replaced was incorrect behavior and should be listed in the retracted list in `go.mod` in both main and `plugin` modules.