### PR TITLE
Use the group from the manifest for --grouping=group package names

### DIFF
--- a/codegen/jennies/openapi.go
+++ b/codegen/jennies/openapi.go
@@ -65,7 +65,11 @@ func (o *OpenAPI) Generate(kinds ...codegen.Kind) (codejen.Files, error) {
 				if !v.Codegen.Backend {
 					continue
 				}
-				gvs[schema.GroupVersion{Group: k.Properties().Group, Version: v.Version}] = struct{}{}
+				grp := k.Properties().ManifestGroup
+				if grp == "" {
+					grp = k.Properties().Group
+				}
+				gvs[schema.GroupVersion{Group: grp, Version: v.Version}] = struct{}{}
 			}
 		}
 		for gv := range gvs {


### PR DESCRIPTION
Since the openapi jenny doesn't use `GetGeneratedPath` when `--grouping=group`, duplicate the correct group name logic for the path there.