### PR TITLE
[App Manifest + Docs] Tutorial Doc Update for New Manifest, Associated Fixes

### DIFF
--- a/cmd/grafana-app-sdk/templates/manifest.cue.tmpl
+++ b/cmd/grafana-app-sdk/templates/manifest.cue.tmpl
@@ -7,9 +7,9 @@ manifest: {
 	// kinds is the list of kinds that your app defines and manages. If your app deals with kinds defined/managed
 	// by another app, use permissions.accessKinds to allow your app access
 	kinds: []
-	// permissions contains any additional permissions your app may require to function.
+	// extraPermissions contains any additional permissions your app may require to function.
 	// Your app will always have all permissions for each kind it manages (the items defined in 'kinds').
-	permissions: {
+	extraPermissions: {
 		// If your app needs access to additional kinds supplied by other apps, you can list them here
 		accessKinds: [
 			// Here is an example for your app accessing the playlist kind for reads and watch

--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -139,8 +139,8 @@ Kind: S={
 			// Fields must be from the root of the schema, i.e. 'spec.foo', and have a string type.
 			// Fields cannot include custom metadata (TODO: check if we can use annotations for field selectors)
 			selectableFields: [...string]
-			validation: #AdmissionCapability | *S.apiResource.validation
-			mutation: #AdmissionCapability | *S.apiResource.mutation
+			validation: #AdmissionCapability | *S.validation
+			mutation: #AdmissionCapability | *S.mutation
 			// additionalPrinterColumns is a list of additional columns to be printed in kubectl output
 			additionalPrinterColumns?: [...#AdditionalPrinterColumns]
 		}

--- a/codegen/jennies/backendplugin.go
+++ b/codegen/jennies/backendplugin.go
@@ -2,6 +2,7 @@ package jennies
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/grafana/codejen"
 
@@ -36,7 +37,7 @@ func (m *backendPluginMainGenerator) Generate(decls ...codegen.Kind) (*codejen.F
 	for _, decl := range decls {
 		tmd.Resources = append(tmd.Resources, decl.Properties())
 		if decl.Properties().Group != "" {
-			tmd.PluginID = decl.Properties().Group
+			tmd.PluginID = strings.Split(decl.Properties().Group, ".")[0]
 		}
 	}
 

--- a/codegen/testing/golden_generated/manifest/go/testkinds/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/manifest/go/testkinds/testapp_manifest.go.txt
@@ -33,14 +33,27 @@ var appManifestData = app.ManifestData{
 			Conversion: true,
 			Versions: []app.ManifestKindVersion{
 				{
-					Name:   "v1",
+					Name: "v1",
+					Admission: &app.AdmissionCapabilities{
+						Validation: &app.ValidationCapability{
+							Operations: []app.AdmissionOperation{
+								app.AdmissionOperationCreate,
+								app.AdmissionOperationUpdate,
+							},
+						},
+					},
 					Schema: &versionSchemaTestKindv1,
 				},
 
 				{
 					Name: "v2",
 					Admission: &app.AdmissionCapabilities{
-
+						Validation: &app.ValidationCapability{
+							Operations: []app.AdmissionOperation{
+								app.AdmissionOperationCreate,
+								app.AdmissionOperationUpdate,
+							},
+						},
 						Mutation: &app.MutationCapability{
 							Operations: []app.AdmissionOperation{
 								app.AdmissionOperationCreate,

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
@@ -10,6 +10,11 @@ spec:
           scope: Namespaced
           versions:
             - name: v1
+              admission:
+                validation:
+                    operations:
+                        - CREATE
+                        - UPDATE
               schema:
                 spec:
                     properties:
@@ -58,6 +63,10 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
             - name: v2
               admission:
+                validation:
+                    operations:
+                        - CREATE
+                        - UPDATE
                 mutation:
                     operations:
                         - CREATE

--- a/docs/tutorials/issue-tracker/01-project-init.md
+++ b/docs/tutorials/issue-tracker/01-project-init.md
@@ -19,20 +19,12 @@ go install github.com/grafana/grafana-app-sdk/cmd/grafana-app-sdk@latest
 If you're unfamiliar with `go install`, it's similar to `go get`, but will compile a binary for the `main` package in what it pulls, and put that in `$GOPATH/bin`. If you don't have `$GOPATH/bin` in your path, you will want to add it, otherwise the CLI commands won't work for you. You can check if the CLI was installed successfully with:
 You can then check if the install was successful by running.
 
-> [!NOTE]  
-> There is currently a [known issue with running go install](https://github.com/grafana/grafana-app-sdk/issues/189) for many versions. 
-> You can install locally with
-> ```shell
-> git clone git@github.com:grafana/grafana-app-sdk.git && cd grafana-app-sdk/cmd/grafana-app-sdk && go install 
-> ```
-> But be advised this will install the latest `main` commit. To install a specific version, use `git checkout <version>` before running `go install`.
->
-> Alternatively, you can install by running `make build` in the repository root, and copying `target/grafana-app-sdk` into your `PATH`.
-
-If you're not comfortable using `go install`, the [github releases page](https://github.com/grafana/grafana-app-sdk/releases) for the project includes a binary for each architecture per release. You can download the binary and add it to your `PATH` to use the SDK CLI the same way as if you used `go install`.
 ```shell
 grafana-app-sdk --help
 ```
+
+> [!NOTE]
+> If you're not comfortable using `go install`, the [github releases page](https://github.com/grafana/grafana-app-sdk/releases) for the project includes a binary for each architecture per release. You can download the binary and add it to your `PATH` to use the SDK CLI the same way as if you used `go install`.
 
 Now that we have the CLI installed, let's initialize our project. In this tutorial, we're going to use `github.com/grafana/issue-tracker-project` as our go module name, but you can use whatever name you like--it won't affect anything except some imports on code that we work on later.
 ```shell
@@ -44,6 +36,7 @@ $ grafana-app-sdk project init "github.com/grafana/issue-tracker-project"
  * Writing file go.mod
  * Writing file go.sum
  * Writing file kinds/cue.mod/module.cue
+ * Writing file kinds/manifest.cue
  * Writing file Makefile
  * Writing file local/config.yaml
  * Writing file local/scripts/cluster.sh
@@ -56,6 +49,10 @@ $ tree .
 │   └── operator
 ├── go.mod
 ├── go.sum
+├── kinds
+│   ├── cue.mod
+│   │   └── module.cue
+│   └── manifest.cue
 ├── local
 │   ├── Tiltfile
 │   ├── additional
@@ -66,12 +63,9 @@ $ tree .
 │       ├── cluster.sh
 │       └── push_image.sh
 ├── pkg
-├── plugin
-└── kinds
-    └── cue.mod
-        └── module.cue
+└── plugin
 
-12 directories, 8 files
+12 directories, 9 files
 ```
 
 As we can see from the command output, and the `tree` command, the `project init` command created a go module in the current directory, a Makefile, and several other directories. 

--- a/docs/tutorials/issue-tracker/02-defining-our-kinds.md
+++ b/docs/tutorials/issue-tracker/02-defining-our-kinds.md
@@ -22,8 +22,7 @@ package kinds
 
 issue: {
 	kind: "Issue"
-	group: "issue-tracker-project"
-	apiResource: {}
+	scope: "Namespaced"
 	codegen: {
 		frontend: true
 		backend: true
@@ -52,7 +51,7 @@ Now, we get to the actual definition of our `issue` model:
 ```cue
 issue: {
 	kind: "Issue"
-	apiResource: {}
+	scope: "Namespaced"
 	codegen: {
 		frontend: true
 		backend: true
@@ -63,13 +62,13 @@ issue: {
 ```
 Here we have a collection of metadata relating to our model, and then a `versions` definition, which we'll get to in a moment. Let's break down the other fields first:
 
-| Snippit                               | Meaning                                                                                                                                                                                                                                                                                                                               |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <nobr>`kind: "Issue"`</nobr>           | This is just the human-readable name, which will be used for naming some things in-code.                                                                                                                                                                                                                                              |
-| <nobr>`apiResource: {}`</nobr>         | This field is an indicator that the kind is expressible as an API Server resource (typically, a Custom Resource Definition). From a codegen perspective, that means that generated go code will be compatible with `resource`-package interfaces. There are fields that can be set within `apiResource`, but we're ok with its default values |
- | <nobr>`codegen.frontend: true`</nobr> | This instructs the CLI to generate front-end (TypeScript interfaces) code for our schema. This defaults to `true`, but we're specifying it here for clarity.                                                                                                                                                                          |
-| <nobr>`codegen.backend: true`</nobr>  | This instructs the CLI to generate back-end (go) code for our schema. This defaults to `true`, but we're specifying it here for clarity.                                                                                                                                                                                              |
-| <nobr>`currentVersion: [0,0]`</nobr>  | This is the current version of the Schema to use for codegen (will default to the latest if not present)                                                                                                                                                                                                                              |
+| Snippit                               | Meaning                                                                                                                                                                                                           |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <nobr>`kind: "Issue"`</nobr>          | This is just the human-readable name, which will be used for naming some things in-code.                                                                                                                          |
+| <nobr>`scope: "Namespaced"`</nobr>    | This is an optional field, which designates whether instances of the kind (resources) are created on a per-tenant basis (Namespaced) or globally (Cluster). It defaults to Namespaced if you leave the field out. |
+ | <nobr>`codegen.frontend: true`</nobr> | This instructs the CLI to generate front-end (TypeScript interfaces) code for our schema. This defaults to `true`, but we're specifying it here for clarity.                                                      |
+| <nobr>`codegen.backend: true`</nobr>  | This instructs the CLI to generate back-end (go) code for our schema. This defaults to `true`, but we're specifying it here for clarity.                                                                          |
+| <nobr>`current: "v1"`</nobr>          | This is the current version of the Schema to use for codegen.                                                                                                                                                     |
 
 ok, now back to `versions`. In the CUE kind, `versions` is a map of a version name to an object containing meta-information about the version, and its `schema`. 
 The map is unordered, so there is no implicit or explicit sequential relationship between versions in your Kind definition, but consider naming conventions that portray the evolution of the kind (for example, `v1`, `v1beta`, `v2`, etc. like kubernetes' kind versions). The `current` top-level Kind attribute declares which version in this map is the current, 

--- a/docs/tutorials/issue-tracker/03-generate-kind-code.md
+++ b/docs/tutorials/issue-tracker/03-generate-kind-code.md
@@ -1,10 +1,50 @@
 # Generating Kind Code
 
-Now that we have our kind and schema defined, we want to generate code from them that we can use. In the future, we'll want to re-generate this code whenever we change anything in our `kinds` directory. The SDK provides a command for this: `grafana-app-sdk generate`, but our project init also gave us a make target which will do the same thing, so you can run either. Here, I'm running the make target:
+Now that we have our kind and schema defined, we want to generate code from them that we can use. 
+To do this, we need to add the kind to our **manifest**. The manifest is information about our app, 
+including the kinds it provides. If we don't add our kind to the manifest, it isn't considered part of our app. 
+
+Our project init created a default manifest for us, found in `./kinds/manifest.cue`:
+```cue
+package kinds
+
+manifest: {
+	// appName is the unique name of your app. It is used to reference the app from other config objects,
+	// and to generate the group used by your app in the app platform API.
+	appName: "issue-tracker-project"
+	// kinds is the list of kinds that your app defines and manages. If your app deals with kinds defined/managed
+	// by another app, use permissions.accessKinds to allow your app access
+	kinds: []
+	// extraPermissions contains any additional permissions your app may require to function.
+	// Your app will always have all permissions for each kind it manages (the items defined in 'kinds').
+	extraPermissions: {
+		// If your app needs access to additional kinds supplied by other apps, you can list them here
+		accessKinds: [
+			// Here is an example for your app accessing the playlist kind for reads and watch
+			// {
+			//	group: "playlist.grafana.app"
+			//	resource: "playlists"
+			//	actions: ["get","list","watch"]
+			// }
+		]
+	}
+}
+```
+
+By default, the `appName` is the final part of our module path. We don't need to worry about `extraPermissions`, as our app doesn't need to work with any other apps' kinds. 
+However, right now, our `kinds` list is empty. To add our kind to the manifest, we just need to add the field name of our kind:
+```cue
+kinds: [issue]
+```
+
+> [!TIP]
+> If you add a new kind to your project with the command `grafana-app-sdk project kind add <KindName>`, it will automatically add it to the manifest as well
+
+In the future, we'll want to re-generate this code whenever we change anything in our `kinds` directory. The SDK provides a command for this: `grafana-app-sdk generate`, but our project init also gave us a make target which will do the same thing, so you can run either. Here, I'm running the make target:
 ```shell
 make generate
 ```
-This command should ouput a list of all the files it writes:
+This command should output a list of all the files it writes:
 ```shell
 $ make generate
  * Writing file pkg/generated/resource/issue/v1/issue_codec_gen.go
@@ -17,7 +57,9 @@ $ make generate
  * Writing file plugin/src/generated/issue/v1/types.metadata.gen.ts
  * Writing file plugin/src/generated/issue/v1/types.spec.gen.ts
  * Writing file plugin/src/generated/issue/v1/types.status.gen.ts
- * Writing file definitions/issue.issue-tracker-project.ext.grafana.com.json
+ * Writing file definitions/issue.issuetrackerproject.ext.grafana.com.json
+ * Writing file definitions/issue-tracker-project-manifest.json
+ * Writing file pkg/generated/issuetrackerproject_manifest.go
 ```
 That's a bunch of files written! Let's tree the directory to understand the structure a bit better.
 ```shell
@@ -27,13 +69,15 @@ $ tree .
 ├── cmd
 │   └── operator
 ├── definitions
-│   └── issue.issue-tracker-project.ext.grafana.com.json
+│   ├── issue-tracker-project-manifest.json
+│   └── issue.issuetrackerproject.ext.grafana.com.json
 ├── go.mod
 ├── go.sum
 ├── kinds
 │   ├── cue.mod
 │   │   └── module.cue
-│   └── issue.cue
+│   ├── issue.cue
+│   └── manifest.cue
 ├── local
 │   ├── Tiltfile
 │   ├── additional
@@ -45,6 +89,7 @@ $ tree .
 │       └── push_image.sh
 ├── pkg
 │   └── generated
+│       ├── issuetrackerproject_manifest.go
 │       └── resource
 │           └── issue
 │               └── v1
@@ -64,15 +109,11 @@ $ tree .
                     ├── types.spec.gen.ts
                     └── types.status.gen.ts
 
-21 directories, 20 files
+21 directories, 23 files
 ```
 
-So we can now see that all our generated go code lives in the `pkg/generated` package. Since our `target` was `"resource"`, the generated code for `issue` is in the `pkg/generated/resource` package. 
-Each `resource`-target kind then lives in a package defined by the name of the kind: in our case, that is `issue`. If we created another kind in our `kinds` directory called "foo", we'd see a `pkg/generated/resource/foo` directory.
-
-If we had a separate kind which didn't have the `apiResource` field, we'd see a `pkg/generated/models` package directory. We'll see that later, in our follow-up, where we extend on the project.
-
-Note that the go types are in versioned packages, as by default the SDK will generate types for each version of the kind.
+All of our generated go code lives in `pkg/generated`, and all the generated TypeScript lives in `plugin/src/generated`. 
+We also have some JSON files in `definitions`
 
 Note that we also have generated TypeScript in our previously-empty `plugin` directory. By convention, the Grafana plugin for your project will live in the `plugin` directory, so here we've got some TypeScript generated in `plugin/src/generated` to use when we start working on the front-end of our plugin.
 
@@ -85,6 +126,7 @@ Let's take a closer look at the list of files:
 ```shell
 $ tree pkg/generated
 pkg/generated
+├── issuetrackerproject_manifest.go
 └── resource
     └── issue
         └── v1
@@ -95,7 +137,7 @@ pkg/generated
             ├── issue_spec_gen.go
             └── issue_status_gen.go
 
-4 directories, 6 files
+4 directories, 7 files
 ```
 
 The exported go types from our kind's `v1` schema definition are `issue_spec_gen.go` and `issue_status_gen.go`. 
@@ -107,6 +149,10 @@ In addition to the types generated from our kind's schema, we have `issue_object
 Likewise, `issue_schema_gen.go` defines a `resource.Schema` for this specific version of the kind which can be used in your project, 
 in addition to a `resource.Kind` for the kind. Finally, `issue_codec_gen.go` contains code for a kubernetes-JSON-bytes<->Issue `Object` codec, 
 which is used by the `Kind` for marshaling and unmarshaling our Object when interacting with the API server.
+
+Finally, we have `issuetrackerproject_manifest.go` in the `pkg/generated` directory. This contains an in-code version of our manifest. 
+As we'll see a bit later, the manifest is also used in code to communicate app capabilities, so we have this in-code representation, 
+as well as an API server one.
 
 ## Generated TypeScript Code
 
@@ -135,12 +181,15 @@ Finally, we have the custom resource definition file that describes our `issue` 
 Note that this is a CRD of the kind, not just the schema, so the CRD will contain all schema versions in the kind. 
 This can be used to set up kubernetes as our storage layer for our project.
 
+We also have a manifest here, which will be used by the grafana API server in the future to register the app.
+
 ```shell
 $ tree definitions
 definitions
-└── issue.issue-tracker-project.ext.grafana.com.json
+├── issue-tracker-project-manifest.json
+└── issue.issuetrackerproject.ext.grafana.com.json
 
-1 directory, 1 file
+1 directory, 2 files
 ```
 
 So now we have a bunch of generated code, but we still need a project to actually use it in. 

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -46,43 +46,12 @@ Let's give our plugin an ID (I'm going to use `issue-tracker-project`, but you c
 ```shell
 grafana-app-sdk project component add frontend backend operator --plugin-id="issue-tracker-project"
 ```
-Just like with any other command that writes files, the output is a list of all written files:
+Just like with any other command that writes files, the output is a list of all written files, though the front-end files are created with `yarn` and are not listed.
 ```shell
 $ grafana-app-sdk project component add frontend backend operator --plugin-id="issue-tracker-project"
- * Writing file plugin/.config/.eslintrc
- * Writing file plugin/.config/.prettierrc.js
- * Writing file plugin/.config/Dockerfile
- * Writing file plugin/.config/README.md
- * Writing file plugin/.config/jest/mocks/react-inlinesvg.tsx
- * Writing file plugin/.config/jest/utils.js
- * Writing file plugin/.config/jest-setup.js
- * Writing file plugin/.config/jest.config.js
- * Writing file plugin/.config/tsconfig.json
- * Writing file plugin/.config/types/custom.d.ts
- * Writing file plugin/.config/webpack/constants.ts
- * Writing file plugin/.config/webpack/utils.ts
- * Writing file plugin/.config/webpack/webpack.config.ts
- * Writing file plugin/.eslintrc
- * Writing file plugin/.nvmrc
- * Writing file plugin/.prettierrc.js
- * Writing file plugin/CHANGELOG.md
- * Writing file plugin/LICENSE
- * Writing file plugin/README.md
- * Writing file plugin/jest-setup.js
- * Writing file plugin/jest.config.js
- * Writing file plugin/src/App.tsx
- * Writing file plugin/src/components/Routes/Routes.tsx
- * Writing file plugin/src/components/Routes/index.tsx
- * Writing file plugin/src/module.ts
- * Writing file plugin/src/pages/index.tsx
- * Writing file plugin/src/pages/main.tsx
- * Writing file plugin/src/types.ts
- * Writing file plugin/src/utils/utils.plugin.ts
- * Writing file plugin/src/utils/utils.routing.ts
- * Writing file plugin/tsconfig.json
+Creating plugin frontend using `yarn create @grafana/plugin` (this may take a moment)...
  * Writing file plugin/src/plugin.json
  * Writing file plugin/src/constants.ts
- * Writing file plugin/package.json
  * Writing file plugin/pkg/main.go
  * Writing file pkg/plugin/handler_issue.go
  * Writing file pkg/plugin/plugin.go
@@ -98,64 +67,79 @@ $ grafana-app-sdk project component add frontend backend operator --plugin-id="i
  * Writing file pkg/watchers/watcher_issue.go
  * Writing file cmd/operator/Dockerfile
 ```
-Wow, that's a lot more files written out than in our Kind codegen. Let's take a look at the tree to get a better picture of everything:
+Let's take a look at the tree to get a better picture of everything:
 ```shell
 $ tree -I "generated|definitions|kinds|local" .
 .
 ├── Makefile
 ├── cmd
-│   └── operator
-│       ├── Dockerfile
-│       ├── config.go
-│       ├── kubeconfig.go
-│       └── main.go
+│   └── operator
+│       ├── Dockerfile
+│       ├── config.go
+│       ├── kubeconfig.go
+│       └── main.go
 ├── go.mod
 ├── go.sum
 ├── pkg
-│   ├── app
-│   │   └── app.go
-│   ├── plugin
-│   │   ├── handler_issue.go
-│   │   ├── plugin.go
-│   │   └── secure
-│   │       ├── data.go
-│   │       ├── middleware.go
-│   │       └── retriever.go
-│   └── watchers
-│       ├── watcher_foo.go
-│       └── watcher_issue.go
+│   ├── app
+│   │   └── app.go
+│   ├── plugin
+│   │   ├── handler_issue.go
+│   │   ├── plugin.go
+│   │   └── secure
+│   │       ├── data.go
+│   │       ├── middleware.go
+│   │       └── retriever.go
+│   └── watchers
+│       └── watcher_issue.go
 └── plugin
     ├── CHANGELOG.md
     ├── LICENSE
     ├── Magefile.go
     ├── README.md
+    ├── docker-compose.yaml
     ├── jest-setup.js
     ├── jest.config.js
     ├── package.json
     ├── pkg
-    │   └── main.go
+    │   └── main.go
+    ├── playwright.config.ts
+    ├── provisioning
+    │   └── plugins
+    │       ├── README.md
+    │       └── apps.yaml
     ├── src
-    │   ├── App.tsx
-    │   ├── components
-    │   │   └── Routes
-    │   │       ├── Routes.tsx
-    │   │       └── index.tsx
-    │   ├── constants.ts
-    │   ├── module.ts
-    │   ├── pages
-    │   │   ├── index.tsx
-    │   │   └── main.tsx
-    │   ├── plugin.json
-    │   ├── types.ts
-    │   └── utils
-    │       ├── utils.plugin.ts
-    │       └── utils.routing.ts
+    │   ├── README.md
+    │   ├── components
+    │   │   ├── App
+    │   │   │   ├── App.test.tsx
+    │   │   │   └── App.tsx
+    │   │   ├── AppConfig
+    │   │   │   ├── AppConfig.test.tsx
+    │   │   │   └── AppConfig.tsx
+    │   │   └── testIds.ts
+    │   ├── constants.ts
+    │   ├── img
+    │   │   └── logo.svg
+    │   ├── module.tsx
+    │   ├── pages
+    │   │   ├── PageFour.tsx
+    │   │   ├── PageOne.tsx
+    │   │   ├── PageThree.tsx
+    │   │   └── PageTwo.tsx
+    │   ├── plugin.json
+    │   └── utils
+    │       └── utils.routing.ts
+    ├── tests
+    │   ├── appConfig.spec.ts
+    │   ├── appNavigation.spec.ts
+    │   └── fixtures.ts
     └── tsconfig.json
 
-15 directories, 35 files
+20 directories, 45 files
 ```
 
-Excluding our previously-generated files, we can see that we have a few new go packages (`pkg/watchers`, `pkg/plugin`, and `pkg/plugin/secure`), some go files and a Dockerfile in `cmd/operator`, and a bunch of new stuff in the `plugin` directory.
+Excluding our previously-generated files, we can see that we have a few new go packages (`pkg/app`, `pkg/watchers`, `pkg/plugin`, and `pkg/plugin/secure`), some go files and a Dockerfile in `cmd/operator`, and a bunch of new stuff in the `plugin` directory.
 
 If we had split up our `project add` into `project add backend`, we'd only get our generated go files in `pkg/plugin`, `project add frontend` would only give us the non-`plugin/pkg` plugin files, and `project add operator` would give us the `pkg/watchers` and `cmd/operator` files. As we can see, none of these `project add` components have overlapping code, which is deliberate. If you prefer to not use boilerplate for a given component, you can simply not add it and not worry that another component will depend on boilerplate from it.
 
@@ -318,37 +302,53 @@ plugin
 ├── LICENSE
 ├── Magefile.go
 ├── README.md
+├── docker-compose.yaml
 ├── jest-setup.js
 ├── jest.config.js
 ├── package.json
 ├── pkg
 │   └── main.go
+├── playwright.config.ts
+├── provisioning
+│   └── plugins
+│       ├── README.md
+│       └── apps.yaml
 ├── src
-│   ├── App.tsx
+│   ├── README.md
 │   ├── components
-│   │   └── Routes
-│   │       ├── Routes.tsx
-│   │       └── index.tsx
+│   │   ├── App
+│   │   │   ├── App.test.tsx
+│   │   │   └── App.tsx
+│   │   ├── AppConfig
+│   │   │   ├── AppConfig.test.tsx
+│   │   │   └── AppConfig.tsx
+│   │   └── testIds.ts
 │   ├── constants.ts
 │   ├── generated
 │   │   └── issue
 │   │       └── v1
-│   │           └── issue_object_gen.ts
-│   │           └── types.metadata.gen.ts
-│   │           └── types.spec.gen.ts
+│   │           ├── issue_object_gen.ts
+│   │           ├── types.metadata.gen.ts
+│   │           ├── types.spec.gen.ts
 │   │           └── types.status.gen.ts
-│   ├── module.ts
+│   ├── img
+│   │   └── logo.svg
+│   ├── module.tsx
 │   ├── pages
-│   │   ├── index.tsx
-│   │   └── main.tsx
+│   │   ├── PageFour.tsx
+│   │   ├── PageOne.tsx
+│   │   ├── PageThree.tsx
+│   │   └── PageTwo.tsx
 │   ├── plugin.json
-│   ├── types.ts
 │   └── utils
-│       ├── utils.plugin.ts
 │       └── utils.routing.ts
+├── tests
+│   ├── appConfig.spec.ts
+│   ├── appNavigation.spec.ts
+│   └── fixtures.ts
 └── tsconfig.json
 
-10 directories, 21 files
+15 directories, 35 files
 ```
 We can also safely _ignore_ a lot of this generation. If you create a grafana plugin, there's a certain amount of metadata that needs to be created, and, likewise, when you create a react app (which front-end plugins are), there's some other data that needs to exist. So basically everything in the root `plugin` directory is something we can ignore for the moment, as it's just things telling either grafana how to handle this app, or react how to compile it. But, as a quick breakdown, here's what each file does that we're going to ignore:
 
@@ -365,44 +365,33 @@ That leaves us with just our varying TypeScript files.
 
 ### Pages
 
-`pages/` contains the acual front-end pages to be displayed for the app. `main.tsx` is your main plugin page, which by default just contains a simple statement declaring it your main landing page:
+`pages/` contains the actual front-end pages to be displayed for the app. `PageOne.tsx` is your main plugin page, which by default just contains a simple statement declaring it your main landing page:
 
 ```TypeScript
-export const MainPage = () => {
-  useStyles2(getStyles);
+function PageOne() {
+    const s = useStyles2(getStyles);
 
-  return (
-      <div>
-        <h1>Main Landing Page</h1>
-        <div>This is your main landing page</div>
-      </div>
-  );
-};
+    return (
+        <PluginPage>
+            <div data-testid={testIds.pageOne.container}>
+            This is page one.
+    <div className={s.marginTop}>
+    <LinkButton data-testid={testIds.pageOne.navigateToFour} href={prefixRoute(ROUTES.Four)}>
+    Full-width page example
+    </LinkButton>
+    </div>
+    </div>
+    </PluginPage>
+);
+}
 ```
+There are other pages generated here as examples from the output of `yarn create @grafana/plugin`. The routing for these pages is in `components/App/App.tsx`.
 
 `MainPage` is used by the router when displaying pages--you can add more by creating other exported functions and registering them in the router.
 
-### Router
+### Components
 
-`components/Routes/Router.tsx` contains the router for your app frontend. By default only the `MainPage` is routed, and matches any path:
-```TypeScript
-export const Routes = () => {
-  useNavigation();
-
-  return (
-    <Switch>
-      <Route exact path={prefixRoute(ROUTES.Main)} component={MainPage} />
-
-      {/* Default page */}
-      <Route exact path="*">
-        <Redirect to={prefixRoute(ROUTES.Main)} />
-      </Route>
-    </Switch>
-  );
-};
-```
-
-`ROUTES.Main` is a constant pulled from `constants.ts`. `useNavigation` and `prefixRoute` are pulled from `utils`.
+`components` contains your front-end App declaration and AppConfig.
 
 ### Types
 

--- a/docs/tutorials/issue-tracker/06-frontend.md
+++ b/docs/tutorials/issue-tracker/06-frontend.md
@@ -17,9 +17,9 @@ The client uses grafana libraries to make fetch requests to perform relevent act
 ## Main Page
 
 We already have a very empty generated main page located at `plugin/src/pages/main.tsx`. We're going to overwrite all of this with new contents. 
-Either copy [the contents of this file](frontend-files/main.tsx) into `plugin/src/pages/main.tsx` (overwriting the current contents), or do it with curl:
+Either copy [the contents of this file](frontend-files/main.tsx) into `plugin/src/pages/PageOne.tsx` (overwriting the current contents), or do it with curl:
 ```bash
-curl -o plugin/src/pages/main.tsx https://raw.githubusercontent.com/grafana/grafana-app-sdk/main/docs/tutorials/issue-tracker/frontend-files/main.tsx
+curl -o plugin/src/pages/PageOne.tsx https://raw.githubusercontent.com/grafana/grafana-app-sdk/main/docs/tutorials/issue-tracker/frontend-files/main.tsx
 ```
 
 We've now updated the main page to display a list of our `Issue` resources, with some basic options.

--- a/docs/tutorials/issue-tracker/cue/issue-v1.cue
+++ b/docs/tutorials/issue-tracker/cue/issue-v1.cue
@@ -8,21 +8,11 @@ issue: {
 	// The human-readable plural form of the "name" field.
 	// Will default to <name>+"s" if not present.
 	pluralName: "Issues"
-	// Group determines the grouping of the kind in the API server and elsewhere.
-	// This is typically the same root as the plugin ID.
-	group: "issue-tracker-project"
-	// apiResource is a field that indicates to the codegen, and to the CUE kind system (kindsys), that this is a kind
-	// which can be expressed as an API Server resource (Custom Resource Definition or otherwise).
-	// When present, it also imposes certain generation and runtime restrictions on the form of the kind's schema(s).
-	// It can be left as an empty object, or the fields can be populated, as we do below,
-	// to either be explicit or use non-default values (here we ware being explicit about the fields).
-	apiResource: {
-		// [OPTIONAL]
-		// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
-		// "Namespaced" kinds have resources which live in specific namespaces, whereas
-		// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
-		scope: "Namespaced"
-	}
+	// [OPTIONAL]
+	// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
+	// "Namespaced" kinds have resources which live in specific namespaces, whereas
+	// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
+	scope: "Namespaced"
 	// Current is the current version of the Schema.
 	current: "v1"
 	// Codegen is an object which provides information to the codegen tooling about what sort of code you want generated.

--- a/docs/tutorials/issue-tracker/cue/issue-v2.cue
+++ b/docs/tutorials/issue-tracker/cue/issue-v2.cue
@@ -10,21 +10,11 @@ issue: {
 	// The human-readable plural form of the "name" field.
 	// Will default to <name>+"s" if not present.
 	pluralName: "Issues"
-	// Group determines the grouping of the kind in the API server and elsewhere.
-	// This is typically the same root as the plugin ID.
-	group: "issue-tracker-project"
-	// apiResource is a field that indicates to the codegen, and to the CUE kind system (kindsys), that this is a kind
-	// which can be expressed as an API Server resource (Custom Resource Definition or otherwise).
-	// When present, it also imposes certain generation and runtime restrictions on the form of the kind's schema(s).
-	// It can be left as an empty object, or the fields can be populated, as we do below,
-	// to either be explicit or use non-default values (here we ware being explicit about the fields).
-	apiResource: {
-		// [OPTIONAL]
-		// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
-		// "Namespaced" kinds have resources which live in specific namespaces, whereas
-		// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
-		scope: "Namespaced"
-	}
+	// [OPTIONAL]
+	// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
+	// "Namespaced" kinds have resources which live in specific namespaces, whereas
+	// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
+	scope: "Namespaced"
 	// Current is the current version of the Schema.
 	current: "v1"
 	// Codegen is an object which provides information to the codegen tooling about what sort of code you want generated.

--- a/docs/tutorials/issue-tracker/cue/issue-v3.cue
+++ b/docs/tutorials/issue-tracker/cue/issue-v3.cue
@@ -10,24 +10,14 @@ issue: {
 	// The human-readable plural form of the "name" field.
 	// Will default to <name>+"s" if not present.
 	pluralName: "Issues"
-	// Group determines the grouping of the kind in the API server and elsewhere.
-	// This is typically the same root as the plugin ID.
-	group: "issue-tracker-project"
-	// apiResource is a field that indicates to the codegen, and to the CUE kind system (kindsys), that this is a kind
-	// which can be expressed as an API Server resource (Custom Resource Definition or otherwise).
-	// When present, it also imposes certain generation and runtime restrictions on the form of the kind's schema(s).
-	// It can be left as an empty object, or the fields can be populated, as we do below,
-	// to either be explicit or use non-default values (here we ware being explicit about the fields).
-	apiResource: {
-		// [OPTIONAL]
-		// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
-		// "Namespaced" kinds have resources which live in specific namespaces, whereas
-		// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
-		scope: "Namespaced"
-		// Validation is used when generating the manifest to indicate support for validating admission control
-		// for this kind. Here, we list that we want to do validation for CREATE and UPDATE operations.
-		validation: operations: ["CREATE","UPDATE"]
-	}
+	// [OPTIONAL]
+	// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
+	// "Namespaced" kinds have resources which live in specific namespaces, whereas
+	// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
+	scope: "Namespaced"
+	// Validation is used when generating the manifest to indicate support for validating admission control
+	// for this kind. Here, we list that we want to do validation for CREATE and UPDATE operations.
+	validation: operations: ["CREATE","UPDATE"]
 	// Current is the current version of the Schema.
 	current: "v1"
 	// Codegen is an object which provides information to the codegen tooling about what sort of code you want generated.

--- a/docs/tutorials/issue-tracker/cue/issue-v4.cue
+++ b/docs/tutorials/issue-tracker/cue/issue-v4.cue
@@ -10,27 +10,17 @@ issue: {
 	// The human-readable plural form of the "name" field.
 	// Will default to <name>+"s" if not present.
 	pluralName: "Issues"
-	// Group determines the grouping of the kind in the API server and elsewhere.
-	// This is typically the same root as the plugin ID.
-	group: "issue-tracker-project"
-	// apiResource is a field that indicates to the codegen, and to the CUE kind system (kindsys), that this is a kind
-	// which can be expressed as an API Server resource (Custom Resource Definition or otherwise).
-	// When present, it also imposes certain generation and runtime restrictions on the form of the kind's schema(s).
-	// It can be left as an empty object, or the fields can be populated, as we do below,
-	// to either be explicit or use non-default values (here we ware being explicit about the fields).
-	apiResource: {
-		// [OPTIONAL]
-		// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
-		// "Namespaced" kinds have resources which live in specific namespaces, whereas
-		// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
-		scope: "Namespaced"
-		// Validation is used when generating the manifest to indicate support for validating admission control
-		// for this kind. Here, we list that we want to do validation for CREATE and UPDATE operations.
-		validation: operations: ["CREATE","UPDATE"]
-		// Validation is used when generating the manifest to indicate support for mutating admission control
-		// for this kind. Here, we list that we want to do mutation for CREATE and UPDATE operations.
-		mutation: operations: ["CREATE","UPDATE"]
-	}
+	// [OPTIONAL]
+	// Scope is the scope of the API server resource, limited to "Namespaced" (default), or "Cluster"
+	// "Namespaced" kinds have resources which live in specific namespaces, whereas
+	// "Cluster" kinds' resources all exist in a global namespace and cannot be localized to a single one.
+	scope: "Namespaced"
+	// Validation is used when generating the manifest to indicate support for validating admission control
+	// for this kind. Here, we list that we want to do validation for CREATE and UPDATE operations.
+	validation: operations: ["CREATE","UPDATE"]
+	// Validation is used when generating the manifest to indicate support for mutating admission control
+	// for this kind. Here, we list that we want to do mutation for CREATE and UPDATE operations.
+	mutation: operations: ["CREATE","UPDATE"]
 	// Current is the current version of the Schema.
 	current: "v1"
 	// Codegen is an object which provides information to the codegen tooling about what sort of code you want generated.

--- a/docs/tutorials/issue-tracker/frontend-files/issue-client.ts
+++ b/docs/tutorials/issue-tracker/frontend-files/issue-client.ts
@@ -1,7 +1,6 @@
 import { Issue } from '../generated/issue/v1/issue_object_gen';
 import { BackendSrvRequest, getBackendSrv, FetchResponse } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
-import { PLUGIN_API_URL } from '../constants';
 
 export interface ListResponse<T> {
     items: T[];
@@ -11,11 +10,13 @@ export class IssueClient {
     apiEndpoint: string
 
     constructor() {
-        this.apiEndpoint = PLUGIN_API_URL + '/issues';
+        this.apiEndpoint = '/apis/issuetrackerproject.ext.grafana.com/v1/namespaces/default/issues';
     }
 
     async create(title: string, description: string): Promise<FetchResponse<Issue>> {
         let issue = {
+            kind: 'Issue',
+            apiVersion: 'issuetrackerproject.ext.grafana.com/v1',
             spec: {
                 title: title,
                 description: description,
@@ -27,7 +28,9 @@ export class IssueClient {
             }
         }
         const options: BackendSrvRequest = {
-            headers: {},
+            headers: {
+                'content-type':'application/json',
+            },
             method: 'POST',
             url: this.apiEndpoint,
             data: JSON.stringify(issue),
@@ -71,7 +74,9 @@ export class IssueClient {
 
     async update(name: string, updated: Issue): Promise<FetchResponse<Issue>> {
         const options: BackendSrvRequest = {
-            headers: {},
+            headers: {
+                'content-type':'application/json',
+            },
             method: 'PUT',
             url: this.apiEndpoint + '/' + name,
             data: JSON.stringify(updated),

--- a/docs/tutorials/issue-tracker/frontend-files/main.tsx
+++ b/docs/tutorials/issue-tracker/frontend-files/main.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { css } from '@emotion/css';
 import { useForm } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
@@ -6,6 +6,7 @@ import { useStyles2, Button, IconButton, Field, Input, Card, TagList } from '@gr
 import { IssueClient } from '../api/issue_client';
 import { Issue } from '../generated/issue/v1/issue_object_gen';
 import { useState, useEffect } from 'react';
+import { PluginPage } from '@grafana/runtime';
 
 // This is used for the create new issue form
 type ReactHookFormProps = {
@@ -13,10 +14,8 @@ type ReactHookFormProps = {
     description: string;
 };
 
-
-// MainPage is the main (and only) page of the plugin, where issues are listed, and can be created, updated, or deleted
-export const MainPage = () => {
-    useStyles2(getStyles);
+function PageOne() {
+    const s = useStyles2(getStyles);
 
     let issues: Issue[] = [];
     const [issuesData, setIssuesData] = useState(issues);
@@ -49,7 +48,7 @@ export const MainPage = () => {
     };
 
     const updateStatus = async (issue: Issue, newStatus: string) => {
-    issue.spec.status = newStatus;
+        issue.spec.status = newStatus;
         await ic.update(issue.metadata.name, issue);
         await listIssues();
     }
@@ -57,11 +56,11 @@ export const MainPage = () => {
 
     // Form handling
     const { handleSubmit, register } = useForm<ReactHookFormProps>({
-    mode: 'onChange',
-    defaultValues: {
-        title: '',
-        description: '',
-    },
+        mode: 'onChange',
+        defaultValues: {
+            title: '',
+            description: '',
+        },
     });
 
     const handleCreate = handleSubmit((issue) => {
@@ -72,16 +71,16 @@ export const MainPage = () => {
     const getActions = (issue: Issue) => {
         if(issue.spec.status === 'open') {
             return (
-            <Card.Actions>
-                <Button key="mark-in-progress" onClick={() => {updateStatus(issue, 'in_progress')}}>Start Progress</Button>
-            </Card.Actions>
+                <Card.Actions>
+                    <Button key="mark-in-progress" onClick={() => {updateStatus(issue, 'in_progress')}}>Start Progress</Button>
+                </Card.Actions>
             )
         } else if(issue.spec.status === 'in_progress') {
             return (
-            <Card.Actions>
-                <Button key="mark-open" onClick={() => {updateStatus(issue, 'open')}}>Stop Progress</Button>
-                <Button key="mark-closed" onClick={() => {updateStatus(issue, 'closed')}}>Complete</Button>
-            </Card.Actions>
+                <Card.Actions>
+                    <Button key="mark-open" onClick={() => {updateStatus(issue, 'open')}}>Stop Progress</Button>
+                    <Button key="mark-closed" onClick={() => {updateStatus(issue, 'closed')}}>Complete</Button>
+                </Card.Actions>
             )
         } else {
             return <Card.Actions></Card.Actions>
@@ -89,57 +88,60 @@ export const MainPage = () => {
     }
 
     return (
-    <div>
-        <h1>Issue list</h1>
-        {issuesData.length > 0 && (
-        <ul>
-            {issuesData.map((issue: any) => (
-            <li key={issue.metadata.name}>
-                <Card>
-                <Card.Heading>{issue.spec.title}</Card.Heading>
-                <Card.Description>{issue.spec.description}</Card.Description>
-                <Card.Tags>
-                    <TagList tags={[issue.spec.status]} />
-                </Card.Tags>
-                { getActions(issue) }
-                <Card.SecondaryActions>
-                    <IconButton
-                    key="delete-issue"
-                    name="trash-alt"
-                    size={'md'}
-                    aria-label="delete-issue"
-                    onClick={() => {
-                        deleteIssue(issue.metadata.name);
-                    }}
-                    >
-                    Delete
-                    </IconButton>
-                </Card.SecondaryActions>
-                </Card>
-            </li>
-            ))}
-        </ul>
-        )}
-        <br />
-        <h1>Create New Issue</h1>
-        <form onSubmit={handleCreate}>
-        <Field label="Issue Title">
-            <Input type="text" aria-label="issue title" id="title" {...register('title')} />
-        </Field>
-        <Field label="Issue Description">
-            <Input type="text" aria-label="issue description" id="description" {...register('description')} />
-        </Field>
-        <Button type="submit" aria-label="Create Issue">
-            Create
-        </Button>
-        </form>
-    </div>
+        <PluginPage>
+            <div>
+                <h1>Issue list</h1>
+                {issuesData.length > 0 && (
+                    <ul>
+                        {issuesData.map((issue: any) => (
+                            <li key={issue.metadata.name}>
+                                <Card>
+                                    <Card.Heading>{issue.spec.title}</Card.Heading>
+                                    <Card.Description>{issue.spec.description}</Card.Description>
+                                    <Card.Tags>
+                                        <TagList tags={[issue.spec.status]} />
+                                    </Card.Tags>
+                                    { getActions(issue) }
+                                    <Card.SecondaryActions>
+                                        <IconButton
+                                            key="delete-issue"
+                                            name="trash-alt"
+                                            size={'md'}
+                                            aria-label="delete-issue"
+                                            onClick={() => {
+                                                deleteIssue(issue.metadata.name);
+                                            }}
+                                        >
+                                            Delete
+                                        </IconButton>
+                                    </Card.SecondaryActions>
+                                </Card>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+                <br />
+                <h1>Create New Issue</h1>
+                <form onSubmit={handleCreate}>
+                    <Field label="Issue Title">
+                        <Input type="text" aria-label="issue title" id="title" {...register('title')} />
+                    </Field>
+                    <Field label="Issue Description">
+                        <Input type="text" aria-label="issue description" id="description" {...register('description')} />
+                    </Field>
+                    <Button type="submit" aria-label="Create Issue">
+                        Create
+                    </Button>
+                </form>
+            </div>
+        </PluginPage>
     );
-};
+}
 
+export default PageOne;
 
 const getStyles = (theme: GrafanaTheme2) => ({
     marginTop: css`
     margin-top: ${theme.spacing(2)};
-    `,
+  `,
 });

--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/grafana-app-sdk/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/codes"
 	"k8s.io/utils/strings/slices"
 
@@ -44,6 +46,7 @@ type OpinionatedWatcher struct {
 	finalizer  string
 	schema     resource.Schema
 	client     PatchClient
+	collectors []prometheus.Collector
 }
 
 // FinalizerSupplier represents a function that creates string finalizer from provider schema.
@@ -72,9 +75,10 @@ func NewOpinionatedWatcherWithFinalizer(sch resource.Schema, client PatchClient,
 		return nil, fmt.Errorf("finalizer length cannot exceed 63 chars: %s", finalizer)
 	}
 	return &OpinionatedWatcher{
-		client:    client,
-		schema:    sch,
-		finalizer: finalizer,
+		client:     client,
+		schema:     sch,
+		finalizer:  finalizer,
+		collectors: make([]prometheus.Collector, 0),
 	}, nil
 }
 
@@ -91,6 +95,10 @@ func (o *OpinionatedWatcher) Wrap(watcher ResourceWatcher, syncToAdd bool) { // 
 	o.DeleteFunc = watcher.Delete
 	if syncToAdd {
 		o.SyncFunc = watcher.Add
+	}
+
+	if cast, ok := watcher.(metrics.Provider); ok {
+		o.collectors = append(o.collectors, cast.PrometheusCollectors()...)
 	}
 }
 
@@ -265,6 +273,10 @@ func (o *OpinionatedWatcher) Update(ctx context.Context, old resource.Object, ne
 func (*OpinionatedWatcher) Delete(context.Context, resource.Object) error {
 	// Do nothing here, because we add finalizers, so we actually call delete code on updates/add-sync
 	return nil
+}
+
+func (o *OpinionatedWatcher) PrometheusCollectors() []prometheus.Collector {
+	return o.collectors
 }
 
 // addFunc is a wrapper for AddFunc which makes a nil check to avoid panics

--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/grafana-app-sdk/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/codes"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/metrics"
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 


### PR DESCRIPTION
Update the tutorial doc based on the changes from https://github.com/grafana/grafana-app-sdk/pull/483 and https://github.com/grafana/grafana-app-sdk/pull/491. Running through the tutorial again ran into a few bugs that this PR also resolves:
* The template kind used `permissions` instead of `extraPermissions`
* The default plugin name uses the full group, which contains `.` and is invalid. Fixed to use only the appName portion
* The updated kind in `cue.def` still had a reference to `apiResource` in the version map for inheriting validation/mutation, fixed to not use apiResource
* Prometheus metrics for watchers cannot be exposed in the `simple.App` design as they can for `simple.Operator`, updated `operator.OpinionatedWatcher` to expose metrics from wrapped watchers, and a method to `simple.App` to allow exposing arbitrary prometheus collectors to the runner.

The tutorial front-end has also been updated to use the grafana API server, rather than the plugin back-end. The plugin back-end will be phased out of the tutorial entirely in the near future.