### PR TITLE
Small fixes for the Issue Tracker tutorial

### DIFF
--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -363,7 +363,7 @@ func projectAddKind(cmd *cobra.Command, args []string) error {
 //nolint:revive,funlen,gocyclo
 func projectAddComponent(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		fmt.Println(`Usage: grafana-app-sdk project add component [options] <components>
+		fmt.Println(`Usage: grafana-app-sdk project component add [options] <components>
 	where <components> are one or more of:
 		backend
 		frontend

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -353,20 +353,20 @@ That leaves us with just our varying TypeScript files.
 
 ```TypeScript
 function PageOne() {
-    const s = useStyles2(getStyles);
+  const s = useStyles2(getStyles);
 
-    return (
-        <PluginPage>
-            <div data-testid={testIds.pageOne.container}>
-            This is page one.
-    <div className={s.marginTop}>
-    <LinkButton data-testid={testIds.pageOne.navigateToFour} href={prefixRoute(ROUTES.Four)}>
-    Full-width page example
-    </LinkButton>
-    </div>
-    </div>
+  return (
+    <PluginPage>
+      <div data-testid={testIds.pageOne.container}>
+        This is page one.
+        <div className={s.marginTop}>
+          <LinkButton data-testid={testIds.pageOne.navigateToFour} href={prefixRoute(ROUTES.Four)}>
+            Full-width page example
+          </LinkButton>
+        </div>
+      </div>
     </PluginPage>
-);
+  );
 }
 ```
 There are other pages generated here as examples from the output of `yarn create @grafana/plugin`. The routing for these pages is in `components/App/App.tsx`.

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -4,9 +4,9 @@ Since this is a fresh project, we can take advantage of the CLI's tooling to set
 
 ## The `project add` Command
 
-Earlier, we used the CLI's `project` command with `project init`, initializing our project with some very basic stuff. Now, we can again use the `project` command, this time to add boilerplate components to our app. These are added using the `project add` command, with the name of one or more components you wish to add to the project. To see the list of possible components, you can run it sans arguments, like so:
+Earlier, we used the CLI's `project` command with `project init`, initializing our project with some very basic stuff. Now, we can again use the `project` command, this time to add boilerplate components to our app. These are added using the `project component add` command, with the name of one or more components you wish to add to the project. To see the list of possible components, you can run it sans arguments, like so:
 ```shell
-$ grafana-app-sdk project add
+$ grafana-app-sdk project component add
 Usage: grafana-app-sdk project component add [options] <components>
 	where <components> are one or more of:
 		backend
@@ -26,10 +26,11 @@ Flags:
   -h, --help              help for add
 
 Global Flags:
-  -f, --format string   Format in which kinds are written for this project (currently allowed values are 'cue') (default "cue")
-      --overwrite       Overwrite existing files instead of prompting
-  -p, --path string     Path to project directory
-  -s, --source string   Path to directory with your codegen source files (such as a CUE module) (default "kinds")
+  -f, --format string     Format in which kinds are written for this project (currently allowed values are 'cue') (default "cue")
+      --manifest string   Path selector to use for the manifest (default "manifest")
+      --overwrite         Overwrite existing files instead of prompting
+  -p, --path string       Path to project directory
+  -s, --source string     Path to directory with your codegen source files (such as a CUE module) (default "kinds")
 ```
 
 We can leave all these flags empty, as we're fine with the defaults, but it's good to know how we can find information about the CLI commands.

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -2,7 +2,7 @@
 
 Since this is a fresh project, we can take advantage of the CLI's tooling to set up boilerplate code for us which we can then extend on. Note that this is not strictly necessary for writing an application (whereas running the CUE codegen is something you'll likely want for every project), but it makes initial project bootstrapping simpler, and will help us move along here faster. If you decide in future projects you want to handle your routing, storage, or front-end framework differently, you can eschew some or all of the things laid out in this section.
 
-## The `project add` Command
+## The `project component add` Command
 
 Earlier, we used the CLI's `project` command with `project init`, initializing our project with some very basic stuff. Now, we can again use the `project` command, this time to add boilerplate components to our app. These are added using the `project component add` command, with the name of one or more components you wish to add to the project. To see the list of possible components, you can run it sans arguments, like so:
 ```shell
@@ -134,7 +134,7 @@ $ tree -I "generated|definitions|kinds|local" .
 
 Excluding our previously-generated files, we can see that we have a few new go packages (`pkg/app`, `pkg/watchers`, `pkg/plugin`, and `pkg/plugin/secure`), some go files and a Dockerfile in `cmd/operator`, and a bunch of new stuff in the `plugin` directory.
 
-If we had split up our `project add` into `project add backend`, we'd only get our generated go files in `pkg/plugin`, `project add frontend` would only give us the non-`plugin/pkg` plugin files, and `project add operator` would give us the `pkg/watchers` and `cmd/operator` files. As we can see, none of these `project add` components have overlapping code, which is deliberate. If you prefer to not use boilerplate for a given component, you can simply not add it and not worry that another component will depend on boilerplate from it.
+If we had split up our `project component add` into `project component add backend`, we'd only get our generated go files in `pkg/plugin`, `project component add frontend` would only give us the non-`plugin/pkg` plugin files, and `project component add operator` would give us the `pkg/watchers` and `cmd/operator` files. As we can see, none of these `project component add` components have overlapping code, which is deliberate. If you prefer to not use boilerplate for a given component, you can simply not add it and not worry that another component will depend on boilerplate from it.
 
 So, what are these new bits of code doing?
 
@@ -144,7 +144,7 @@ So, what are these new bits of code doing?
 
 ### `pkg/plugin`
 
-The `project add` didn't actually generate too many files for our back-end boilerplate, just a couple of go files in `pkg/plugin` and then some code in `pkg/plugin/secure`:
+The `project component add` didn't actually generate too many files for our back-end boilerplate, just a couple of go files in `pkg/plugin` and then some code in `pkg/plugin/secure`:
 ```shell
 $ tree pkg/plugin
 pkg/plugin
@@ -409,7 +409,7 @@ Here is where the `main` code to run the operator lives, and the docker file to 
 
 ### `pkg/watchers`
 
-Here we only have one file, created for our Issue kind. If we had more kinds, we'd have more files here, as the `project add operator` command generates a boilerplate watcher for each kind in CUE with a `target: "resource"`. This file defines a simple watcher object which implements `operator.ResourceWatcher`, with an additional `Sync` function which is used in conjunction with a `resource.OpinionatedWatcher`. All this boilerplate watcher does is check that it can cast the provided resource(s) into the `issue.Object` type, and then print a line to the console with the event type and details.
+Here we only have one file, created for our Issue kind. If we had more kinds, we'd have more files here, as the `project component add operator` command generates a boilerplate watcher for each kind in CUE with a `target: "resource"`. This file defines a simple watcher object which implements `operator.ResourceWatcher`, with an additional `Sync` function which is used in conjunction with a `resource.OpinionatedWatcher`. All this boilerplate watcher does is check that it can cast the provided resource(s) into the `issue.Object` type, and then print a line to the console with the event type and details.
 
 Next, now that we have minimal functioning code, we can try, [deploying our project locally](05-local-deployment.md)
 

--- a/docs/tutorials/issue-tracker/06-frontend.md
+++ b/docs/tutorials/issue-tracker/06-frontend.md
@@ -1,6 +1,6 @@
 # Front-End
 
-Alright, now that we've verified that we have a working back-end of our plugin, and have a local deployment where we can browse to our UI, it's time to make the front-end work work, and look a bit nicer.
+Alright, now that we've verified that we have a working back-end of our plugin, and have a local deployment where we can browse to our UI, it's time to make the front-end work, and look a bit nicer.
 
 We're still going to keep our front-end pretty simple, so all we're going to do is have our landing page list our issues, allow a user to create a new issue, and be able to update an issue's status, or delete an issue. To allow for this, we'll need a client we can use to do all these things. 
 


### PR DESCRIPTION
This PR updates the Issue Tracker tutorial with few small fixes.

Apart from these fixes, I had to change `issue-tracker-project-app` part of URL (eg. in `curl http://grafana.k3d.localhost:9999/api/plugins/issue-tracker-project-app/resources/v1/issues` command) to `issuetrackerprojectapp`. I'm not sure why, or whether this is specific to my installation somehow, or version, so I didn't update the commands in this PR.

