### PR TITLE
Add warning to CLI output when using --format=thema

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -55,7 +55,7 @@ Allowed values are 'group' and 'kind'. Dictates the packaging of go kinds, where
 	generateCmd.SilenceUsage = true
 }
 
-//nolint:funlen
+//nolint:funlen,revive
 func generateCmdFunc(cmd *cobra.Command, _ []string) error {
 	cuePath, err := cmd.Flags().GetString("cuepath")
 	if err != nil {
@@ -116,6 +116,7 @@ func generateCmdFunc(cmd *cobra.Command, _ []string) error {
 	var files codejen.Files
 	switch format {
 	case FormatThema:
+		fmt.Println(themaWarning)
 		files, err = generateKindsThema(os.DirFS(cuePath), kindGenConfig{
 			GoGenBasePath: goGenPath,
 			TSGenBasePath: tsGenPath,
@@ -148,6 +149,11 @@ func generateCmdFunc(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if format == FormatThema {
+		// Print the warning at the end of the output as well
+		fmt.Println(themaWarning)
 	}
 
 	// Jennies that need to be run post-file-write

--- a/cmd/grafana-app-sdk/main.go
+++ b/cmd/grafana-app-sdk/main.go
@@ -17,10 +17,17 @@ var rootCmd = &cobra.Command{
 	Long:  "A tool for working with grafana apps, used for generating code from CUE kinds, creating project boilerplate, and running local deployments",
 }
 
+const themaWarning = `
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! WARNING: --format=thema is deprecated and will be removed in a future release.          !!!
+!!! Please use the (default) CUE format instead. For more details, see                      !!!
+!!! https://github.com/grafana/grafana-app-sdk/blob/main/docs/custom-kinds/writing-kinds.md !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`
+
 func main() {
 	rootCmd.PersistentFlags().StringP("cuepath", "c", "kinds", "Path to directory with cue.mod")
 	rootCmd.PersistentFlags().StringSliceP("selectors", "s", []string{}, "selectors")
-	rootCmd.PersistentFlags().StringP("format", "f", "cue", "Format in which kinds are written for this project (allowed values are 'cue' and 'thema')")
+	rootCmd.PersistentFlags().StringP("format", "f", "cue", "Format in which kinds are written for this project (currently allowed values are 'cue')")
 
 	setupVersionCmd()
 	setupGenerateCmd()

--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -364,6 +364,9 @@ func projectAddKind(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	if format == FormatThema {
+		fmt.Println(themaWarning)
+	}
 
 	return nil
 }
@@ -489,6 +492,10 @@ func projectAddComponent(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if format == FormatThema {
+		fmt.Println(themaWarning)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds a prominent warning to users when running the CLI with the `--format=thema` flag that thema support is deprecated and it will be removed in a future release. The warning message points to the docs on writing kinds for how to write a kind in the CUE format instead.

Resolves https://github.com/grafana/grafana-app-sdk/issues/275