### PR TITLE
Allow configuring Grafana image

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -48,6 +48,7 @@ type localEnvConfig struct {
 	OperatorImage             string                `json:"operatorImage" yaml:"operatorImage"`
 	Webhooks                  localEnvWebhookConfig `json:"webhooks" yaml:"webhooks"`
 	GenerateGrafanaDeployment bool                  `json:"generateGrafanaDeployment" yaml:"generateGrafanaDeployment"`
+	GrafanaImage              string               	`json:"grafanaImage" yaml:"grafanaImage"`
 }
 
 type dataSourceConfig struct {
@@ -234,6 +235,7 @@ func getLocalEnvConfig(localPath string) (*localEnvConfig, error) {
 	// Read config (try YAML first, then JSON)
 	config := localEnvConfig{
 		GenerateGrafanaDeployment: true,
+		GrafanaImage: "grafana/grafana-enterprise:11.2.2",
 	}
 	if _, err := os.Stat(filepath.Join(localPath, "config.yaml")); err == nil {
 		cfgBytes, err := os.ReadFile(filepath.Join(localPath, "config.yaml"))
@@ -301,6 +303,7 @@ type yamlGenProperties struct {
 	OperatorImage             string
 	WebhookProperties         yamlGenPropsWebhooks
 	GenerateGrafanaDeployment bool
+	GrafanaImage              string
 }
 
 type yamlGenPropsCRD struct {
@@ -357,6 +360,7 @@ func generateKubernetesYAML(crdGenFunc func() (codejen.Files, error), pluginID s
 			Enabled: config.Webhooks.Mutating || config.Webhooks.Validating || config.Webhooks.Converting,
 		},
 		GenerateGrafanaDeployment: config.GenerateGrafanaDeployment,
+		GrafanaImage: 						config.GrafanaImage,
 	}
 	props.Services = append(props.Services, yamlGenPropsService{
 		KubeName: "grafana",

--- a/cmd/grafana-app-sdk/templates/local/config.yaml
+++ b/cmd/grafana-app-sdk/templates/local/config.yaml
@@ -34,3 +34,6 @@ datasourceConfigs:
 #
 # Toggle the generating of the grafana deployments, if you want to control these elsewhere
 generateGrafanaDeployment: true
+
+# which grafana image to use
+grafanaImage: grafana/grafana-enterprise:11.2.2

--- a/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
@@ -111,7 +111,7 @@ spec:
             - name: GF_INSTALL_PLUGINS
             - name: GF_PATHS_CONFIG
               value: /etc/grafana-config/grafana.ini
-          image: grafana/grafana-enterprise:10.0.3
+          image: {{.GrafanaImage}}
           imagePullPolicy: IfNotPresent
           name: grafana
           ports:


### PR DESCRIPTION
:wave:  Introducing App SDK into   App O11y plugin, it doesn't run because Grafana image is too old :grin: 

Updated default to latest and added option to customize image in config