### PR TITLE
Expose GF_INSTALL_PLUGINS via config

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -46,6 +46,7 @@ type localEnvConfig struct {
 	Webhooks                  localEnvWebhookConfig `json:"webhooks" yaml:"webhooks"`
 	GenerateGrafanaDeployment bool                  `json:"generateGrafanaDeployment" yaml:"generateGrafanaDeployment"`
 	GrafanaImage              string                `json:"grafanaImage" yaml:"grafanaImage"`
+	GrafanaInstallPlugins     string                `json:"grafanaInstallPlugins" yaml:"grafanaInstallPlugins"`
 }
 
 type dataSourceConfig struct {
@@ -310,6 +311,7 @@ type yamlGenProperties struct {
 	WebhookProperties         yamlGenPropsWebhooks
 	GenerateGrafanaDeployment bool
 	GrafanaImage              string
+	GrafanaInstallPlugins     string
 }
 
 type yamlGenPropsCRD struct {
@@ -367,6 +369,7 @@ func generateKubernetesYAML(crdGenFunc func() (codejen.Files, error), pluginID s
 		},
 		GenerateGrafanaDeployment: config.GenerateGrafanaDeployment,
 		GrafanaImage:              config.GrafanaImage,
+		GrafanaInstallPlugins:     config.GrafanaInstallPlugins,
 	}
 	props.Services = append(props.Services, yamlGenPropsService{
 		KubeName: "grafana",

--- a/cmd/grafana-app-sdk/templates/local/config.yaml
+++ b/cmd/grafana-app-sdk/templates/local/config.yaml
@@ -37,3 +37,6 @@ generateGrafanaDeployment: true
 
 # which grafana image to use
 grafanaImage: grafana/grafana-enterprise:main
+
+# Install plugins from other sources (URLS). See https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-from-other-sources
+grafanaInstallPlugins: ""

--- a/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
@@ -132,6 +132,7 @@ spec:
       containers:
         - env:
             - name: GF_INSTALL_PLUGINS
+              value: "{{.GrafanaInstallPlugins}}"
             - name: GF_PATHS_CONFIG
               value: /etc/grafana-config/grafana.ini
           image: {{.GrafanaImage}}

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -5,16 +5,21 @@ The SDK CLI provides the `project local` command for local development, which by
 ## Setup
 
 If you set up your project with
+
 ```
 grafana-app-sdk project init
 ```
+
 then you should already have a `local` directory in the root of your project. If you did not, you can run
+
 ```
 grafana-app-sdk project local init
 ```
-in the root of your project to create the `local` directory and its files. 
+
+in the root of your project to create the `local` directory and its files.
 
 In the `local` directory, we have:
+
 ```shell
 $ tree local
 local
@@ -29,6 +34,7 @@ local
 
 5 directories, 4 files
 ```
+
 Let's break down what each of these files is for:
 | File | Purpose |
 |------|---------|
@@ -40,6 +46,7 @@ Let's break down what each of these files is for:
 | `scripts/push_image.sh` | Script to push an image from a local registry to the K3D internal registry. |
 
 If you created your project with `project init`, you'll also have some default `Makefile` targets. If you didn't (and for clarity in this doc), here's the Makefile snippit:
+
 ```Makefile
 .PHONY: local/up
 local/up: local/generate
@@ -70,11 +77,13 @@ local/push_operator:
 local/clean: local/down
 	@sh local/scripts/cluster.sh delete
 ```
+
 (`OPERATOR_DOCKERIMAGE` is defined at the top of your Makefile)
 
 ## `local/config.yaml`
 
 Before we get into generating our local environment or breaking down the steps, let's take a look at our `local/config.yaml`:
+
 ```yaml
 # Port used to bind services to localhost, for example, grafana will be available at http://grafana.k3d.localhost:9999
 port: 9999
@@ -106,63 +115,86 @@ datasourceConfigs:
 #
 # Toggle the generating of the grafana deployments, if you want to control these elsewhere
 generateGrafanaDeployment: true
+
+# Install plugins from other sources (URLS). See https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker#install-plugins-from-other-sources
+grafanaInstallPlugins: ""
 ```
+
 Most of these fields are broken down in the comments, but let's quickly touch on a few things:
-* `port`: this defaults to 9999, and is the port you use on your localhost to get to containers running in the cluster which expose a web interface (such as grafana). If you already have a process that runs on 9999 on your localhost, make sure to change this.
-* `kubePort`: this port is also bound on your localhost, and is the port which you will use to talk to the kubernetes API server. Again, if somethings else is already bound to this port on your localhost, make sure to change this.
-* `datasources`: Pre-configred datasources to set up in your local environment. Right now, only `cortex` is supported. You can check the list of supported datasources in [ cmd/grafana-app-sdk/project_local_datasources.go](../cmd/grafana-app-sdk/project_local_datasources.go).
-* `operatorImage`: make sure the image sans-tag (`:latest`) matches the image name you're building your operator with. If you used the SDK to initialize your project, this should automatically match.
+
+- `port`: this defaults to 9999, and is the port you use on your localhost to get to containers running in the cluster which expose a web interface (such as grafana). If you already have a process that runs on 9999 on your localhost, make sure to change this.
+- `kubePort`: this port is also bound on your localhost, and is the port which you will use to talk to the kubernetes API server. Again, if somethings else is already bound to this port on your localhost, make sure to change this.
+- `datasources`: Pre-configred datasources to set up in your local environment. Right now, only `cortex` is supported. You can check the list of supported datasources in [ cmd/grafana-app-sdk/project_local_datasources.go](../cmd/grafana-app-sdk/project_local_datasources.go).
+- `operatorImage`: make sure the image sans-tag (`:latest`) matches the image name you're building your operator with. If you used the SDK to initialize your project, this should automatically match.
 
 OK, with that out of the way, let's discuss doing a local deployment.
 
 ## Local Deployment
 
 A local deployment consists of three steps:
+
 1. Generate the kubernetes manifests and local kubernetes config
 2. Start up the kubernetes cluster
 3. Deploy the cluster resources
 
 In the default Makefile, these three steps are all done with the `make local/up` command. This command runs the following:
+
 ```
 $ grafana-app-sdk project local generate
 ```
-This generates the kube manifests and k3d config file based on your `local/config.yaml`. The generated manifests and config are placed in `local/generated`. 
-*Generally, this directory should not be commited to source control*, as the k3d config requires an absolute path for your mounted volumes, which is user-specific. Additionally, local deployments should be re-generating the kubernetes manifests every time.
+
+This generates the kube manifests and k3d config file based on your `local/config.yaml`. The generated manifests and config are placed in `local/generated`.
+_Generally, this directory should not be commited to source control_, as the k3d config requires an absolute path for your mounted volumes, which is user-specific. Additionally, local deployments should be re-generating the kubernetes manifests every time.
+
 ```
 $ sh local/scripts/cluster.sh create "local/generated/k3d-config.json"
 ```
+
 This creates the k3d kubernetes cluster using the generated k3d config. If the cluster is already running, this is a no-op.
+
 ```
 $ cd local && tilt up
 ```
+
 Finally, we run tilt from the `local` directory. The `Tiltfile` there gathers all the kubernetes objects from `local/generated`, and then goes through all YAML files in `local/additional`, and if any kubernetes objects conflict (same name and kind), the ones in `local/additional` are used instead. This allows you to manually overwrite generated manifests as needed without needing to commit the generated code or worry about your changes being overwritten after a new generate command. It also allows you to add arbitrary kubernetes manifests to your local deployment in addition to what's created by the generate command.
 
 This is all well and good, but for a full local deployment, we need two additional things:
-* the plugin built and deployed to `local/mounted-files/plugin`, and
-* the operator image built and pushed to the k3d registry
+
+- the plugin built and deployed to `local/mounted-files/plugin`, and
+- the operator image built and pushed to the k3d registry
 
 For the plugin, this can be done prior to setting up the local deployment if desired, or after it. If it is done after, keep in mind that the `grafana` container will be in a crash loop until the plugin is deployed. With the default makefile, you can deploy (or redeploy if you've made changes) the plugin with
+
 ```
 make local/deploy_plugin
 ```
+
 By hand, you can do it this way:
+
 ```
 cp -R plugin/dist local/mounted-files/plugin/dist
 ```
+
 If you _already_ have the plugin deployed and are redploying a new version, you'll need to disable the grafana deployment first, as you can't overwrite the backend binary while it's in-use (the make target does this automatically).
 
 For the operator image, this must be done _after_ the cluster is up, as there's no way to push an image to the k3d registry prior to that. Again, the default Makefile has a target for this:
+
 ```
 make local/push_operator
 ```
+
 To do this step manually, you'll need to first make sure your locally-built image is tagged with the `localhost/` prefix in the image name, as that's what the generated operator kubernetes deployment uses (the reason for this is twofold: to avoid confusion with production operator images of the same name, and to create seamless compatibility with docker or podman as tooling). If it isn't already called `localhost/<image name>:latest`, tag it with:
+
 ```
 docker tag "<image name>:latest" "localhost/<image name>:latest
 ```
+
 With that done, you can push it to the k3d registry with:
+
 ```
 sh local/scripts/push_image.sh "localhost/<image name>:latest"
 ```
+
 The `local/scripts/push_image.sh` script will work with any image you provide it as well, so if you need additional local images pushed to your local deployment for manifests in `local/additional`, this can be used for that, too.
 
 With those extra two steps done, you should now have a working local deployment.


### PR DESCRIPTION
:wave: 

Have a use case for configuring `GF_INSTALL_PLUGINS` for app o11y local dev env. This PR exposes it via local config `grafanaInstallPlugins` property.

Also it seems prettier went to town on local dev markdown file formatting a bit :/ let me know if it's an issue, happy to revert these changes