### PR TITLE
[codegen] Rename generated 'Group' and 'Version' constants

### DIFF
--- a/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
+++ b/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.24-alpine as builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/codegen/jennies/operator.go
+++ b/codegen/jennies/operator.go
@@ -39,13 +39,14 @@ func (w *watcherJenny) Generate(kind codegen.Kind) (*codejen.File, error) {
 	props := kind.Properties()
 	b := bytes.Buffer{}
 	err := templates.WriteWatcher(templates.WatcherMetadata{
-		KindProperties:  props,
-		PackageName:     "watchers",
-		Repo:            w.projectRepo,
-		CodegenPath:     w.codegenPath,
-		Version:         ver,
-		KindPackage:     GetGeneratedPath(w.groupByKind, kind, ver),
-		KindsAreGrouped: !w.groupByKind,
+		KindProperties:   props,
+		PackageName:      "watchers",
+		Repo:             w.projectRepo,
+		CodegenPath:      w.codegenPath,
+		Version:          ver,
+		KindPackage:      GetGeneratedPath(w.groupByKind, kind, ver),
+		KindsAreGrouped:  !w.groupByKind,
+		KindPackageAlias: fmt.Sprintf("%s%s", kind.Properties().MachineName, kind.Properties().Current),
 	}, &b)
 	if err != nil {
 		return nil, err

--- a/codegen/templates/app/watcher.tmpl
+++ b/codegen/templates/app/watcher.tmpl
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 	"go.opentelemetry.io/otel"
 
-	{{ if ne .Version "" }}{{.MachineName}} "{{.Repo}}/{{.CodegenPath}}{{ if not .KindsAreGrouped }}{{end}}/{{.KindPackage}}"
-	{{ else }}"{{.Repo}}/{{.CodegenPath}}/{{.MachineName}}"{{ end }}
+	{{ if ne .Version "" }}{{.KindPackageAlias}} "{{.Repo}}/{{.CodegenPath}}{{ if not .KindsAreGrouped }}{{end}}/{{.KindPackage}}"
+	{{ else }}{{.KindPackageAlias}} "{{.Repo}}/{{.CodegenPath}}/{{.MachineName}}"{{ end }}
 )
 
 var _ operator.ResourceWatcher = &{{.Kind}}Watcher{}
@@ -21,13 +21,13 @@ func New{{.Kind}}Watcher() (*{{.Kind}}Watcher, error) {
 	return &{{.Kind}}Watcher{}, nil
 }
 
-// Add handles add events for {{.MachineName}}.{{.Kind}} resources.
+// Add handles add events for {{.KindPackageAlias}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Add(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-add")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
+    object, ok := rObj.(*{{.KindPackageAlias}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.KindPackageAlias}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 
@@ -36,19 +36,19 @@ func (s *{{.Kind}}Watcher) Add(ctx context.Context, rObj resource.Object) error 
 	return nil
 }
 
-// Update handles update events for {{.MachineName}}.{{.Kind}} resources.
+// Update handles update events for {{.KindPackageAlias}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Update(ctx context.Context, rOld resource.Object, rNew resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-update")
 	defer span.End()
-    oldObject, ok := rOld.(*{{.MachineName}}.{{.Kind}})
+    oldObject, ok := rOld.(*{{.KindPackageAlias}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.KindPackageAlias}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rOld.GetStaticMetadata().Name, rOld.GetStaticMetadata().Namespace, rOld.GetStaticMetadata().Kind)
     }
 
-    _, ok = rNew.(*{{.MachineName}}.{{.Kind}})
+    _, ok = rNew.(*{{.KindPackageAlias}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.KindPackageAlias}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rNew.GetStaticMetadata().Name, rNew.GetStaticMetadata().Namespace, rNew.GetStaticMetadata().Kind)
     }
 
@@ -57,13 +57,13 @@ func (s *{{.Kind}}Watcher) Update(ctx context.Context, rOld resource.Object, rNe
 	return nil
 }
 
-// Delete handles delete events for {{.MachineName}}.{{.Kind}} resources.
+// Delete handles delete events for {{.KindPackageAlias}}.{{.Kind}} resources.
 func (s *{{.Kind}}Watcher) Delete(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-delete")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
+    object, ok := rObj.(*{{.KindPackageAlias}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.KindPackageAlias}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 
@@ -77,9 +77,9 @@ func (s *{{.Kind}}Watcher) Delete(ctx context.Context, rObj resource.Object) err
 func (s *{{.Kind}}Watcher) Sync(ctx context.Context, rObj resource.Object) error {
     ctx, span := otel.GetTracerProvider().Tracer("watcher").Start(ctx, "watcher-sync")
 	defer span.End()
-    object, ok := rObj.(*{{.MachineName}}.{{.Kind}})
+    object, ok := rObj.(*{{.KindPackageAlias}}.{{.Kind}})
     if !ok {
-        return fmt.Errorf("provided object is not of type *{{.MachineName}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
+        return fmt.Errorf("provided object is not of type *{{.KindPackageAlias}}.{{.Kind}} (name=%s, namespace=%s, kind=%s)",
             rObj.GetStaticMetadata().Name, rObj.GetStaticMetadata().Namespace, rObj.GetStaticMetadata().Kind)
     }
 

--- a/codegen/templates/constants.tmpl
+++ b/codegen/templates/constants.tmpl
@@ -3,16 +3,16 @@ package {{ .Package }}
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group   = "{{ .Group }}"
-	// Version is the API version used by all kinds in this package
-	Version = "{{ .Version }}"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup   = "{{ .Group }}"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "{{ .Version }}"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -314,12 +314,13 @@ func GetBackendPluginSecurePackageFiles() (map[string][]byte, error) {
 
 type WatcherMetadata struct {
 	codegen.KindProperties
-	PackageName     string
-	Repo            string
-	CodegenPath     string
-	Version         string
-	KindPackage     string
-	KindsAreGrouped bool
+	PackageName      string
+	Repo             string
+	CodegenPath      string
+	Version          string
+	KindPackage      string
+	KindsAreGrouped  bool
+	KindPackageAlias string
 }
 
 func (WatcherMetadata) ToPackageName(input string) string {
@@ -327,6 +328,10 @@ func (WatcherMetadata) ToPackageName(input string) string {
 }
 
 func WriteWatcher(metadata WatcherMetadata, out io.Writer) error {
+	if metadata.KindPackageAlias == "" {
+		metadata.KindPackageAlias = metadata.MachineName
+	}
+	metadata.KindPackageAlias = ToPackageName(metadata.KindPackageAlias)
 	return templateWatcher.Execute(out, metadata)
 }
 

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
@@ -3,16 +3,16 @@ package v0_0
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "customapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v0-0"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "customapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0-0"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
@@ -3,16 +3,16 @@ package v1_0
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "customapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v1-0"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "customapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v1-0"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
@@ -3,16 +3,16 @@ package v1
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "testapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v1"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "testapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v1"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
@@ -3,16 +3,16 @@ package v2
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "testapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v2"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "testapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v2"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
@@ -3,16 +3,16 @@ package v0_0
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "customapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v0-0"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "customapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v0-0"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
@@ -3,16 +3,16 @@ package v1_0
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	// Group is the API group used by all kinds in this package
-	Group = "customapp.ext.grafana.com"
-	// Version is the API version used by all kinds in this package
-	Version = "v1-0"
+	// APIGroup is the API group used by all kinds in this package
+	APIGroup = "customapp.ext.grafana.com"
+	// APIVersion is the API version used by all kinds in this package
+	APIVersion = "v1-0"
 )
 
 var (
 	// GroupVersion is a schema.GroupVersion consisting of the Group and Version constants for this package
 	GroupVersion = schema.GroupVersion{
-		Group:   Group,
-		Version: Version,
+		Group:   APIGroup,
+		Version: APIVersion,
 	}
 )


### PR DESCRIPTION
Rename generated 'Group' and 'Version' constants to 'APIGroup' and 'APIVersion' to avoid naming conflicts with kinds. Use machinename+version for package alias in generated watcher code to avoid similar conflicts.

Resolves https://github.com/grafana/grafana-app-sdk/issues/666