### PR TITLE
[ci] Update go workspace action permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,10 +15,11 @@ on:
       - '**.go'
 permissions:
   contents: write
+  id-token: write
 jobs:
   update:
     runs-on: "ubuntu-latest"
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     continue-on-error: true
     steps:
     - name: Retrieve GitHub App secrets
@@ -51,8 +52,8 @@ jobs:
     
     - name: Configure Git
       run: |
-          git config --local user.email "${APP_INSTALLATION_ID}+grafana-go-workspace-bot[bot]@users.noreply.github.com"
-          git config --local user.name "grafana-go-workspace-bot[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git config --local --add --bool push.autoSetupRemote true
 
     - name: Update workspace


### PR DESCRIPTION
* adds `id-token: write` permission, which is needed to prevent [this error](https://github.com/grafana/grafana-app-sdk/actions/runs/12599467998/job/35116430246#step:2:49)
* switch back to github action bot in git commits (this fix is already applied on the LTS branch)
* prevent forks from triggering go workspace action