### PR TITLE
Add typed and namespaced resource clients

### DIFF
--- a/resource/namespaced_client.go
+++ b/resource/namespaced_client.go
@@ -1,0 +1,68 @@
+package resource
+
+import (
+	"context"
+)
+
+// NamespacedClient is a typed client that is scoped to a single namespace.
+// It prevents the user from having to specify the namespace in every request.
+type NamespacedClient[T Object, L ListObject] struct {
+	cli       *TypedClient[T, L]
+	namespace string
+}
+
+// NewNamespacedClient creates a new NamespacedClient.
+func NewNamespaced[T Object, L ListObject](cli *TypedClient[T, L], namespace string) *NamespacedClient[T, L] {
+	return &NamespacedClient[T, L]{
+		cli:       cli,
+		namespace: namespace,
+	}
+}
+
+// List lists all resources in the namespace.
+func (c *NamespacedClient[T, L]) List(ctx context.Context, opts ListOptions) (L, error) {
+	return c.cli.List(ctx, c.namespace, opts)
+}
+
+// Watch watches all resources in the namespace.
+func (c *NamespacedClient[T, L]) Watch(ctx context.Context, opts WatchOptions) (WatchResponse, error) {
+	return c.cli.Watch(ctx, c.namespace, opts)
+}
+
+// Get gets a resource by name in the namespace.
+func (c *NamespacedClient[T, L]) Get(ctx context.Context, uid string) (T, error) {
+	return c.cli.Get(ctx, Identifier{
+		Namespace: c.namespace,
+		Name:      uid,
+	})
+}
+
+// Create creates a resource in the namespace.
+func (c *NamespacedClient[T, L]) Create(ctx context.Context, obj T, opts CreateOptions) (T, error) {
+	obj.SetNamespace(c.namespace)
+	return c.cli.Create(ctx, obj, opts)
+}
+
+// Update updates a resource in the namespace.
+func (c *NamespacedClient[T, L]) Update(ctx context.Context, obj T, opts UpdateOptions) (T, error) {
+	obj.SetNamespace(c.namespace)
+	return c.cli.Update(ctx, obj, opts)
+}
+
+// Patch patches a resource in the namespace.
+func (c *NamespacedClient[T, L]) Patch(
+	ctx context.Context, uid string, req PatchRequest, opts PatchOptions,
+) (T, error) {
+	return c.cli.Patch(ctx, Identifier{
+		Namespace: c.namespace,
+		Name:      uid,
+	}, req, opts)
+}
+
+// Delete deletes a resource in the namespace.
+func (c *NamespacedClient[T, L]) Delete(ctx context.Context, uid string, opts DeleteOptions) error {
+	return c.cli.Delete(ctx, Identifier{
+		Namespace: c.namespace,
+		Name:      uid,
+	}, opts)
+}

--- a/resource/typedclient.go
+++ b/resource/typedclient.go
@@ -1,0 +1,129 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+)
+
+// TypedClient is a wrapper around a Client that works with a specific Object type.
+// It is used to provide type safety and convenience methods for working with a specific object type.
+// It automatically sets the GroupVersionKind on the provided object type when creating or updating resources,
+// which means that the caller doesn't need to ensure that they are set in advance.
+type TypedClient[T Object, L ListObject] struct {
+	cli  Client
+	kind Kind
+}
+
+// NewTypedClient creates a new TypedClient.
+// It requires the caller to provide the kind, because it's possible that empty objects of the provided type
+// will not have their kind set.
+func NewTypedClient[T Object, L ListObject](cli Client, kind Kind) *TypedClient[T, L] {
+	return &TypedClient[T, L]{
+		cli:  cli,
+		kind: kind,
+	}
+}
+
+// List returns the list of objects of the provided type.
+func (c *TypedClient[T, L]) List(ctx context.Context, namespace string, opts ListOptions) (L, error) {
+	var res L
+
+	v, err := c.cli.List(ctx, namespace, opts)
+	if err != nil {
+		return res, err
+	}
+
+	res, ok := v.(L)
+	if !ok {
+		return res, fmt.Errorf("expected %T, got %T", res, v)
+	}
+
+	return res, nil
+}
+
+// Watch returns an untyped watch response.
+// It is the same as calling the underlying client's Watch method.
+// Due to how the SDK handles watch responses, it is currently not possible to provide a type-safe watch response.
+func (c *TypedClient[T, L]) Watch(ctx context.Context, namespace string, opts WatchOptions) (WatchResponse, error) {
+	return c.cli.Watch(ctx, namespace, opts)
+}
+
+// Get returns an object of the provided type.
+func (c *TypedClient[T, L]) Get(ctx context.Context, id Identifier) (T, error) {
+	var res T
+
+	v, err := c.cli.Get(ctx, id)
+	if err != nil {
+		return res, err
+	}
+
+	res, ok := v.(T)
+	if !ok {
+		return res, fmt.Errorf("expected %T, got %T", res, v)
+	}
+
+	return res, nil
+}
+
+// Create creates the provided object.
+// It automatically sets the GroupVersionKind on the provided object type when creating resources,
+// so the caller doesn't need to ensure that they are set in advance.
+func (c *TypedClient[T, L]) Create(ctx context.Context, obj T, opts CreateOptions) (T, error) {
+	obj.SetGroupVersionKind(c.kind.GroupVersionKind())
+
+	var res T
+
+	v, err := c.cli.Create(ctx, obj.GetStaticMetadata().Identifier(), obj, opts)
+	if err != nil {
+		return res, err
+	}
+
+	res, ok := v.(T)
+	if !ok {
+		return res, fmt.Errorf("expected %T, got %T", res, v)
+	}
+
+	return res, nil
+}
+
+// Update updates the provided object.
+// It automatically sets the GroupVersionKind on the provided object type when updating resources,
+// so the caller doesn't need to ensure that they are set in advance.
+func (c *TypedClient[T, L]) Update(ctx context.Context, obj T, opts UpdateOptions) (T, error) {
+	obj.SetGroupVersionKind(c.kind.GroupVersionKind())
+
+	var res T
+	v, err := c.cli.Update(ctx, obj.GetStaticMetadata().Identifier(), obj, opts)
+	if err != nil {
+		return res, err
+	}
+
+	res, ok := v.(T)
+	if !ok {
+		return res, fmt.Errorf("expected %T, got %T", res, v)
+	}
+
+	return res, nil
+}
+
+// Patch patches the provided object.
+func (c *TypedClient[T, L]) Patch(ctx context.Context, id Identifier, req PatchRequest, opts PatchOptions) (T, error) {
+	var res T
+
+	v, err := c.cli.Patch(ctx, id, req, opts)
+	if err != nil {
+		return res, err
+	}
+
+	res, ok := v.(T)
+	if !ok {
+		return res, fmt.Errorf("expected %T, got %T", res, v)
+	}
+
+	return res, nil
+}
+
+// Delete deletes the provided object.
+func (c *TypedClient[T, L]) Delete(ctx context.Context, id Identifier, opts DeleteOptions) error {
+	return c.cli.Delete(ctx, id, opts)
+}


### PR DESCRIPTION
### What

This change adds two new resource clients - a typed client, which uses generics and ensures the GVK is always properly set on mutations and a namespaced client, which builds on top of the typed client and additionally sets the namespace to all requests, based on the value passed in initializer.

### Why

These clients are more convenient to work with, when a store is not required, e.g. in short-lived processes like CLIs or other tools which interact with the APIs.

We could e.g. use these in codegen for providing instantiated clients for generated kinds.

Closes https://github.com/grafana/grafana-app-sdk/issues/690