### PR TITLE
Add `--noschemasinmanifest` flag to CLI generate command

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -772,7 +772,7 @@ func updateLocalConfigFromManifest(config *localEnvConfig, format string, cuePat
 		if err != nil {
 			return err
 		}
-		fs, err := generator.Generate(cuekind.ManifestGenerator(json.Marshal, "json"), selectors...)
+		fs, err := generator.Generate(cuekind.ManifestGenerator(json.Marshal, "json", false), selectors...)
 		if err != nil {
 			return err
 		}

--- a/codegen/cuekind/generators.go
+++ b/codegen/cuekind/generators.go
@@ -123,19 +123,21 @@ func PostResourceGenerationGenerator(projectRepo, goGenPath string, groupKinds b
 	return g
 }
 
-func ManifestGenerator(encoder jennies.ManifestOutputEncoder, extension string) *codejen.JennyList[codegen.AppManifest] {
+func ManifestGenerator(encoder jennies.ManifestOutputEncoder, extension string, includeSchemas bool) *codejen.JennyList[codegen.AppManifest] {
 	g := codejen.JennyListWithNamer[codegen.AppManifest](namerFuncManifest)
 	g.Append(&jennies.ManifestGenerator{
-		Encoder:       encoder,
-		FileExtension: extension,
+		Encoder:        encoder,
+		FileExtension:  extension,
+		IncludeSchemas: includeSchemas,
 	})
 	return g
 }
 
-func ManifestGoGenerator(pkg string) *codejen.JennyList[codegen.AppManifest] {
+func ManifestGoGenerator(pkg string, includeSchemas bool) *codejen.JennyList[codegen.AppManifest] {
 	g := codejen.JennyListWithNamer[codegen.AppManifest](namerFuncManifest)
 	g.Append(&jennies.ManifestGoGenerator{
-		Package: pkg,
+		Package:        pkg,
+		IncludeSchemas: includeSchemas,
 	})
 	return g
 }

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -112,7 +112,7 @@ func TestManifestGenerator(t *testing.T) {
 	t.Run("resource", func(t *testing.T) {
 		kinds, err := parser.ManifestParser().Parse(os.DirFS(TestCUEDirectory), "testManifest")
 		require.Nil(t, err)
-		files, err := ManifestGenerator(yaml.Marshal, "yaml").Generate(kinds...)
+		files, err := ManifestGenerator(yaml.Marshal, "yaml", true).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
 		// 5 -> object, spec, metadata, status, schema
@@ -129,7 +129,7 @@ func TestManifestGoGenerator(t *testing.T) {
 	t.Run("resource", func(t *testing.T) {
 		kinds, err := parser.ManifestParser().Parse(os.DirFS(TestCUEDirectory), "testManifest")
 		require.Nil(t, err)
-		files, err := ManifestGoGenerator("groupbygroup").Generate(kinds...)
+		files, err := ManifestGoGenerator("groupbygroup", true).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
 		// 5 -> object, spec, metadata, status, schema

--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -11,10 +11,10 @@ import (
     "github.com/grafana/grafana-app-sdk/app"
 )
 
-var ({{ range .ManifestData.Kinds }}{{$k:=.}}{{ range .Versions }}
+var ({{ range .ManifestData.Kinds }}{{$k:=.}}{{ range .Versions }}{{ if .Schema }}
     rawSchema{{$k.Kind}}{{$.ToPackageName .Name}} = []byte({{$.ToJSONBacktickString .Schema}})
     versionSchema{{$k.Kind}}{{$.ToPackageName .Name}} app.VersionSchema
-    _ = json.Unmarshal(rawSchema{{$k.Kind}}{{$.ToPackageName .Name}}, &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}}){{end}}{{end}}
+    _ = json.Unmarshal(rawSchema{{$k.Kind}}{{$.ToPackageName .Name}}, &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}}){{end}}{{end}}{{end}}
 )
 
 var appManifestData = app.ManifestData{
@@ -39,8 +39,8 @@ var appManifestData = app.ManifestData{
                         {{ range .Admission.Mutation.Operations }}app.{{ $.ToAdmissionOperationName . }},
                         {{ end }} }, {{ end }}
                     }, {{ end }}
-                }, {{ end }}
-                Schema: &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}},{{ if .SelectableFields }}
+                }, {{ end }}{{ if .Schema }}
+                Schema: &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}},{{end}}{{ if .SelectableFields }}
                 SelectableFields: []string{ {{ range .SelectableFields }}
                     "{{.}}",{{ end }}
                 },{{end}}


### PR DESCRIPTION
Add `--noschemasinmanifest` flag to CLI generate command, which excludes the kind schemas when generating the app manifest. This is required for schemas which are recursive that cog permits codegen for, but CUE's openapi generation, used for creating CRD schemas, does not.

This is a temporary fix until a better resolution can be made by resolving https://github.com/grafana/grafana-app-sdk/issues/460 