### PR TITLE
[ci] Add lts branch to dependabot action

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,9 @@
 name: "Update Go Workspace for Dependabot PRs"
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'lts/**'
     paths:
       - .github/workflows/dependabot.yml
       - go.mod


### PR DESCRIPTION
https://github.com/grafana/grafana-app-sdk/pull/488 is the only dependabot PR open at the moment, and it made me realize i missed the `lts` branch in #554 