### PR TITLE
Allow bool values in pluginJson

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -589,6 +589,8 @@ func parsePluginJSONValue(v any) (string, error) {
 		return strconv.FormatFloat(float64(cast), 'E', -1, 32), nil
 	case float64:
 		return strconv.FormatFloat(cast, 'E', -1, 64), nil
+	case bool:
+		return strconv.FormatBool(cast), nil
 	default:
 		return "", fmt.Errorf("unknown type")
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -926,6 +926,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240930140551-af27646dc61f/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=


### PR DESCRIPTION
Continuing efforts to move App O11y onto app sdk: 

App o11y has some boolean values in it's `pluginJson` which was causing error `Error: unable to parse pluginJson key "someKey"`, found that boolean yaml values were not being handled