### PR TITLE
Make sure CODEOWNERS are consistent with main

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,4 @@
 # https://github.community/t/order-of-owners-in-codeowners-file/143073
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @grafana/cloud-app-platform-squad
-
+* @grafana/grafana-app-platform-squad


### PR DESCRIPTION
### What

Update CODEOWNERS to be consistent with `main`.

### Why

To make sure we have correct code owners for PRs to the v0.24 LTS branch.
