### PR TITLE
anonymous user viewer

### DIFF
--- a/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
@@ -71,7 +71,7 @@ data:
     address = tempo.default.svc:4317
     [auth.anonymous]
     enabled = true
-    org_role = Admin
+    org_role = Viewer
     [log.frontend]
     enabled = true
     [plugins]


### PR DESCRIPTION
We want to deprecate the usage of `[auth.anonymous] org_role = Admin` however the sdk generates a grafana with Admin enabled by default.

This changes the `org_role` to `Viewer` instead.