### PR TITLE
[Client] Add options to Client.Delete and SchemalessClient.Delete

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -13,6 +13,10 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
+var (
+	_ resource.Client = &Client{}
+)
+
 // Client is a kubernetes-specific implementation of resource.Client, using custom resource definitions.
 // A Client is specific to the Schema it was created with.
 // New Clients should only be created via the ClientRegistry.ClientFor method.
@@ -209,8 +213,8 @@ func (c *Client) PatchInto(ctx context.Context, identifier resource.Identifier, 
 }
 
 // Delete deletes the specified resource
-func (c *Client) Delete(ctx context.Context, identifier resource.Identifier) error {
-	return c.client.delete(ctx, identifier, c.schema.Plural())
+func (c *Client) Delete(ctx context.Context, identifier resource.Identifier, options resource.DeleteOptions) error {
+	return c.client.delete(ctx, identifier, c.schema.Plural(), options)
 }
 
 // Watch makes a watch request for the namespace, and returns a WatchResponse which wraps a kubernetes

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -511,7 +511,7 @@ func TestClient_Delete(t *testing.T) {
 			writer.WriteHeader(http.StatusBadRequest)
 		}
 
-		err := client.Delete(ctx, id)
+		err := client.Delete(ctx, id, resource.DeleteOptions{})
 		require.NotNil(t, err)
 		cast, ok := err.(*ServerResponseError)
 		require.True(t, ok)
@@ -526,7 +526,41 @@ func TestClient_Delete(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id.Namespace, testSchema.Plural(), id.Name), r.URL.Path)
 		}
 
-		err := client.Delete(ctx, id)
+		err := client.Delete(ctx, id, resource.DeleteOptions{})
+		assert.Nil(t, err)
+	})
+
+	t.Run("propagationPolicy", func(t *testing.T) {
+		server.responseFunc = func(writer http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodDelete, r.Method)
+			writer.Write(responseBytes)
+			writer.WriteHeader(http.StatusOK)
+			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id.Namespace, testSchema.Plural(), id.Name), r.URL.Path)
+			assert.Equal(t, string(resource.DeleteOptionsPropagationPolicyForeground), r.URL.Query().Get("propagationPolicy"))
+		}
+
+		err := client.Delete(ctx, id, resource.DeleteOptions{
+			PropagationPolicy: resource.DeleteOptionsPropagationPolicyForeground,
+		})
+		assert.Nil(t, err)
+	})
+
+	t.Run("preconditions", func(t *testing.T) {
+		server.responseFunc = func(writer http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodDelete, r.Method)
+			writer.Write(responseBytes)
+			writer.WriteHeader(http.StatusOK)
+			assert.Equal(t, fmt.Sprintf("/namespaces/%s/%s/%s", id.Namespace, testSchema.Plural(), id.Name), r.URL.Path)
+			assert.Equal(t, "123", r.URL.Query().Get("preconditions.resourceVersion"))
+			assert.Equal(t, "abc", r.URL.Query().Get("preconditions.uid"))
+		}
+
+		err := client.Delete(ctx, id, resource.DeleteOptions{
+			Preconditions: resource.DeleteOptionsPreconditions{
+				ResourceVersion: "123",
+				UID:             "abc",
+			},
+		})
 		assert.Nil(t, err)
 	})
 }

--- a/k8s/gvclient.go
+++ b/k8s/gvclient.go
@@ -320,13 +320,22 @@ func (g *groupVersionClient) patch(ctx context.Context, identifier resource.Iden
 	return nil
 }
 
-func (g *groupVersionClient) delete(ctx context.Context, identifier resource.Identifier, plural string) error {
+func (g *groupVersionClient) delete(ctx context.Context, identifier resource.Identifier, plural string, options resource.DeleteOptions) error {
 	ctx, span := GetTracer().Start(ctx, "kubernetes-delete")
 	defer span.End()
 	sc := 0
 	request := g.client.Delete().Resource(plural).Name(identifier.Name)
 	if strings.TrimSpace(identifier.Namespace) != "" {
 		request = request.Namespace(identifier.Namespace)
+	}
+	if options.Preconditions.ResourceVersion != "" {
+		request = request.Param("preconditions.resourceVersion", options.Preconditions.ResourceVersion)
+	}
+	if options.Preconditions.UID != "" {
+		request = request.Param("preconditions.uid", options.Preconditions.UID)
+	}
+	if options.PropagationPolicy != "" {
+		request = request.Param("propagationPolicy", string(options.PropagationPolicy))
 	}
 	start := time.Now()
 	err := request.Do(ctx).StatusCode(&sc).Error()

--- a/k8s/schemaless.go
+++ b/k8s/schemaless.go
@@ -16,6 +16,10 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
+var (
+	_ resource.SchemalessClient = &SchemalessClient{}
+)
+
 // SchemalessClient implements resource.SchemalessClient and allows for working with Schemas as kubernetes
 // Custom Resource Definitions without being tied to a particular Schema (or GroupVerson).
 // Since the largest unit a kubernetes rest.Interface can work with is a GroupVersion,
@@ -170,7 +174,7 @@ func (s *SchemalessClient) Patch(ctx context.Context, identifier resource.FullId
 }
 
 // Delete deletes a resource identified by identifier
-func (s *SchemalessClient) Delete(ctx context.Context, identifier resource.FullIdentifier) error {
+func (s *SchemalessClient) Delete(ctx context.Context, identifier resource.FullIdentifier, options resource.DeleteOptions) error {
 	client, err := s.getClient(identifier)
 	if err != nil {
 		return err
@@ -179,7 +183,7 @@ func (s *SchemalessClient) Delete(ctx context.Context, identifier resource.FullI
 	return client.delete(ctx, resource.Identifier{
 		Namespace: identifier.Namespace,
 		Name:      identifier.Name,
-	}, s.getPlural(identifier))
+	}, s.getPlural(identifier), options)
 }
 
 // List lists all resources that satisfy identifier, ignoring `Name`. The response is marshaled into `into`

--- a/resource/client.go
+++ b/resource/client.go
@@ -88,6 +88,29 @@ type PatchOptions struct {
 	// TODO: nothing at-present
 }
 
+type DeleteOptionsPropagationPolicy string
+
+const (
+	DeleteOptionsPropagationPolicyOrphan     DeleteOptionsPropagationPolicy = "Orphan"
+	DeleteOptionsPropagationPolicyBackground DeleteOptionsPropagationPolicy = "Background"
+	DeleteOptionsPropagationPolicyForeground DeleteOptionsPropagationPolicy = "Foreground"
+	DeleteOptionsPropagationPolicyDefault    DeleteOptionsPropagationPolicy = ""
+)
+
+// DeleteOptions are the options passed to a Client.Delete call
+type DeleteOptions struct {
+	// Preconditions describes any conditions that must be true for the delete request to be processed
+	Preconditions     DeleteOptionsPreconditions
+	PropagationPolicy DeleteOptionsPropagationPolicy
+}
+
+type DeleteOptionsPreconditions struct {
+	// ResourceVersion, if supplied, requires that the existing ResourceVersion in the API server must match for the delete request to be processed
+	ResourceVersion string
+	// UID, if supplied, requires that the existing UID in the API server must match for the delete request to be processed
+	UID string
+}
+
 // WatchOptions are the options passed to a Client.Watch call
 type WatchOptions struct {
 	// ResourceVersion is the resource version to target with the call
@@ -152,7 +175,7 @@ type Client interface {
 	PatchInto(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions, into Object) error
 
 	// Delete deletes an exiting resource
-	Delete(ctx context.Context, identifier Identifier) error
+	Delete(ctx context.Context, identifier Identifier, options DeleteOptions) error
 
 	// List lists objects based on the options criteria.
 	// For resources with a schema.Scope() of ClusterScope, `namespace` must be resource.NamespaceAll
@@ -186,12 +209,12 @@ type SchemalessClient interface {
 	Patch(ctx context.Context, identifier FullIdentifier, path PatchRequest, options PatchOptions, into Object) error
 
 	// Delete deletes a resource identified by identifier
-	Delete(ctx context.Context, identifier FullIdentifier) error
+	Delete(ctx context.Context, identifier FullIdentifier, options DeleteOptions) error
 
 	// List lists all resources that satisfy identifier, ignoring `Name`. The response is marshaled into `into`.
 	// `exampleListItem` must be provided for proper type unmarshaling, and should be the same kind of object
 	// that would be passed to a Get call for `into`
-	List(ctx context.Context, identifier FullIdentifier, into ListObject, exampleListItem Object) error
+	List(ctx context.Context, identifier FullIdentifier, options ListOptions, into ListObject, exampleListItem Object) error
 
 	// Watch watches all resources that satisfy the identifier, ignoring `Name`.
 	// The WatchResponse's WatchEvent Objects are created by unmarshaling into an object created by calling

--- a/resource/simplestore.go
+++ b/resource/simplestore.go
@@ -192,7 +192,7 @@ func (s *SimpleStore[T]) UpdateSubresource(ctx context.Context, identifier Ident
 
 // Delete deletes a resource with the given identifier.
 func (s *SimpleStore[T]) Delete(ctx context.Context, identifier Identifier) error {
-	return s.client.Delete(ctx, identifier)
+	return s.client.Delete(ctx, identifier, DeleteOptions{})
 }
 
 type MapSubresourceCatalog map[string]any

--- a/resource/simplestore_test.go
+++ b/resource/simplestore_test.go
@@ -304,7 +304,7 @@ func TestSimpleStore_Delete(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		cerr := fmt.Errorf("I AM ERROR")
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return cerr
@@ -314,7 +314,7 @@ func TestSimpleStore_Delete(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return nil

--- a/resource/store.go
+++ b/resource/store.go
@@ -233,7 +233,7 @@ func (s *Store) Delete(ctx context.Context, kind string, identifier Identifier) 
 		return err
 	}
 
-	return client.Delete(ctx, identifier)
+	return client.Delete(ctx, identifier, DeleteOptions{})
 }
 
 // ForceDelete deletes a resource with the given Identifier and kind, ignores client 404 errors.
@@ -243,7 +243,7 @@ func (s *Store) ForceDelete(ctx context.Context, kind string, identifier Identif
 		return err
 	}
 
-	err = client.Delete(ctx, identifier)
+	err = client.Delete(ctx, identifier, DeleteOptions{})
 
 	if cast, ok := err.(APIServerResponseError); ok && cast.StatusCode() == http.StatusNotFound {
 		return nil

--- a/resource/store_test.go
+++ b/resource/store_test.go
@@ -756,7 +756,7 @@ func TestStore_Delete(t *testing.T) {
 
 	t.Run("client error", func(t *testing.T) {
 		cerr := fmt.Errorf("JE SUIS ERROR")
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			return cerr
 		}
 		generator.ClientForFunc = func(kind Kind) (Client, error) {
@@ -771,7 +771,7 @@ func TestStore_Delete(t *testing.T) {
 			Namespace: "foo",
 			Name:      "bar",
 		}
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return nil
@@ -808,7 +808,7 @@ func TestStore_ForceDelete(t *testing.T) {
 
 	t.Run("client error", func(t *testing.T) {
 		cerr := fmt.Errorf("JE SUIS ERROR")
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			return cerr
 		}
 		generator.ClientForFunc = func(kind Kind) (Client, error) {
@@ -820,7 +820,7 @@ func TestStore_ForceDelete(t *testing.T) {
 
 	t.Run("success with 404", func(t *testing.T) {
 		cerr := &testAPIError{fmt.Errorf("Not Found"), http.StatusNotFound}
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			return cerr
 		}
 		generator.ClientForFunc = func(kind Kind) (Client, error) {
@@ -835,7 +835,7 @@ func TestStore_ForceDelete(t *testing.T) {
 			Namespace: "foo",
 			Name:      "bar",
 		}
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return nil
@@ -955,7 +955,7 @@ type mockClient struct {
 	UpdateIntoFunc func(ctx context.Context, identifier Identifier, obj Object, options UpdateOptions, into Object) error
 	PatchFunc      func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions) (Object, error)
 	PatchIntoFunc  func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions, into Object) error
-	DeleteFunc     func(ctx context.Context, identifier Identifier) error
+	DeleteFunc     func(ctx context.Context, identifier Identifier, options DeleteOptions) error
 	ListFunc       func(ctx context.Context, namespace string, options ListOptions) (ListObject, error)
 	ListIntoFunc   func(ctx context.Context, namespace string, options ListOptions, into ListObject) error
 	WatchFunc      func(ctx context.Context, namespace string, options WatchOptions) (WatchResponse, error)
@@ -1009,9 +1009,9 @@ func (c *mockClient) PatchInto(ctx context.Context, identifier Identifier, patch
 	}
 	return nil
 }
-func (c *mockClient) Delete(ctx context.Context, identifier Identifier) error {
+func (c *mockClient) Delete(ctx context.Context, identifier Identifier, options DeleteOptions) error {
 	if c.DeleteFunc != nil {
-		return c.DeleteFunc(ctx, identifier)
+		return c.DeleteFunc(ctx, identifier, options)
 	}
 	return nil
 }

--- a/resource/typedstore.go
+++ b/resource/typedstore.go
@@ -155,12 +155,12 @@ func (t *TypedStore[T]) UpdateSubresource(ctx context.Context, identifier Identi
 
 // Delete deletes a resource with the provided identifier
 func (t *TypedStore[T]) Delete(ctx context.Context, identifier Identifier) error {
-	return t.client.Delete(ctx, identifier)
+	return t.client.Delete(ctx, identifier, DeleteOptions{})
 }
 
 // ForceDelete deletes a resource with the provided identifier, ignores 404 errors
 func (t *TypedStore[T]) ForceDelete(ctx context.Context, identifier Identifier) error {
-	err := t.client.Delete(ctx, identifier)
+	err := t.client.Delete(ctx, identifier, DeleteOptions{})
 
 	if cast, ok := err.(APIServerResponseError); ok && cast.StatusCode() == http.StatusNotFound {
 		return nil

--- a/resource/typedstore_test.go
+++ b/resource/typedstore_test.go
@@ -329,7 +329,7 @@ func TestTypedStore_Delete(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		cerr := fmt.Errorf("I AM ERROR")
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return cerr
@@ -339,7 +339,7 @@ func TestTypedStore_Delete(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return nil
@@ -359,7 +359,7 @@ func TestTypedStore_ForceDelete(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		cerr := fmt.Errorf("I AM ERROR")
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return cerr
@@ -369,7 +369,7 @@ func TestTypedStore_ForceDelete(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return nil
@@ -379,7 +379,7 @@ func TestTypedStore_ForceDelete(t *testing.T) {
 	})
 
 	t.Run("success with 404", func(t *testing.T) {
-		client.DeleteFunc = func(c context.Context, identifier Identifier) error {
+		client.DeleteFunc = func(c context.Context, identifier Identifier, _ DeleteOptions) error {
 			assert.Equal(t, ctx, c)
 			assert.Equal(t, id, identifier)
 			return &testAPIError{fmt.Errorf("Not Found"), http.StatusNotFound}


### PR DESCRIPTION
Added `DeleteOptions` to `resource.Client.Delete` and `resource.SchemalessClient.Delete`, along with implementation in `k8s.Client` and `k8s.SchemalessClient`.

`resource.DeleteOptions` includes `preconditions` and `propagationPolicy` from [kubernetes' delete options](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/delete-options/).

Resolves https://github.com/grafana/grafana-app-sdk/issues/456