### PR TITLE
Disable revive:use-errors-new linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,8 @@ linters-settings:
         disabled: true
       - name:  nested-structs
         disabled: true
+      - name: use-errors-new
+        disabled: true
   gocognit:
     min-complexity: 50
   mnd:

--- a/operator/reconciler.go
+++ b/operator/reconciler.go
@@ -154,6 +154,8 @@ const (
 //   - If the action is a Create, and the OpinionatedReconciler's finalizer is missing, add the finalizer after the delegated Reconcile request returns successfully
 //   - If the action is an Update, and the DeletionTimestamp is non-nil, remove the OpinionatedReconciler's finalizer, and do not delegate (the subsequent Delete will be delegated)
 //   - If the action is an Update, and the OpinionatedReconciler's finalizer is missing (and DeletionTimestamp is nil), add the finalizer, and do not delegate (the subsequent update action will delegate)
+//
+//nolint:funlen
 func (o *OpinionatedReconciler) Reconcile(ctx context.Context, request ReconcileRequest) (ReconcileResult, error) {
 	ctx, span := GetTracer().Start(ctx, "OpinionatedReconciler-reconcile")
 	defer span.End()

--- a/operator/runner.go
+++ b/operator/runner.go
@@ -225,6 +225,7 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 	return runner.Run(ctx)
 }
 
+//nolint:revive
 func (s *Runner) getManifestData(provider app.Provider) (*app.ManifestData, error) {
 	manifest := provider.Manifest()
 	data := app.ManifestData{}


### PR DESCRIPTION
Disable revive:use-errors-new linter, as it requires too many changes to the codebase for now.

Also ignore two other linter errors that have cropped up.