### PR TITLE
Update APIVersion in AppManifest Jenny to Match AppManifest CRD Definition

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -45,7 +45,7 @@ func (m *ManifestGenerator) Generate(appManifest codegen.AppManifest) (codejen.F
 
 	// Make into kubernetes format
 	output := make(map[string]any)
-	output["apiVersion"] = "apps.grafana.com/v1"
+	output["apiVersion"] = "apps.grafana.com/v1alpha1"
 	output["kind"] = "AppManifest"
 	output["metadata"] = map[string]string{
 		"name": manifestData.AppName,


### PR DESCRIPTION
Update the `apiVersion` in the generated AppManifest CR to match the `apiVersion` in the [CUE definition of the AppManifest CRD](https://github.com/grafana/grafana-app-sdk/blob/main/app/manifest.cue#L14).