### PR TITLE
[operator] Call ErrorHandler on reconciler errors

### DIFF
--- a/operator/informer_controller.go
+++ b/operator/informer_controller.go
@@ -561,6 +561,10 @@ func (c *InformerController) doReconcile(ctx context.Context, reconciler Reconci
 		})
 	} else if err != nil {
 		// Otherwise, if err is non-nil, queue a retry according to the RetryPolicy
+		if c.ErrorHandler != nil {
+			// Call the ErrorHandler function as well if it's set
+			c.ErrorHandler(ctx, err)
+		}
 		c.queueRetry(retryKey, err, func() (*time.Duration, error) {
 			ctx, span := GetTracer().Start(ctx, "controller-retry")
 			defer span.End()

--- a/simple/app.go
+++ b/simple/app.go
@@ -215,6 +215,9 @@ func NewApp(config AppConfig) (*App, error) {
 		cfg:                config,
 		collectors:         make([]prometheus.Collector, 0),
 	}
+	if config.InformerConfig.ErrorHandler != nil {
+		a.informerController.ErrorHandler = config.InformerConfig.ErrorHandler
+	}
 	discoveryRefresh := config.DiscoveryRefreshInterval
 	if discoveryRefresh == 0 {
 		discoveryRefresh = time.Minute * 10


### PR DESCRIPTION
Call `ErrorHandler` on reconciler errors, and ensure that a custom `ErrorHandler` is properly set in `simple.NewApp`