### PR TITLE
[operator] Clean up New functions

### DIFF
--- a/examples/operator/opinionated/reconciler/main.go
+++ b/examples/operator/opinionated/reconciler/main.go
@@ -99,7 +99,7 @@ func main() {
 	informerController := operator.NewInformerController(operator.DefaultInformerControllerConfig())
 
 	// Create an informer for the schema to watch all namespaces.
-	informer, err := operator.NewKubernetesBasedInformer(kind, client, "")
+	informer, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{})
 	if err != nil {
 		panic(fmt.Errorf("unable to create controller: %w", err))
 	}

--- a/examples/operator/opinionated/watcher/main.go
+++ b/examples/operator/opinionated/watcher/main.go
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	// Create an informer for the schema to watch all namespaces.
-	informer, err := operator.NewKubernetesBasedInformer(kind, client, "")
+	informer, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{})
 	if err != nil {
 		panic(fmt.Errorf("unable to create controller: %w", err))
 	}

--- a/operator/informer_customcache.go
+++ b/operator/informer_customcache.go
@@ -46,25 +46,26 @@ type CustomCacheInformer struct {
 	runContext        context.Context
 }
 
-// NewMemcachedInformer creates a new CustomCacheInformer which uses memcached as its custom cache.
-// This is analogous to calling NewCustomCacheInformer with a MemcachedStore as the store.
-func NewMemcachedInformer(kind resource.Kind, client ListWatchClient, namespace string, addrs ...string) (*CustomCacheInformer, error) {
-	return NewMemcachedInformerWithFilters(kind, client, ListWatchOptions{Namespace: namespace}, addrs...)
+type MemcachedInformerOptions struct {
+	Addrs            []string
+	ListWatchOptions ListWatchOptions
 }
 
-// NewMemcachedInformerWithFilters creates a new CustomCacheInformer which uses memcached as its custom cache.
-// This is analogous to calling NewCustomCacheInformer with a MemcachedStore as the store.
-func NewMemcachedInformerWithFilters(kind resource.Kind, client ListWatchClient, filterOptions ListWatchOptions, addrs ...string) (*CustomCacheInformer, error) {
+// NewMemcachedInformer creates a new CustomCacheInformer which uses memcached as its custom cache.
+// This is analogous to calling NewCustomCacheInformer with a MemcachedStore as the store, using the default memcached options.
+// To set additional memcached options, use NewCustomCacheInformer and NewMemcachedStore.
+func NewMemcachedInformer(kind resource.Kind, client ListWatchClient, opts MemcachedInformerOptions) (*CustomCacheInformer, error) {
 	c, err := NewMemcachedStore(kind, MemcachedStoreConfig{
-		Addrs: addrs,
+		Addrs: opts.Addrs,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return NewCustomCacheInformer(c, NewListerWatcher(client, kind, filterOptions), kind), nil
+	return NewCustomCacheInformer(c, NewListerWatcher(client, kind, opts.ListWatchOptions), kind), nil
 }
 
 // NewCustomCacheInformer returns a new CustomCacheInformer using the provided cache.Store and cache.ListerWatcher.
+// To use ListWatchOptions, use NewListerWatcher to get a cache.ListerWatcher.
 func NewCustomCacheInformer(store cache.Store, lw cache.ListerWatcher, kind resource.Kind) *CustomCacheInformer {
 	return &CustomCacheInformer{
 		store:         store,

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -24,6 +24,7 @@ type KubernetesBasedInformer struct {
 }
 
 type KubernetesBasedInformerOptions struct {
+	// ListWatchOptions are the options for filtering the watch based on namespace and other compatible filters.
 	ListWatchOptions ListWatchOptions
 	// CacheResyncInterval is the interval at which the informer will emit CacheResync events for all resources in the cache.
 	// This is distinct from a full resync, as no information is fetched from the API server.
@@ -31,18 +32,9 @@ type KubernetesBasedInformerOptions struct {
 	CacheResyncInterval time.Duration
 }
 
-// NewKubernetesBasedInformer creates a new KubernetesBasedInformer for the provided schema and namespace,
-// using the ListWatchClient provided to do its List and Watch requests.
-func NewKubernetesBasedInformer(sch resource.Kind, client ListWatchClient, namespace string) (
-	*KubernetesBasedInformer, error) {
-	return NewKubernetesBasedInformerWithFilters(sch, client, KubernetesBasedInformerOptions{
-		ListWatchOptions: ListWatchOptions{Namespace: namespace},
-	})
-}
-
-// NewKubernetesBasedInformerWithFilters creates a new KubernetesBasedInformer for the provided schema and namespace,
+// NewKubernetesBasedInformer creates a new KubernetesBasedInformer for the provided kind and options,
 // using the ListWatchClient provided to do its List and Watch requests applying provided labelFilters if it is not empty.
-func NewKubernetesBasedInformerWithFilters(sch resource.Kind, client ListWatchClient, options KubernetesBasedInformerOptions) (
+func NewKubernetesBasedInformer(sch resource.Kind, client ListWatchClient, options KubernetesBasedInformerOptions) (
 	*KubernetesBasedInformer, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client cannot be nil")

--- a/simple/app.go
+++ b/simple/app.go
@@ -339,7 +339,7 @@ func (a *App) watchKind(kind AppUnmanagedKind) error {
 		if err != nil {
 			return err
 		}
-		inf, err := operator.NewKubernetesBasedInformerWithFilters(kind.Kind, client, operator.KubernetesBasedInformerOptions{
+		inf, err := operator.NewKubernetesBasedInformer(kind.Kind, client, operator.KubernetesBasedInformerOptions{
 			ListWatchOptions: operator.ListWatchOptions{
 				Namespace:      kind.ReconcileOptions.Namespace,
 				LabelFilters:   kind.ReconcileOptions.LabelFilters,

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -205,7 +205,7 @@ func (o *Operator) WatchKind(kind resource.Kind, watcher SyncWatcher, options op
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformerWithFilters(kind, client, operator.KubernetesBasedInformerOptions{
+	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{
 		ListWatchOptions:    operator.ListWatchOptions{Namespace: options.Namespace, LabelFilters: options.LabelFilters, FieldSelectors: options.FieldSelectors},
 		CacheResyncInterval: o.cacheResyncInterval,
 	})
@@ -242,7 +242,7 @@ func (o *Operator) ReconcileKind(kind resource.Kind, reconciler operator.Reconci
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformerWithFilters(kind, client, operator.KubernetesBasedInformerOptions{
+	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{
 		ListWatchOptions:    operator.ListWatchOptions{Namespace: options.Namespace, LabelFilters: options.LabelFilters, FieldSelectors: options.FieldSelectors},
 		CacheResyncInterval: o.cacheResyncInterval,
 	})


### PR DESCRIPTION
Reduce number of New functions in the operator package to a singular New for each type with an options struct. Future new functionality for any type in the operator package can now be added to the options struct for that type, without needing additional New methods, or breaking the signature of an existing New method.

Relates to https://github.com/grafana/grafana-app-sdk/issues/454