### PR TITLE
Add dependabot entries for the lts/v0.24 branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,35 @@ updates:
     all:
       patterns:
       - "*"
+# LTS branch
+- package-ecosystem: gomod
+  directory: "/"
+  target-branch: "lts/v0.24"
+  schedule:
+    interval: daily
+  groups:
+    cue:
+      patterns:
+        - "*cue*"
+        - "*thema*"
+        - "*codejen*"
+    all:
+      exclude-patterns:
+        - "*cue*"
+        - "*thema*"
+        - "*codejen*"
+      patterns:
+        - "*"
+  labels:
+    - "type/dependabot"
+- package-ecosystem: gomod
+  directory: "/plugin/"
+  target-branch: "lts/v0.24"
+  schedule:
+    interval: daily
+  groups:
+    all:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "*grafana-app-sdk*" # Don't update the app-sdk version via dependabot for this branch


### PR DESCRIPTION
Now that we have an LTS branch which we would like to keep dependencies up-to-date on, add entries in dependabot for targeting that branch as well as `main`.