### PR TITLE
Fix resource.CopyObject and resource.CopyObjectInto zeroing time.Time

### DIFF
--- a/health/observer.go
+++ b/health/observer.go
@@ -32,7 +32,7 @@ func (c CheckStatus) String() string {
 	b := strings.Builder{}
 
 	for _, result := range c.Results {
-		b.WriteString(fmt.Sprintf("%s\n", result.String()))
+		b.WriteString(fmt.Sprintf("%s\n", result.String())) //nolint:revive
 	}
 	return b.String()
 }

--- a/resource/object_test.go
+++ b/resource/object_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,7 @@ type ComplexTestObject struct {
 	IntPointer   *int
 	SlicePointer *[]int          // Weird, but valid, types
 	MapPointer   *map[string]int // Weird, but valid, types
+	Timestamp    time.Time       // Times won't be copied right if you try to copy them as a struct (they'll become 0)
 }
 
 type ComplexTestObjectChild struct {
@@ -119,6 +121,7 @@ func TestCopyObjectInto(t *testing.T) {
 			IntPointer:   &i,
 			SlicePointer: &si,
 			MapPointer:   &mi,
+			Timestamp:    time.Now(),
 		},
 		out: &ComplexTestObject{},
 	}}


### PR DESCRIPTION
`resource.CopyObject` and `resource.CopyObjectInto` incorrectly zero `time.Time` values when doing their copy, as it tries to copy `time.Time` instances as structs using reflection. Since `time.Time` has no exported fields, this does not work. To fix this behavior, check if the struct to be copied is `typeOf(time.Time)`, and, if so, directly copy it with `dst.Set(src)`, rather than recursively calling `CopyObjectInto` to copy it as a user-defined struct.

This does bring up the issue that any other "special" types which have custom `MarshalJSON`/`UnmarshalJSON` implementations but no exported fields will also fail with the deep copy performed by `resource.CopyObject`/`resource.CopyObjectInto`. I'm not sure if this is a restriction we want to live with, or attempt to solve here.

Ultimately, a better solution would be to avoid using relfection for copying objects entirely, and rely on generated deep copy methods in objects (see https://github.com/grafana/grafana-app-sdk/pull/424).