### PR TITLE
[AppManifest] Add tests for generated AppManifest code and conversion code

### DIFF
--- a/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
+++ b/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
@@ -138,7 +138,7 @@ func NewAppManifestSpec() *AppManifestSpec {
 // +k8s:openapi-gen=true
 type AppManifestV1alpha1SpecExtraPermissions struct {
 	// accessKinds is a list of KindPermission objects for accessing additional kinds provided by other apps
-	AccessKinds []AppManifestKindPermission `json:"accessKinds,omitempty"`
+	AccessKinds []AppManifestKindPermission `json:"accessKinds"`
 }
 
 // NewAppManifestV1alpha1SpecExtraPermissions creates a new AppManifestV1alpha1SpecExtraPermissions object.

--- a/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
+++ b/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
@@ -20,7 +20,7 @@ type AppManifestManifestKindVersion struct {
 	Name                     string                                `json:"name"`
 	Admission                *AppManifestAdmissionCapabilities     `json:"admission,omitempty"`
 	Schema                   AppManifestManifestKindVersionSchema  `json:"schema"`
-	SelectableFields         []string                              `json:"selectableFields"`
+	SelectableFields         []string                              `json:"selectableFields,omitempty"`
 	AdditionalPrinterColumns []AppManifestAdditionalPrinterColumns `json:"additionalPrinterColumns,omitempty"`
 }
 
@@ -120,7 +120,7 @@ type AppManifestSpec struct {
 	Kinds   []AppManifestManifestKind `json:"kinds"`
 	// ExtraPermissions contains additional permissions needed for an app's backend component to operate.
 	// Apps implicitly have all permissions for kinds they managed (defined in `kinds`).
-	ExtraPermissions AppManifestV1alpha1SpecExtraPermissions `json:"extraPermissions"`
+	ExtraPermissions *AppManifestV1alpha1SpecExtraPermissions `json:"extraPermissions,omitempty"`
 	// DryRunKinds dictates whether this revision should create/update CRD's from the provided kinds,
 	// Or simply validate and report errors in status.resources.crds.
 	// If dryRunKinds is true, CRD change validation will be skipped on ingress and reported in status instead.
@@ -131,15 +131,14 @@ type AppManifestSpec struct {
 // NewAppManifestSpec creates a new AppManifestSpec object.
 func NewAppManifestSpec() *AppManifestSpec {
 	return &AppManifestSpec{
-		ExtraPermissions: *NewAppManifestV1alpha1SpecExtraPermissions(),
-		DryRunKinds:      (func(input bool) *bool { return &input })(false),
+		DryRunKinds: (func(input bool) *bool { return &input })(false),
 	}
 }
 
 // +k8s:openapi-gen=true
 type AppManifestV1alpha1SpecExtraPermissions struct {
 	// accessKinds is a list of KindPermission objects for accessing additional kinds provided by other apps
-	AccessKinds []AppManifestKindPermission `json:"accessKinds"`
+	AccessKinds []AppManifestKindPermission `json:"accessKinds,omitempty"`
 }
 
 // NewAppManifestV1alpha1SpecExtraPermissions creates a new AppManifestV1alpha1SpecExtraPermissions object.

--- a/app/appmanifest/v1alpha1/conversion.go
+++ b/app/appmanifest/v1alpha1/conversion.go
@@ -57,7 +57,7 @@ func (s *AppManifestSpec) ToManifestData() (app.ManifestData, error) {
 		data.Kinds[idx] = k
 	}
 	// Permissions
-	if s.ExtraPermissions.AccessKinds != nil {
+	if s.ExtraPermissions != nil && s.ExtraPermissions.AccessKinds != nil {
 		data.ExtraPermissions = &app.Permissions{
 			AccessKinds: make([]app.KindPermission, len(s.ExtraPermissions.AccessKinds)),
 		}

--- a/app/appmanifest/v1alpha1/conversion_test.go
+++ b/app/appmanifest/v1alpha1/conversion_test.go
@@ -1,0 +1,46 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppManifestSpec_ToManifestData(t *testing.T) {
+	t.Run("successful conversion", func(t *testing.T) {
+		// For v1alpha1, app.ManifestData is essentially a subset of v1alpha1.AppManifestSpec,
+		// so we only need to check that the same JSON loaded for the AppManifestSpec and using ToManifestData()
+		// is identical to loading that JSON for app.ManifestData
+		file, err := os.ReadFile(filepath.Join("testfiles", "spec-01.json"))
+		require.Nil(t, err)
+		v1alpha1 := AppManifestSpec{}
+		md := app.ManifestData{}
+		err = json.Unmarshal(file, &v1alpha1)
+		require.Nil(t, err)
+		err = json.Unmarshal(file, &md)
+		require.Nil(t, err)
+		v1md, err := v1alpha1.ToManifestData()
+		require.Nil(t, err)
+		assert.Equal(t, md, v1md)
+	})
+
+	t.Run("bad schema data", func(t *testing.T) {
+		v1alpha1 := AppManifestSpec{
+			Kinds: []AppManifestManifestKind{{
+				Versions: []AppManifestManifestKindVersion{{
+					Schema: map[string]interface{}{
+						"openAPIV3Schema": "foo", // Bad OpenAPI document, conversion will fail when loading the openAPI
+					},
+				}},
+			}},
+		}
+		_, err := v1alpha1.ToManifestData()
+		assert.Equal(t, errors.New("'openAPIV3Schema' must be an object"), err)
+	})
+}

--- a/app/appmanifest/v1alpha1/generated_code_test.go
+++ b/app/appmanifest/v1alpha1/generated_code_test.go
@@ -1,0 +1,91 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAppManifestKind_Read(t *testing.T) {
+	kind := AppManifestKind()
+
+	// Valid JSON
+	file, err := os.ReadFile(filepath.Join("testfiles", "manifest-01.json"))
+	require.Nil(t, err)
+	obj, err := kind.Read(bytes.NewReader(file), resource.KindEncodingJSON)
+	require.Nil(t, err)
+	cast, ok := obj.(*AppManifest)
+	require.True(t, ok, "read object is not of type *AppManifest")
+	tm, _ := time.Parse(time.RFC3339, "2025-02-19T20:36:00Z")
+	schemaBytes, err := os.ReadFile(filepath.Join("testfiles", "schema-01.json"))
+	require.Nil(t, err)
+	schema := make(map[string]interface{})
+	require.Nil(t, json.Unmarshal(schemaBytes, &schema))
+	assert.Equal(t, &AppManifest{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AppManifest",
+			APIVersion: "apps.grafana.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "issue-tracker-project",
+			CreationTimestamp: metav1.NewTime(tm.Local()),
+		},
+		Spec: AppManifestSpec{
+			AppName: "issue-tracker-project",
+			Group:   "issuetrackerproject.ext.grafana.com",
+			Kinds: []AppManifestManifestKind{{
+				Kind:  "Issue",
+				Scope: "Namespaced",
+				Versions: []AppManifestManifestKindVersion{{
+					Name:   "v1",
+					Schema: schema,
+				}},
+			}},
+		},
+		AppManifestStatus: AppManifestStatus{
+			Resources: map[string]AppManifeststatusApplyStatus{
+				"crds": {
+					Status: AppManifestStatusApplyStatusStatusSuccess,
+				},
+			},
+		},
+	}, cast)
+}
+
+func TestAppManifestKind_Write(t *testing.T) {
+	kind := AppManifestKind()
+
+	// Valid JSON
+	file, err := os.ReadFile(filepath.Join("testfiles", "manifest-01.json"))
+	require.Nil(t, err)
+	obj, err := kind.Read(bytes.NewReader(file), resource.KindEncodingJSON)
+	require.Nil(t, err)
+	cast, ok := obj.(*AppManifest)
+	require.True(t, ok, "read object is not of type *AppManifest")
+	out := bytes.Buffer{}
+	err = kind.Write(cast, &out, resource.KindEncodingJSON)
+	require.Nil(t, err)
+	assert.JSONEq(t, string(file), out.String())
+}
+
+func TestAppManifestKind_GroupVersionKind(t *testing.T) {
+	kind := AppManifestKind()
+	assert.Equal(t, "apps.grafana.com", kind.GroupVersionKind().Group)
+	assert.Equal(t, "v1alpha1", kind.GroupVersionKind().Version)
+	assert.Equal(t, "AppManifest", kind.GroupVersionKind().Kind)
+}
+
+func TestAppManifestKind_GroupVersionResource(t *testing.T) {
+	kind := AppManifestKind()
+	assert.Equal(t, "apps.grafana.com", kind.GroupVersionResource().Group)
+	assert.Equal(t, "v1alpha1", kind.GroupVersionResource().Version)
+	assert.Equal(t, "appmanifests", kind.GroupVersionResource().Resource)
+}

--- a/app/appmanifest/v1alpha1/testfiles/manifest-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/manifest-01.json
@@ -1,0 +1,99 @@
+{
+  "apiVersion": "apps.grafana.com/v1alpha1",
+  "kind": "AppManifest",
+  "metadata": {
+    "name": "issue-tracker-project",
+    "creationTimestamp": "2025-02-19T20:36:00Z"
+  },
+  "spec": {
+    "appName": "issue-tracker-project",
+    "group": "issuetrackerproject.ext.grafana.com",
+    "kinds": [
+      {
+        "kind": "Issue",
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "name": "v1",
+            "schema": {
+              "spec": {
+                "description": "spec is the schema of our resource.\nWe could include `status` or `metadata` top-level fields here as well,\nbut `status` is for state information, which we don't need to track,\nand `metadata` is for kind/schema-specific custom metadata in addition to the existing\ncommon metadata, and we don't need to track any specific custom metadata.",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "description",
+                  "status"
+                ],
+                "type": "object"
+              },
+              "status": {
+                "properties": {
+                  "additionalFields": {
+                    "description": "additionalFields is reserved for future use",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "operatorStates": {
+                    "additionalProperties": {
+                      "properties": {
+                        "descriptiveState": {
+                          "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
+                          "type": "string"
+                        },
+                        "details": {
+                          "description": "details contains any extra information that is operator-specific",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "lastEvaluation": {
+                          "description": "lastEvaluation is the ResourceVersion last evaluated",
+                          "type": "string"
+                        },
+                        "state": {
+                          "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
+                          "enum": [
+                            "success",
+                            "in_progress",
+                            "failed"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "lastEvaluation",
+                        "state"
+                      ],
+                      "type": "object"
+                    },
+                    "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              }
+            }
+          }
+        ],
+        "conversion": false
+      }
+    ]
+  },
+  "status": {
+    "resources": {
+      "crds": {
+        "status": "success"
+      }
+    }
+  }
+}

--- a/app/appmanifest/v1alpha1/testfiles/schema-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/schema-01.json
@@ -1,0 +1,68 @@
+{
+  "spec": {
+    "description": "spec is the schema of our resource.\nWe could include `status` or `metadata` top-level fields here as well,\nbut `status` is for state information, which we don't need to track,\nand `metadata` is for kind/schema-specific custom metadata in addition to the existing\ncommon metadata, and we don't need to track any specific custom metadata.",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "description",
+      "status"
+    ],
+    "type": "object"
+  },
+  "status": {
+    "properties": {
+      "additionalFields": {
+        "description": "additionalFields is reserved for future use",
+        "type": "object",
+        "x-kubernetes-preserve-unknown-fields": true
+      },
+      "operatorStates": {
+        "additionalProperties": {
+          "properties": {
+            "descriptiveState": {
+              "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
+              "type": "string"
+            },
+            "details": {
+              "description": "details contains any extra information that is operator-specific",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "lastEvaluation": {
+              "description": "lastEvaluation is the ResourceVersion last evaluated",
+              "type": "string"
+            },
+            "state": {
+              "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
+              "enum": [
+                "success",
+                "in_progress",
+                "failed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "lastEvaluation",
+            "state"
+          ],
+          "type": "object"
+        },
+        "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
+        "type": "object"
+      }
+    },
+    "type": "object",
+    "x-kubernetes-preserve-unknown-fields": true
+  }
+}

--- a/app/appmanifest/v1alpha1/testfiles/spec-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/spec-01.json
@@ -1,0 +1,84 @@
+{
+  "appName": "issue-tracker-project",
+  "group": "issuetrackerproject.ext.grafana.com",
+  "kinds": [
+    {
+      "kind": "Issue",
+      "scope": "Namespaced",
+      "versions": [
+        {
+          "name": "v1",
+          "schema": {
+            "spec": {
+              "description": "spec is the schema of our resource.\nWe could include `status` or `metadata` top-level fields here as well,\nbut `status` is for state information, which we don't need to track,\nand `metadata` is for kind/schema-specific custom metadata in addition to the existing\ncommon metadata, and we don't need to track any specific custom metadata.",
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "description",
+                "status"
+              ],
+              "type": "object"
+            },
+            "status": {
+              "properties": {
+                "additionalFields": {
+                  "description": "additionalFields is reserved for future use",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorStates": {
+                  "additionalProperties": {
+                    "properties": {
+                      "descriptiveState": {
+                        "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
+                        "type": "string"
+                      },
+                      "details": {
+                        "description": "details contains any extra information that is operator-specific",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "lastEvaluation": {
+                        "description": "lastEvaluation is the ResourceVersion last evaluated",
+                        "type": "string"
+                      },
+                      "state": {
+                        "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
+                        "enum": [
+                          "success",
+                          "in_progress",
+                          "failed"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "lastEvaluation",
+                      "state"
+                    ],
+                    "type": "object"
+                  },
+                  "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          }
+        }
+      ],
+      "conversion": false
+    }
+  ]
+}

--- a/app/definitions/app-manifest-manifest.json
+++ b/app/definitions/app-manifest-manifest.json
@@ -55,9 +55,6 @@
                                                 "type": "array"
                                             }
                                         },
-                                        "required": [
-                                            "accessKinds"
-                                        ],
                                         "type": "object"
                                     },
                                     "group": {
@@ -179,8 +176,7 @@
                                                         },
                                                         "required": [
                                                             "name",
-                                                            "schema",
-                                                            "selectableFields"
+                                                            "schema"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -201,8 +197,7 @@
                                 "required": [
                                     "appName",
                                     "group",
-                                    "kinds",
-                                    "extraPermissions"
+                                    "kinds"
                                 ],
                                 "type": "object"
                             },

--- a/app/definitions/app-manifest-manifest.json
+++ b/app/definitions/app-manifest-manifest.json
@@ -55,6 +55,9 @@
                                                 "type": "array"
                                             }
                                         },
+                                        "required": [
+                                            "accessKinds"
+                                        ],
                                         "type": "object"
                                     },
                                     "group": {

--- a/app/definitions/appmanifest.apps.grafana.com.json
+++ b/app/definitions/appmanifest.apps.grafana.com.json
@@ -54,9 +54,6 @@
                                                 "type": "array"
                                             }
                                         },
-                                        "required": [
-                                            "accessKinds"
-                                        ],
                                         "type": "object"
                                     },
                                     "group": {
@@ -178,8 +175,7 @@
                                                         },
                                                         "required": [
                                                             "name",
-                                                            "schema",
-                                                            "selectableFields"
+                                                            "schema"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -200,8 +196,7 @@
                                 "required": [
                                     "appName",
                                     "group",
-                                    "kinds",
-                                    "extraPermissions"
+                                    "kinds"
                                 ],
                                 "type": "object"
                             },

--- a/app/definitions/appmanifest.apps.grafana.com.json
+++ b/app/definitions/appmanifest.apps.grafana.com.json
@@ -54,6 +54,9 @@
                                                 "type": "array"
                                             }
                                         },
+                                        "required": [
+                                            "accessKinds"
+                                        ],
                                         "type": "object"
                                     },
                                     "group": {

--- a/app/manifest.cue
+++ b/app/manifest.cue
@@ -63,7 +63,7 @@ appManifest: versions: v1alpha1: {
 			name: string
 			admission?: #AdmissionCapabilities
 			schema: #ManifestKindVersionSchema
-			selectableFields: [...string]
+			selectableFields?: [...string]
 			additionalPrinterColumns?: [...#AdditionalPrinterColumns]
 		}
 		#ManifestKind: {
@@ -83,9 +83,9 @@ appManifest: versions: v1alpha1: {
 			kinds: [...#ManifestKind]
 			// ExtraPermissions contains additional permissions needed for an app's backend component to operate.
 			// Apps implicitly have all permissions for kinds they managed (defined in `kinds`).
-			extraPermissions: {
+			extraPermissions?: {
 				// accessKinds is a list of KindPermission objects for accessing additional kinds provided by other apps
-				accessKinds: [...#KindPermission]
+				accessKinds?: [...#KindPermission]
 			}
 			// DryRunKinds dictates whether this revision should create/update CRD's from the provided kinds,
 			// Or simply validate and report errors in status.resources.crds.

--- a/app/manifest.cue
+++ b/app/manifest.cue
@@ -85,7 +85,7 @@ appManifest: versions: v1alpha1: {
 			// Apps implicitly have all permissions for kinds they managed (defined in `kinds`).
 			extraPermissions?: {
 				// accessKinds is a list of KindPermission objects for accessing additional kinds provided by other apps
-				accessKinds?: [...#KindPermission]
+				accessKinds: [...#KindPermission]
 			}
 			// DryRunKinds dictates whether this revision should create/update CRD's from the provided kinds,
 			// Or simply validate and report errors in status.resources.crds.


### PR DESCRIPTION
This is a follow-up to https://github.com/grafana/grafana-app-sdk/pull/639

Add tests for generated AppManifest code and conversion code. As part of this, I realized that some fields (`extraPermissions` and `selectableFields`) should be optional in the CUE, so as not to be required in the CRD, so I updated those fields and re-ran `make generate`.