### PR TITLE
Fix codegen omitting Go manifest file with `defencoding=none`

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -201,8 +201,16 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 	}
 
 	// Manifest
+	goManifestFiles, err := generatorForManifest.Generate(cuekind.ManifestGoGenerator(filepath.Base(cfg.GoGenBasePath)), selectors...)
+	if err != nil {
+		return nil, err
+	}
+	for i, f := range goManifestFiles {
+		goManifestFiles[i].RelativePath = filepath.Join(cfg.GoGenBasePath, f.RelativePath)
+	}
+
+	// Manifest CRD
 	var manifestFiles codejen.Files
-	var goManifestFiles codejen.Files
 	if cfg.CRDEncoding != "none" {
 		encFunc := func(v any) ([]byte, error) {
 			return json.MarshalIndent(v, "", "    ")
@@ -210,20 +218,13 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 		if cfg.CRDEncoding == "yaml" {
 			encFunc = yaml.Marshal
 		}
+
 		manifestFiles, err = generatorForManifest.Generate(cuekind.ManifestGenerator(encFunc, cfg.CRDEncoding), selectors...)
 		if err != nil {
 			return nil, err
 		}
 		for i, f := range manifestFiles {
 			manifestFiles[i].RelativePath = filepath.Join(cfg.CRDPath, f.RelativePath)
-		}
-
-		goManifestFiles, err = generatorForManifest.Generate(cuekind.ManifestGoGenerator(filepath.Base(cfg.GoGenBasePath)), selectors...)
-		if err != nil {
-			return nil, err
-		}
-		for i, f := range goManifestFiles {
-			goManifestFiles[i].RelativePath = filepath.Join(cfg.GoGenBasePath, f.RelativePath)
 		}
 	}
 


### PR DESCRIPTION
### What

This commit fixes codegen issue that omits generating Go manifest file if the codegen is invoked with `defencoding=none`.

### Why

The `defencoding=none` is supposed to only omit generating the CRD definitions for kinds & manifest but still generate the Go file for the manifest correctly.