### PR TITLE
Fix CopyObject to deep copy the object rather than shallow copy

### DIFF
--- a/cmd/grafana-app-sdk/templates/Makefile.tmpl
+++ b/cmd/grafana-app-sdk/templates/Makefile.tmpl
@@ -54,7 +54,7 @@ build/operator:
 
 .PHONY: compile/operator
 compile/operator:
-	@go build cmd/operator -o target/operator
+	@go build -o "target/operator" cmd/operator/*.go
 
 .PHONY: generate
 generate:

--- a/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
+++ b/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.24-alpine as builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -5,96 +5,96 @@
 package {{.Package}}{{$root := .}}
 
 import ({{ range .CustomMetadataFields }}{{ range $imp := .GoType.AdditionalImports }}
-    "{{$imp}}"{{ end }}{{ end }}
-    "fmt"
-    "github.com/grafana/grafana-app-sdk/resource"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/runtime"
-    "k8s.io/apimachinery/pkg/runtime/schema"
+	"{{$imp}}"{{ end }}{{ end }}
+	"fmt"
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // +k8s:openapi-gen=true
 type {{.TypeName}} struct {
-    metav1.TypeMeta `json:",inline" yaml:",inline"`
-    metav1.ObjectMeta `json:"metadata" yaml:"metadata"`
+	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata" yaml:"metadata"`
 
-    // Spec is the spec of the {{.TypeName}}
-    Spec       {{.SpecTypeName}} `json:"spec" yaml:"spec"`
+	// Spec is the spec of the {{.TypeName}}
+	Spec	   {{.SpecTypeName}} `json:"spec" yaml:"spec"`
 
-    {{ range .Subresources }}
-        {{ if ne .Comment "" }}
-            // {{.Comment }}
-        {{end}}
-        {{ .Name }} {{.TypeName}} `json:"{{.JSONName}}" yaml:"{{.JSONName}}"`
-    {{ end }}
+	{{ range .Subresources }}
+		{{ if ne .Comment "" }}
+			// {{.Comment }}
+		{{end}}
+		{{ .Name }} {{.TypeName}} `json:"{{.JSONName}}" yaml:"{{.JSONName}}"`
+	{{ end }}
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) GetSpec() any {
-    return {{.ObjectShortName}}.Spec
+	return {{.ObjectShortName}}.Spec
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) SetSpec(spec any) error {
-    cast, ok := spec.({{.SpecTypeName}})
-    if !ok {
-        return fmt.Errorf("cannot set spec type %#v, not of type Spec", spec)
-    }
-    {{.ObjectShortName}}.Spec = cast
-    return nil
+	cast, ok := spec.({{.SpecTypeName}})
+	if !ok {
+		return fmt.Errorf("cannot set spec type %#v, not of type Spec", spec)
+	}
+	{{.ObjectShortName}}.Spec = cast
+	return nil
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) GetSubresources() map[string]any {
-    return map[string]any{ {{ range .Subresources }}
-        "{{.JSONName}}": {{$root.ObjectShortName}}.{{.Name}},
-    {{ end }} }
+	return map[string]any{ {{ range .Subresources }}
+		"{{.JSONName}}": {{$root.ObjectShortName}}.{{.Name}},
+	{{ end }} }
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) GetSubresource(name string) (any,bool) {
-    switch name { {{ range .Subresources }}
-    case"{{ .JSONName }}":
-        return {{$root.ObjectShortName}}.{{.Name}}, true
-    {{ end }}default:
-        return nil, false
-    }
+	switch name { {{ range .Subresources }}
+	case"{{ .JSONName }}":
+		return {{$root.ObjectShortName}}.{{.Name}}, true
+	{{ end }}default:
+		return nil, false
+	}
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) SetSubresource(name string, value any) error {
-    switch name { {{ range .Subresources }}
-    case"{{ .JSONName }}":
-        cast, ok := value.({{.TypeName}})
-        if !ok {
-            return fmt.Errorf("cannot set {{.JSONName}} type %#v, not of type {{.TypeName}}", value)
-        }
-        {{$root.ObjectShortName}}.{{.Name}} = cast
-        return nil
-    {{ end }}default:
-        return fmt.Errorf("subresource '%s' does not exist", name)
-    }
+	switch name { {{ range .Subresources }}
+	case"{{ .JSONName }}":
+		cast, ok := value.({{.TypeName}})
+		if !ok {
+			return fmt.Errorf("cannot set {{.JSONName}} type %#v, not of type {{.TypeName}}", value)
+		}
+		{{$root.ObjectShortName}}.{{.Name}} = cast
+		return nil
+	{{ end }}default:
+		return fmt.Errorf("subresource '%s' does not exist", name)
+	}
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) GetStaticMetadata() resource.StaticMetadata {
-    gvk := {{.ObjectShortName}}.GroupVersionKind()
-    return resource.StaticMetadata{
-        Name:      {{.ObjectShortName}}.ObjectMeta.Name,
-    	Namespace: {{.ObjectShortName}}.ObjectMeta.Namespace,
-    	Group:     gvk.Group,
-    	Version:   gvk.Version,
-    	Kind:      gvk.Kind,
-    }
+	gvk := {{.ObjectShortName}}.GroupVersionKind()
+	return resource.StaticMetadata{
+		Name:	  {{.ObjectShortName}}.ObjectMeta.Name,
+		Namespace: {{.ObjectShortName}}.ObjectMeta.Namespace,
+		Group:	 gvk.Group,
+		Version:   gvk.Version,
+		Kind:	  gvk.Kind,
+	}
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) SetStaticMetadata(metadata resource.StaticMetadata) {
-    {{.ObjectShortName}}.Name = metadata.Name
-    {{.ObjectShortName}}.Namespace = metadata.Namespace
-    {{.ObjectShortName}}.SetGroupVersionKind(schema.GroupVersionKind{
-        Group:   metadata.Group,
-        Version: metadata.Version,
-        Kind:    metadata.Kind,
-    })
+	{{.ObjectShortName}}.Name = metadata.Name
+	{{.ObjectShortName}}.Namespace = metadata.Namespace
+	{{.ObjectShortName}}.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   metadata.Group,
+		Version: metadata.Version,
+		Kind:	metadata.Kind,
+	})
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) GetCommonMetadata() resource.CommonMetadata {
-    dt := {{.ObjectShortName}}.DeletionTimestamp
+	dt := {{.ObjectShortName}}.DeletionTimestamp
 	var deletionTimestamp *time.Time
 	if dt != nil {
 		deletionTimestamp = &dt.Time
@@ -102,100 +102,110 @@ func ({{.ObjectShortName}} *{{.TypeName}}) GetCommonMetadata() resource.CommonMe
 	// Legacy ExtraFields support
 	extraFields := make(map[string]any)
 	if {{.ObjectShortName}}.Annotations != nil {
-	    extraFields["annotations"] = {{.ObjectShortName}}.Annotations
+		extraFields["annotations"] = {{.ObjectShortName}}.Annotations
 	}
 	if {{.ObjectShortName}}.ManagedFields != nil {
-	    extraFields["managedFields"] = {{.ObjectShortName}}.ManagedFields
+		extraFields["managedFields"] = {{.ObjectShortName}}.ManagedFields
 	}
 	if {{.ObjectShortName}}.OwnerReferences != nil {
-	    extraFields["ownerReferences"] = {{.ObjectShortName}}.OwnerReferences
+		extraFields["ownerReferences"] = {{.ObjectShortName}}.OwnerReferences
 	}
 	return resource.CommonMetadata{
-		UID:               string({{.ObjectShortName}}.UID),
+		UID:			   string({{.ObjectShortName}}.UID),
 		ResourceVersion:   {{.ObjectShortName}}.ResourceVersion,
-		Generation:        {{.ObjectShortName}}.Generation,
-		Labels:            {{.ObjectShortName}}.Labels,
+		Generation:		{{.ObjectShortName}}.Generation,
+		Labels:			{{.ObjectShortName}}.Labels,
 		CreationTimestamp: {{.ObjectShortName}}.CreationTimestamp.Time,
 		DeletionTimestamp: deletionTimestamp,
-		Finalizers:        {{.ObjectShortName}}.Finalizers,
+		Finalizers:		{{.ObjectShortName}}.Finalizers,
 		UpdateTimestamp:   {{.ObjectShortName}}.GetUpdateTimestamp(),
-		CreatedBy:         {{.ObjectShortName}}.GetCreatedBy(),
-		UpdatedBy:         {{.ObjectShortName}}.GetUpdatedBy(),
-		ExtraFields:       extraFields,
+		CreatedBy:		 {{.ObjectShortName}}.GetCreatedBy(),
+		UpdatedBy:		 {{.ObjectShortName}}.GetUpdatedBy(),
+		ExtraFields:	   extraFields,
 	}
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) SetCommonMetadata(metadata resource.CommonMetadata) {
-    {{.ObjectShortName}}.UID = types.UID(metadata.UID)
-    {{.ObjectShortName}}.ResourceVersion = metadata.ResourceVersion
-    {{.ObjectShortName}}.Generation = metadata.Generation
-    {{.ObjectShortName}}.Labels = metadata.Labels
-    {{.ObjectShortName}}.CreationTimestamp = metav1.NewTime(metadata.CreationTimestamp)
-    if metadata.DeletionTimestamp != nil {
-        dt := metav1.NewTime(*metadata.DeletionTimestamp)
-        {{.ObjectShortName}}.DeletionTimestamp = &dt
-    } else {
-        {{.ObjectShortName}}.DeletionTimestamp = nil
-    }
-    {{.ObjectShortName}}.Finalizers = metadata.Finalizers
-    if {{.ObjectShortName}}.Annotations == nil {
-        {{.ObjectShortName}}.Annotations = make(map[string]string)
-    }
-    if !metadata.UpdateTimestamp.IsZero() {
-        {{.ObjectShortName}}.SetUpdateTimestamp(metadata.UpdateTimestamp)
-    }
-    if metadata.CreatedBy != "" {
-        {{.ObjectShortName}}.SetCreatedBy(metadata.CreatedBy)
-    }
-    if metadata.UpdatedBy != "" {
-        {{.ObjectShortName}}.SetUpdatedBy(metadata.UpdatedBy)
-    }
-    // Legacy support for setting Annotations, ManagedFields, and OwnerReferences via ExtraFields
-    if metadata.ExtraFields != nil {
-        if annotations, ok := metadata.ExtraFields["annotations"]; ok {
-            if cast, ok := annotations.(map[string]string); ok {
-                 {{.ObjectShortName}}.Annotations = cast
-            }
-        }
-        if managedFields, ok := metadata.ExtraFields["managedFields"]; ok {
-            if cast, ok := managedFields.([]metav1.ManagedFieldsEntry); ok {
-                 {{.ObjectShortName}}.ManagedFields = cast
-            }
-        }
-        if ownerReferences, ok := metadata.ExtraFields["ownerReferences"]; ok {
-            if cast, ok := ownerReferences.([]metav1.OwnerReference); ok {
-                 {{.ObjectShortName}}.OwnerReferences = cast
-            }
-        }
-    }
+	{{.ObjectShortName}}.UID = types.UID(metadata.UID)
+	{{.ObjectShortName}}.ResourceVersion = metadata.ResourceVersion
+	{{.ObjectShortName}}.Generation = metadata.Generation
+	{{.ObjectShortName}}.Labels = metadata.Labels
+	{{.ObjectShortName}}.CreationTimestamp = metav1.NewTime(metadata.CreationTimestamp)
+	if metadata.DeletionTimestamp != nil {
+		dt := metav1.NewTime(*metadata.DeletionTimestamp)
+		{{.ObjectShortName}}.DeletionTimestamp = &dt
+	} else {
+		{{.ObjectShortName}}.DeletionTimestamp = nil
+	}
+	{{.ObjectShortName}}.Finalizers = metadata.Finalizers
+	if {{.ObjectShortName}}.Annotations == nil {
+		{{.ObjectShortName}}.Annotations = make(map[string]string)
+	}
+	if !metadata.UpdateTimestamp.IsZero() {
+		{{.ObjectShortName}}.SetUpdateTimestamp(metadata.UpdateTimestamp)
+	}
+	if metadata.CreatedBy != "" {
+		{{.ObjectShortName}}.SetCreatedBy(metadata.CreatedBy)
+	}
+	if metadata.UpdatedBy != "" {
+		{{.ObjectShortName}}.SetUpdatedBy(metadata.UpdatedBy)
+	}
+	// Legacy support for setting Annotations, ManagedFields, and OwnerReferences via ExtraFields
+	if metadata.ExtraFields != nil {
+		if annotations, ok := metadata.ExtraFields["annotations"]; ok {
+			if cast, ok := annotations.(map[string]string); ok {
+				 {{.ObjectShortName}}.Annotations = cast
+			}
+		}
+		if managedFields, ok := metadata.ExtraFields["managedFields"]; ok {
+			if cast, ok := managedFields.([]metav1.ManagedFieldsEntry); ok {
+				 {{.ObjectShortName}}.ManagedFields = cast
+			}
+		}
+		if ownerReferences, ok := metadata.ExtraFields["ownerReferences"]; ok {
+			if cast, ok := ownerReferences.([]metav1.OwnerReference); ok {
+				 {{.ObjectShortName}}.OwnerReferences = cast
+			}
+		}
+	}
 }
 
 {{range .CustomMetadataFields}}func ({{$root.ObjectShortName}} *{{$root.TypeName}}) Get{{.FieldName}}() {{.GoType.GoType}} {
-    if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
-        {{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
-    }
-    {{ $var := (printf "%v.ObjectMeta.Annotations[\"grafana.com/%v\"]" $root.ObjectShortName .JSONName) }}
-    {{ $ret := (call .GoType.GetFuncTemplate $var) }}
-    {{ $ret }}
+	if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
+		{{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
+	}
+	{{ $var := (printf "%v.ObjectMeta.Annotations[\"grafana.com/%v\"]" $root.ObjectShortName .JSONName) }}
+	{{ $ret := (call .GoType.GetFuncTemplate $var) }}
+	{{ $ret }}
 }
 
 func ({{$root.ObjectShortName}} *{{$root.TypeName}}) Set{{.FieldName}}({{.JSONName}} {{.GoType.GoType}}) {
-    if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
-        {{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
-    }
-    {{ $var := (printf "%v.ObjectMeta.Annotations[\"grafana.com/%v\"]" $root.ObjectShortName .JSONName) }}
-    {{ $ret := (call .GoType.SetFuncTemplate .JSONName $var) }}
-    {{ $ret }}
+	if {{$root.ObjectShortName}}.ObjectMeta.Annotations == nil {
+		{{$root.ObjectShortName}}.ObjectMeta.Annotations = make(map[string]string)
+	}
+	{{ $var := (printf "%v.ObjectMeta.Annotations[\"grafana.com/%v\"]" $root.ObjectShortName .JSONName) }}
+	{{ $ret := (call .GoType.SetFuncTemplate .JSONName $var) }}
+	{{ $ret }}
 }
 
 {{end}}
 
 func ({{.ObjectShortName}} *{{.TypeName}}) Copy() resource.Object {
-    return resource.CopyObject({{.ObjectShortName}})
+	return resource.CopyObject({{.ObjectShortName}})
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopyObject() runtime.Object {
-    return {{.ObjectShortName}}.Copy()
+	return {{.ObjectShortName}}.Copy()
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
+	cpy := &{{.TypeName}}{}
+	{{.ObjectShortName}}.DeepCopyInto(cpy)
+	return cpy
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
+	resource.CopyObjectInto(dst, {{.ObjectShortName}})
 }
 
 // Interface compliance compile-time check
@@ -205,7 +215,7 @@ var _ resource.Object = &{{.TypeName}}{}
 type {{.TypeName}}List struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	metav1.ListMeta `json:"metadata" yaml:"metadata"`
-	Items           []{{.TypeName}} `json:"items" yaml:"items"`
+	Items		   []{{.TypeName}} `json:"items" yaml:"items"`
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopyObject() runtime.Object {
@@ -215,11 +225,11 @@ func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopyObject() runtime.Object {
 func ({{.ObjectShortName}} *{{.TypeName}}List) Copy() resource.ListObject {
 	cpy := &{{.TypeName}}List{
 		TypeMeta: {{.ObjectShortName}}.TypeMeta,
-		Items:    make([]{{.TypeName}}, len({{.ObjectShortName}}.Items)),
+		Items:	make([]{{.TypeName}}, len({{.ObjectShortName}}.Items)),
 	}
 	{{.ObjectShortName}}.ListMeta.DeepCopyInto(&cpy.ListMeta)
 	for i := 0; i < len({{.ObjectShortName}}.Items); i++ {
-        if item, ok := o.Items[i].Copy().(*{{.TypeName}}); ok {
+		if item, ok := o.Items[i].Copy().(*{{.TypeName}}); ok {
 			cpy.Items[i] = *item
 		}
 	}
@@ -235,11 +245,44 @@ func ({{.ObjectShortName}} *{{.TypeName}}List) GetItems() []resource.Object {
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}List) SetItems(items []resource.Object) {
-    o.Items = make([]{{.TypeName}}, len(items))
+	o.Items = make([]{{.TypeName}}, len(items))
 	for i := 0; i < len(items); i++ {
 		o.Items[i] = *items[i].(*{{.TypeName}})
 	}
 }
 
+func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopy() *{{.TypeName}}List {
+	cpy := &{{.TypeName}}List{}
+	{{.ObjectShortName}}.DeepCopyInto(cpy)
+	return cpy
+}
+
+func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopyInto(dst *{{.TypeName}}List) {
+	resource.CopyObjectInto(dst, {{.ObjectShortName}})
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &{{.TypeName}}List{}
+
+// Copy methods for all subresource types
+func (s *{{.SpecTypeName}}) DeepCopy() *{{.SpecTypeName}} {
+	cpy := &{{.SpecTypeName}}{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (s *{{.SpecTypeName}}) DeepCopyInto(dst *{{.SpecTypeName}}) {
+	resource.CopyObjectInto(dst, s)
+}
+
+{{ range .Subresources }}
+func(s *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
+	cpy := &{{.TypeName}}{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+func(s *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
+	resource.CopyObjectInto(dst, s)
+}
+{{ end }}

--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -205,7 +205,11 @@ func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
 }
 
 func ({{.ObjectShortName}} *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
-	resource.CopyObjectInto(dst, {{.ObjectShortName}})
+	dst.TypeMeta.APIVersion = {{.ObjectShortName}}.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = {{.ObjectShortName}}.TypeMeta.Kind
+	{{.ObjectShortName}}.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	{{.ObjectShortName}}.Spec.DeepCopyInto(&dst.Spec){{ range .Subresources }}
+	{{$.ObjectShortName}}.{{.Name}}.DeepCopyInto(&dst.{{.Name}}){{end}}
 }
 
 // Interface compliance compile-time check
@@ -265,23 +269,27 @@ func ({{.ObjectShortName}} *{{.TypeName}}List) DeepCopyInto(dst *{{.TypeName}}Li
 var _ resource.ListObject = &{{.TypeName}}List{}
 
 // Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
 func (s *{{.SpecTypeName}}) DeepCopy() *{{.SpecTypeName}} {
 	cpy := &{{.SpecTypeName}}{}
 	s.DeepCopyInto(cpy)
 	return cpy
 }
 
+// DeepCopyInto deep copies Spec into another Spec object
 func (s *{{.SpecTypeName}}) DeepCopyInto(dst *{{.SpecTypeName}}) {
 	resource.CopyObjectInto(dst, s)
 }
 
-{{ range .Subresources }}
+{{ range .Subresources }}// DeepCopy creates a full deep copy of {{.TypeName}}
 func(s *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
 	cpy := &{{.TypeName}}{}
 	s.DeepCopyInto(cpy)
 	return cpy
 }
 
+// DeepCopyInto deep copies {{.TypeName}} into another {{.TypeName}} object
 func(s *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
 	resource.CopyObjectInto(dst, s)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_object_gen.go.txt
@@ -222,6 +222,20 @@ func (o *CustomKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *CustomKind) DeepCopy() *CustomKind {
+	cpy := &CustomKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKind) DeepCopyInto(dst *CustomKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &CustomKind{}
 
@@ -265,5 +279,41 @@ func (o *CustomKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *CustomKindList) DeepCopy() *CustomKindList {
+	cpy := &CustomKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKindList) DeepCopyInto(dst *CustomKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &CustomKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *CustomKindSpec) DeepCopy() *CustomKindSpec {
+	cpy := &CustomKindSpec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *CustomKindSpec) DeepCopyInto(dst *CustomKindSpec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of CustomKindStatus
+func (s *CustomKindStatus) DeepCopy() *CustomKindStatus {
+	cpy := &CustomKindStatus{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies CustomKindStatus into another CustomKindStatus object
+func (s *CustomKindStatus) DeepCopyInto(dst *CustomKindStatus) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
@@ -254,6 +254,20 @@ func (o *CustomKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *CustomKind) DeepCopy() *CustomKind {
+	cpy := &CustomKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKind) DeepCopyInto(dst *CustomKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &CustomKind{}
 
@@ -297,5 +311,41 @@ func (o *CustomKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *CustomKindList) DeepCopy() *CustomKindList {
+	cpy := &CustomKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKindList) DeepCopyInto(dst *CustomKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &CustomKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *CustomKindSpec) DeepCopy() *CustomKindSpec {
+	cpy := &CustomKindSpec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *CustomKindSpec) DeepCopyInto(dst *CustomKindSpec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of CustomKindStatus
+func (s *CustomKindStatus) DeepCopy() *CustomKindStatus {
+	cpy := &CustomKindStatus{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies CustomKindStatus into another CustomKindStatus object
+func (s *CustomKindStatus) DeepCopyInto(dst *CustomKindStatus) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_object_gen.go.txt
@@ -222,6 +222,20 @@ func (o *TestKind2) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *TestKind2) DeepCopy() *TestKind2 {
+	cpy := &TestKind2{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKind2) DeepCopyInto(dst *TestKind2) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &TestKind2{}
 
@@ -265,5 +279,41 @@ func (o *TestKind2List) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *TestKind2List) DeepCopy() *TestKind2List {
+	cpy := &TestKind2List{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKind2List) DeepCopyInto(dst *TestKind2List) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &TestKind2List{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *TestKind2Spec) DeepCopy() *TestKind2Spec {
+	cpy := &TestKind2Spec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *TestKind2Spec) DeepCopyInto(dst *TestKind2Spec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of TestKind2Status
+func (s *TestKind2Status) DeepCopy() *TestKind2Status {
+	cpy := &TestKind2Status{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies TestKind2Status into another TestKind2Status object
+func (s *TestKind2Status) DeepCopyInto(dst *TestKind2Status) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_object_gen.go.txt
@@ -222,6 +222,20 @@ func (o *TestKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *TestKind) DeepCopy() *TestKind {
+	cpy := &TestKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKind) DeepCopyInto(dst *TestKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &TestKind{}
 
@@ -265,5 +279,41 @@ func (o *TestKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *TestKindList) DeepCopy() *TestKindList {
+	cpy := &TestKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKindList) DeepCopyInto(dst *TestKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &TestKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *TestKindSpec) DeepCopy() *TestKindSpec {
+	cpy := &TestKindSpec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *TestKindSpec) DeepCopyInto(dst *TestKindSpec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of TestKindStatus
+func (s *TestKindStatus) DeepCopy() *TestKindStatus {
+	cpy := &TestKindStatus{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies TestKindStatus into another TestKindStatus object
+func (s *TestKindStatus) DeepCopyInto(dst *TestKindStatus) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_object_gen.go.txt
@@ -222,6 +222,20 @@ func (o *TestKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *TestKind) DeepCopy() *TestKind {
+	cpy := &TestKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKind) DeepCopyInto(dst *TestKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &TestKind{}
 
@@ -265,5 +279,41 @@ func (o *TestKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *TestKindList) DeepCopy() *TestKindList {
+	cpy := &TestKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *TestKindList) DeepCopyInto(dst *TestKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &TestKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *TestKindSpec) DeepCopy() *TestKindSpec {
+	cpy := &TestKindSpec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *TestKindSpec) DeepCopyInto(dst *TestKindSpec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of TestKindStatus
+func (s *TestKindStatus) DeepCopy() *TestKindStatus {
+	cpy := &TestKindStatus{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies TestKindStatus into another TestKindStatus object
+func (s *TestKindStatus) DeepCopyInto(dst *TestKindStatus) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_object_gen.go.txt
@@ -222,6 +222,20 @@ func (o *CustomKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *CustomKind) DeepCopy() *CustomKind {
+	cpy := &CustomKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKind) DeepCopyInto(dst *CustomKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &CustomKind{}
 
@@ -265,5 +279,41 @@ func (o *CustomKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *CustomKindList) DeepCopy() *CustomKindList {
+	cpy := &CustomKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKindList) DeepCopyInto(dst *CustomKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &CustomKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *Spec) DeepCopy() *Spec {
+	cpy := &Spec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *Spec) DeepCopyInto(dst *Spec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of Status
+func (s *Status) DeepCopy() *Status {
+	cpy := &Status{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Status into another Status object
+func (s *Status) DeepCopyInto(dst *Status) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
@@ -254,6 +254,20 @@ func (o *CustomKind) DeepCopyObject() runtime.Object {
 	return o.Copy()
 }
 
+func (o *CustomKind) DeepCopy() *CustomKind {
+	cpy := &CustomKind{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKind) DeepCopyInto(dst *CustomKind) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+	o.Spec.DeepCopyInto(&dst.Spec)
+	o.Status.DeepCopyInto(&dst.Status)
+}
+
 // Interface compliance compile-time check
 var _ resource.Object = &CustomKind{}
 
@@ -297,5 +311,41 @@ func (o *CustomKindList) SetItems(items []resource.Object) {
 	}
 }
 
+func (o *CustomKindList) DeepCopy() *CustomKindList {
+	cpy := &CustomKindList{}
+	o.DeepCopyInto(cpy)
+	return cpy
+}
+
+func (o *CustomKindList) DeepCopyInto(dst *CustomKindList) {
+	resource.CopyObjectInto(dst, o)
+}
+
 // Interface compliance compile-time check
 var _ resource.ListObject = &CustomKindList{}
+
+// Copy methods for all subresource types
+
+// DeepCopy creates a full deep copy of Spec
+func (s *Spec) DeepCopy() *Spec {
+	cpy := &Spec{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Spec into another Spec object
+func (s *Spec) DeepCopyInto(dst *Spec) {
+	resource.CopyObjectInto(dst, s)
+}
+
+// DeepCopy creates a full deep copy of Status
+func (s *Status) DeepCopy() *Status {
+	cpy := &Status{}
+	s.DeepCopyInto(cpy)
+	return cpy
+}
+
+// DeepCopyInto deep copies Status into another Status object
+func (s *Status) DeepCopyInto(dst *Status) {
+	resource.CopyObjectInto(dst, s)
+}

--- a/resource/object.go
+++ b/resource/object.go
@@ -179,15 +179,19 @@ func CopyObjectInto[T any](out T, in T) error {
 	dstVal := reflect.ValueOf(out)
 	srcType := reflect.TypeOf(in)
 	dstType := reflect.TypeOf(out)
+	// T must be a pointer to a struct
 	if dstType.Kind() != reflect.Ptr {
 		return errors.New("out must be a pointer to a struct")
 	}
+	// srcType.NumField() panics on a nil type
 	if srcType.Kind() == reflect.Ptr && srcVal.IsNil() {
 		return errors.New("in must not be nil")
 	}
+	// Trying to set values on a nil panics
 	if dstVal.IsNil() {
 		return errors.New("out must not be nil")
 	}
+	// Before we can work with in and out, we actually need the values the T pointers are referencing
 	for dstType.Kind() == reflect.Ptr {
 		dstType = dstType.Elem()
 		dstVal = dstVal.Elem()
@@ -197,94 +201,123 @@ func CopyObjectInto[T any](out T, in T) error {
 		srcVal = srcVal.Elem()
 	}
 
+	// For each field, deep copy the value into dstVal
 	for i := 0; i < srcType.NumField(); i++ {
-		srcField := srcType.Field(i)
 		srcFieldValue := srcVal.Field(i)
 		dstFieldValue := dstVal.Field(i)
-		if dstFieldValue.CanSet() {
-			switch srcField.Type.Kind() {
-			case reflect.Ptr:
-				// If the pointer is nil, just make a new one for the copy
-				if srcFieldValue.IsNil() {
-					if !dstFieldValue.IsNil() {
-						dstFieldValue.Set(reflect.New(srcField.Type.Elem()))
-					}
-					continue
-				}
-				// find the type of the pointer, then copy that
-				typ := srcField.Type.Elem()
-				dstPtr := reflect.New(typ).Interface()
-				err := CopyObjectInto(dstPtr, srcFieldValue.Interface())
-				if err != nil {
-					return err
-				}
-				dstFieldValue.Set(reflect.ValueOf(dstPtr))
-			case reflect.Struct:
-				// Recursively copy the struct
-				dstStruct := reflect.New(dstFieldValue.Type()).Interface()
-				err := CopyObjectInto(dstStruct, srcFieldValue.Interface())
-				if err != nil {
-					return err
-				}
-				dstFieldValue.Set(reflect.ValueOf(dstStruct).Elem())
-			case reflect.Map:
-				if srcFieldValue.IsNil() {
-					if !dstFieldValue.IsNil() {
-						dstFieldValue.Set(reflect.New(srcFieldValue.Type()).Elem())
-					}
-					continue
-				}
-				dstMap := reflect.MakeMap(srcField.Type)
-				for _, key := range srcFieldValue.MapKeys() {
-					srcKeyVal := srcFieldValue.MapIndex(key)
-					dstKeyVal := reflect.New(srcKeyVal.Type()).Elem()
-					if srcKeyVal.Kind() == reflect.Ptr && srcKeyVal.Elem().Kind() == reflect.Struct {
-						// Copy using CopyObjectInto
-						if srcKeyVal.IsNil() {
-							dstKeyVal = reflect.New(srcKeyVal.Elem().Type())
-						} else {
-							// find the type of the pointer, then copy that
-							typ := srcKeyVal.Type().Elem()
-							dstPtr := reflect.New(typ).Interface()
-							err := CopyObjectInto(dstPtr, srcKeyVal.Interface())
-							if err != nil {
-								return err
-							}
-							dstKeyVal = reflect.ValueOf(dstPtr)
-						}
-					} else if srcKeyVal.Kind() == reflect.Struct {
-						// Copy using CopyObjectInto
-						dst := reflect.New(srcKeyVal.Type()).Interface()
-						if err := CopyObjectInto(dst, srcKeyVal.Interface()); err != nil {
-							return err
-						}
-						dstKeyVal = reflect.ValueOf(dst).Elem()
-					} else {
-						dstKeyVal.Set(srcKeyVal)
-					}
-					dstMap.SetMapIndex(key, dstKeyVal)
-				}
-				dstFieldValue.Set(dstMap)
-			case reflect.Slice:
-				if srcFieldValue.IsNil() {
-					if !dstFieldValue.IsNil() {
-						dstFieldValue.Set(reflect.New(srcFieldValue.Type()).Elem())
-					}
-					continue
-				}
-				// Copy slice elements
-				dstSlice := reflect.MakeSlice(srcField.Type, srcFieldValue.Len(), srcFieldValue.Cap())
-				reflect.Copy(dstSlice, srcFieldValue)
-				dstFieldValue.Set(dstSlice)
-			default:
-				// Just copy the value over
-				dstFieldValue.Set(srcFieldValue)
+		if err := copyReflectValueInto(dstFieldValue, srcFieldValue); err != nil {
+			if errors.Is(err, errCannotSetValue) {
+				// Can't set the field, ignore
+				continue
 			}
-		} else {
-			// Can't set field
-			continue
+			return err
 		}
 	}
 
+	return nil
+}
+
+var errCannotSetValue = errors.New("cannot set value")
+
+// nolint:gocognit,gocritic
+func copyReflectValueInto(dst reflect.Value, src reflect.Value) error {
+	// Check if we can set the value (Set panics if this is false)
+	if !dst.CanSet() {
+		return errCannotSetValue
+	}
+
+	switch src.Type().Kind() {
+	case reflect.Ptr:
+		// If the pointer is nil, just make a new one for the copy
+		if src.IsNil() {
+			if !dst.IsNil() {
+				dst.Set(reflect.Zero(src.Type()))
+			}
+			return nil
+		}
+		// find the type of the pointer, then copy that
+		typ := src.Type().Elem()
+		switch src.Type().Elem().Kind() {
+		case reflect.Struct:
+			dstPtr := reflect.New(typ).Interface()
+			err := CopyObjectInto(dstPtr, src.Interface())
+			if err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstPtr))
+		case reflect.Slice:
+			if dst.IsNil() {
+				dst.Set(reflect.New(typ))
+			}
+			return copyReflectValueInto(dst.Elem(), src.Elem())
+		case reflect.Map:
+			if dst.IsNil() {
+				dst.Set(reflect.New(typ))
+			}
+			return copyReflectValueInto(dst.Elem(), src.Elem())
+		default:
+			dst.Set(src)
+		}
+	case reflect.Struct:
+		// Recursively copy the struct
+		dstStruct := reflect.New(dst.Type()).Interface()
+		err := CopyObjectInto(dstStruct, src.Interface())
+		if err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstStruct).Elem())
+	case reflect.Map:
+		if src.IsNil() {
+			if !dst.IsNil() {
+				dst.Set(reflect.New(src.Type()).Elem())
+			}
+			return nil
+		}
+		dstMap := reflect.MakeMap(src.Type())
+		for _, key := range src.MapKeys() {
+			srcKeyVal := src.MapIndex(key)
+			dstKeyVal := reflect.New(srcKeyVal.Type()).Elem()
+			if srcKeyVal.Kind() == reflect.Ptr && srcKeyVal.Elem().Kind() == reflect.Struct {
+				// Copy using CopyObjectInto
+				if srcKeyVal.IsNil() {
+					dstKeyVal = reflect.New(srcKeyVal.Elem().Type())
+				} else {
+					// find the type of the pointer, then copy that
+					typ := srcKeyVal.Type().Elem()
+					dstPtr := reflect.New(typ).Interface()
+					err := CopyObjectInto(dstPtr, srcKeyVal.Interface())
+					if err != nil {
+						return err
+					}
+					dstKeyVal = reflect.ValueOf(dstPtr)
+				}
+			} else if srcKeyVal.Kind() == reflect.Struct {
+				// Copy using CopyObjectInto
+				dst := reflect.New(srcKeyVal.Type()).Interface()
+				if err := CopyObjectInto(dst, srcKeyVal.Interface()); err != nil {
+					return err
+				}
+				dstKeyVal = reflect.ValueOf(dst).Elem()
+			} else {
+				dstKeyVal.Set(srcKeyVal)
+			}
+			dstMap.SetMapIndex(key, dstKeyVal)
+		}
+		dst.Set(dstMap)
+	case reflect.Slice:
+		if src.IsNil() {
+			if !dst.IsNil() {
+				dst.Set(reflect.New(src.Type()).Elem())
+			}
+			return nil
+		}
+		// Copy slice elements
+		dstSlice := reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+		reflect.Copy(dstSlice, src)
+		dst.Set(dstSlice)
+	default:
+		// Just copy the value over
+		dst.Set(src)
+	}
 	return nil
 }

--- a/resource/object_test.go
+++ b/resource/object_test.go
@@ -9,11 +9,14 @@ import (
 )
 
 type ComplexTestObject struct {
-	Slice      []ComplexTestObject
-	Map        map[string]ComplexTestObject
-	PointerMap map[string]*ComplexTestObject
-	Pointer    *ComplexTestObject
-	Child      ComplexTestObjectChild
+	Slice        []ComplexTestObject
+	Map          map[string]ComplexTestObject
+	PointerMap   map[string]*ComplexTestObject
+	Pointer      *ComplexTestObject
+	Child        ComplexTestObjectChild
+	IntPointer   *int
+	SlicePointer *[]int          // Weird, but valid, types
+	MapPointer   *map[string]int // Weird, but valid, types
 }
 
 type ComplexTestObjectChild struct {
@@ -24,6 +27,12 @@ type ComplexTestObjectChild struct {
 }
 
 func TestCopyObjectInto(t *testing.T) {
+	i := 2
+	si := []int{1, 2, 3}
+	mi := map[string]int{
+		"a": 1,
+		"b": 2,
+	}
 	var ncto *ComplexTestObject
 	tests := []struct {
 		name string
@@ -59,11 +68,22 @@ func TestCopyObjectInto(t *testing.T) {
 					Str: "foobar",
 				},
 			}},
+			Map: map[string]ComplexTestObject{
+				"foo": ComplexTestObject{},
+			},
+			PointerMap: map[string]*ComplexTestObject{},
+			Pointer:    &ComplexTestObject{},
 			Child: ComplexTestObjectChild{
+				Next: &ComplexTestObjectChild{
+					Str: "foobar",
+				},
 				Str:   "string",
 				Int32: 42,
 				Int64: 84,
 			},
+			IntPointer:   &i,
+			SlicePointer: &si,
+			MapPointer:   &mi,
 		},
 	}, {
 		name: "complex object",
@@ -96,6 +116,9 @@ func TestCopyObjectInto(t *testing.T) {
 				Str:   "string",
 				Int32: 42,
 			},
+			IntPointer:   &i,
+			SlicePointer: &si,
+			MapPointer:   &mi,
 		},
 		out: &ComplexTestObject{},
 	}}

--- a/resource/object_test.go
+++ b/resource/object_test.go
@@ -1,0 +1,193 @@
+package resource
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ComplexTestObject struct {
+	Slice      []ComplexTestObject
+	Map        map[string]ComplexTestObject
+	PointerMap map[string]*ComplexTestObject
+	Pointer    *ComplexTestObject
+	Child      ComplexTestObjectChild
+}
+
+type ComplexTestObjectChild struct {
+	Next  *ComplexTestObjectChild
+	Str   string
+	Int32 int32
+	Int64 int64
+}
+
+func TestCopyObjectInto(t *testing.T) {
+	var ncto *ComplexTestObject
+	tests := []struct {
+		name string
+		in   any
+		out  any
+		err  error
+	}{{
+		name: "nil in",
+		in:   ncto,
+		out:  &ComplexTestObject{},
+		err:  errors.New("in must not be nil"),
+	}, {
+		name: "nil out",
+		in:   &ComplexTestObject{},
+		out:  ncto,
+		err:  errors.New("out must not be nil"),
+	}, {
+		name: "non-pointer types",
+		in: ComplexTestObject{
+			Child: ComplexTestObjectChild{
+				Str:   "string",
+				Int32: 42,
+			},
+		},
+		out: ComplexTestObject{},
+		err: errors.New("out must be a pointer to a struct"),
+	}, {
+		name: "empty source object, filled destination",
+		in:   &ComplexTestObject{},
+		out: &ComplexTestObject{
+			Slice: []ComplexTestObject{{
+				Child: ComplexTestObjectChild{
+					Str: "foobar",
+				},
+			}},
+			Child: ComplexTestObjectChild{
+				Str:   "string",
+				Int32: 42,
+				Int64: 84,
+			},
+		},
+	}, {
+		name: "complex object",
+		in: &ComplexTestObject{
+			Slice: []ComplexTestObject{{
+				Child: ComplexTestObjectChild{
+					Str: "foo",
+				},
+			}},
+			Map: map[string]ComplexTestObject{
+				"foo": ComplexTestObject{
+					Child: ComplexTestObjectChild{
+						Str: "bar",
+					},
+				},
+			},
+			PointerMap: map[string]*ComplexTestObject{
+				"foo": &ComplexTestObject{
+					Child: ComplexTestObjectChild{
+						Str: "foo",
+					},
+				},
+			},
+			Pointer: &ComplexTestObject{
+				Child: ComplexTestObjectChild{
+					Str: "bar",
+				},
+			},
+			Child: ComplexTestObjectChild{
+				Str:   "string",
+				Int32: 42,
+			},
+		},
+		out: &ComplexTestObject{},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := CopyObjectInto(test.out, test.in)
+
+			if test.err != nil {
+				assert.Equal(t, test.err, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.in, test.out)
+			}
+		})
+	}
+}
+
+func TestCopyObject(t *testing.T) {
+	full := &TypedSpecStatusObject[ComplexTestObject, ComplexTestObjectChild]{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ComplexTestObject",
+			APIVersion: "foo/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: ComplexTestObject{
+			Slice: []ComplexTestObject{{
+				Child: ComplexTestObjectChild{
+					Str: "foo",
+				},
+			}},
+			Map: map[string]ComplexTestObject{
+				"foo": ComplexTestObject{
+					Child: ComplexTestObjectChild{
+						Str: "bar",
+					},
+				},
+			},
+			PointerMap: map[string]*ComplexTestObject{
+				"foo": &ComplexTestObject{
+					Child: ComplexTestObjectChild{
+						Str: "foo",
+					},
+				},
+			},
+			Pointer: &ComplexTestObject{
+				Child: ComplexTestObjectChild{
+					Str: "bar",
+				},
+			},
+			Child: ComplexTestObjectChild{
+				Str:   "string",
+				Int32: 42,
+			},
+		},
+		Status: ComplexTestObjectChild{
+			Str:   "foo",
+			Int32: 42,
+			Next: &ComplexTestObjectChild{
+				Str:   "bar",
+				Int64: 84,
+			},
+		},
+	}
+	tests := []struct {
+		name     string
+		obj      any
+		expected Object
+	}{{
+		name:     "nil",
+		obj:      nil,
+		expected: nil,
+	}, {
+		name:     "non-object",
+		obj:      &ComplexTestObject{},
+		expected: nil,
+	}, {
+		name:     "full object",
+		obj:      full,
+		expected: full,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cpy := CopyObject(test.obj)
+			assert.Equal(t, test.expected, cpy)
+		})
+	}
+}


### PR DESCRIPTION
Fix CopyObject to deep copy the object rather than shallow copy, introduce CopyObjectInto to do a full deep copy using reflection. Add tests for CopyObject and CopyObjectInto. Add DeepCopy and DeepCopyInto methods to generated object and spec/subresource code.