### PR TITLE
[codegen] Generate exported constants for group and version.

### DIFF
--- a/codegen/cuekind/generators.go
+++ b/codegen/cuekind/generators.go
@@ -41,6 +41,9 @@ func ResourceGenerator(groupKinds bool) *codejen.JennyList[codegen.Kind] {
 		&jennies.CodecGenerator{
 			GroupByKind: !groupKinds,
 		},
+		&jennies.Constants{
+			GroupByKind: !groupKinds,
+		},
 	)
 	return g
 }

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -60,8 +60,8 @@ func TestResourceGenerator(t *testing.T) {
 		files, err := ResourceGenerator(false).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		// 12 (6 -> object, spec, metadata, status, schema, codec) * 2 versions
-		assert.Len(t, files, 12)
+		// 14 (6 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
+		assert.Len(t, files, 14, "should be 14 files generated, got %d", len(files))
 		// Check content against the golden files
 		compareToGolden(t, files, "go/groupbykind")
 	})
@@ -70,8 +70,8 @@ func TestResourceGenerator(t *testing.T) {
 		files, err := ResourceGenerator(true).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		// 12 (6 -> object, spec, metadata, status, schema, codec) * 2 versions
-		assert.Len(t, files, 12)
+		// 14 (6 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
+		assert.Len(t, files, 14, "should be 14 files generated, got %d", len(files))
 		// Check content against the golden files
 		compareToGolden(t, files, "go/groupbygroup")
 	})
@@ -80,7 +80,7 @@ func TestResourceGenerator(t *testing.T) {
 		files, err := ResourceGenerator(true).Generate(sameGroupKinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		assert.Len(t, files, 18)
+		assert.Len(t, files, 20, "should be 20 files generated, got %d", len(files))
 		// Check content against the golden files
 		compareToGolden(t, files, "go/groupbygroup")
 	})

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -60,7 +60,7 @@ func TestResourceGenerator(t *testing.T) {
 		files, err := ResourceGenerator(false).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		// 14 (6 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
+		// 14 (7 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
 		assert.Len(t, files, 14, "should be 14 files generated, got %d", len(files))
 		// Check content against the golden files
 		compareToGolden(t, files, "go/groupbykind")
@@ -70,7 +70,7 @@ func TestResourceGenerator(t *testing.T) {
 		files, err := ResourceGenerator(true).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		// 14 (6 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
+		// 14 (7 -> object, spec, metadata, status, schema, codec, constants) * 2 versions
 		assert.Len(t, files, 14, "should be 14 files generated, got %d", len(files))
 		// Check content against the golden files
 		compareToGolden(t, files, "go/groupbygroup")

--- a/codegen/jennies/constants.go
+++ b/codegen/jennies/constants.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/grafana/codejen"
+
 	"github.com/grafana/grafana-app-sdk/codegen"
 	"github.com/grafana/grafana-app-sdk/codegen/templates"
 )
@@ -17,7 +18,7 @@ type Constants struct {
 	GroupByKind bool
 }
 
-func (c *Constants) JennyName() string {
+func (*Constants) JennyName() string {
 	return "ConstantsGenerator"
 }
 

--- a/codegen/jennies/constants.go
+++ b/codegen/jennies/constants.go
@@ -1,0 +1,66 @@
+package jennies
+
+import (
+	"bytes"
+	"go/format"
+	"path/filepath"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/grafana-app-sdk/codegen"
+	"github.com/grafana/grafana-app-sdk/codegen/templates"
+)
+
+// Constants is a Jenny which creates package-wide exported constants
+type Constants struct {
+	// GroupByKind determines whether kinds are grouped by GroupVersionKind or just GroupVersion.
+	// If GroupByKind is true, generated paths are <kind>/<version>/<file>, instead of the default <version>/<file>.
+	GroupByKind bool
+}
+
+func (c *Constants) JennyName() string {
+	return "ConstantsGenerator"
+}
+
+type constantsFileParams struct {
+	group   string
+	version string
+	path    string
+}
+
+func (c *Constants) Generate(kinds ...codegen.Kind) (codejen.Files, error) {
+	m := make(map[string]constantsFileParams)
+	for _, k := range kinds {
+		for _, v := range k.Versions() {
+			path := GetGeneratedPath(c.GroupByKind, k, v.Version)
+			if _, ok := m[path]; !ok {
+				m[path] = constantsFileParams{
+					group:   k.Properties().Group,
+					version: v.Version,
+					path:    filepath.Join(path, "constants.go"),
+				}
+			}
+		}
+	}
+	files := make(codejen.Files, 0)
+	for _, v := range m {
+		b := bytes.Buffer{}
+		err := templates.WriteConstantsFile(templates.ConstantsMetadata{
+			Package: ToPackageName(v.version),
+			Group:   v.group,
+			Version: v.version,
+		}, &b)
+		if err != nil {
+			return nil, err
+		}
+		formatted, err := format.Source(b.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, codejen.File{
+			RelativePath: v.path,
+			From:         []codejen.NamedJenny{c},
+			Data:         formatted,
+		})
+	}
+	return files, nil
+}

--- a/codegen/templates/constants.tmpl
+++ b/codegen/templates/constants.tmpl
@@ -1,0 +1,18 @@
+package {{ .Package }}
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group   = "{{ .Group }}"
+	// Version is the API version used by all kinds in this package
+	Version = "{{ .Version }}"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -26,6 +26,7 @@ var (
 	templateThemaCodec, _     = template.ParseFS(templates, "themacodec.tmpl")
 	templateWrappedType, _    = template.ParseFS(templates, "wrappedtype.tmpl")
 	templateTSType, _         = template.ParseFS(templates, "tstype.tmpl")
+	templateConstants, _      = template.ParseFS(templates, "constants.tmpl")
 
 	templateBackendPluginRouter, _          = template.ParseFS(templates, "plugin/plugin.tmpl")
 	templateBackendPluginResourceHandler, _ = template.ParseFS(templates, "plugin/handler_resource.tmpl")
@@ -466,6 +467,16 @@ func WriteAppGoFile(metadata AppMetadata, out io.Writer) error {
 		}
 	}
 	return templateApp.Execute(out, md)
+}
+
+type ConstantsMetadata struct {
+	Package string
+	Group   string
+	Version string
+}
+
+func WriteConstantsFile(metadata ConstantsMetadata, out io.Writer) error {
+	return templateConstants.Execute(out, metadata)
 }
 
 // ToPackageName sanitizes an input into a deterministic allowed go package name.

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
@@ -1,0 +1,18 @@
+package v0_0
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "customapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v0-0"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
@@ -1,0 +1,18 @@
+package v1_0
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "customapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v1-0"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
@@ -1,0 +1,18 @@
+package v1
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "testapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v1"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
@@ -1,0 +1,18 @@
+package v2
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "testapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v2"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
@@ -1,0 +1,18 @@
+package v0_0
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "customapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v0-0"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
@@ -1,0 +1,18 @@
+package v1_0
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group used by all kinds in this package
+	Group = "customapp.ext.grafana.com"
+	// Version is the API version used by all kinds in this package
+	Version = "v1-0"
+)
+
+var (
+	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
+	GroupVersion = schema.GroupVersion{
+		Group:   Group,
+		Version: Version,
+	}
+)


### PR DESCRIPTION
Generate exported `Group`, `Version`, and `GroupVersion` constants for each generated kind's package (when grouping kinds by version, only one set of constants will be generated for the package). This allows for a more convenient way to reference these constants vs. using the Kind accessor method, and then getting its Group/Version, especially when kinds are grouped by version, so multiple kinds are in the same package, sharing the same constants.

This is implemented as a new generated file because it has to be generated only once per package, unlike the other kind files which exist once per kind.

Resolves https://github.com/grafana/grafana-app-sdk/issues/515