### PR TITLE
[k8s] Allow specifying a KubeConfigProvider in k8s.ClientConfig

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -44,6 +44,11 @@ type ClientConfig struct {
 	// NegotiatedSerializerProvider is a function which provides a runtime.NegotiatedSerializer for the underlying
 	// kubernetes rest.RESTClient, if defined.
 	NegotiatedSerializerProvider func(kind resource.Kind) runtime.NegotiatedSerializer
+
+	// KubeConfigProvider can be used to provide an altered or alternative rest.Config based on kind.
+	// It is passed the Kind and existing rest.Config, and should return a valid rest.Config
+	// (returning the same rest.Config as the input is valid)
+	KubeConfigProvider func(kind resource.Kind, kubeConfig rest.Config) rest.Config
 }
 
 // DefaultClientConfig returns a ClientConfig using defaults that assume you have used the SDK codegen tooling

--- a/k8s/client_registry.go
+++ b/k8s/client_registry.go
@@ -109,6 +109,9 @@ func (c *ClientRegistry) getClient(sch resource.Kind) (rest.Interface, error) {
 	} else {
 		ccfg.NegotiatedSerializer = &GenericNegotiatedSerializer{}
 	}
+	if c.clientConfig.KubeConfigProvider != nil {
+		ccfg = c.clientConfig.KubeConfigProvider(sch, ccfg)
+	}
 	client, err := rest.RESTClientFor(&ccfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Allow specifying a KubeConfigProvider in `k8s.ClientConfig` to let the `k8s.ClientRegistry` alter the KubeConfig based on the kind. This is specifically useful for working with a mix of CRDs and core kubernetes kinds, which use /api instead of /apis.