### PR TITLE
Fix resource.CopyObject for *time.Time elements.

### DIFF
--- a/resource/object.go
+++ b/resource/object.go
@@ -240,7 +240,7 @@ func copyReflectValueInto(dst reflect.Value, src reflect.Value) error {
 		typ := src.Type().Elem()
 		switch src.Type().Elem().Kind() {
 		case reflect.Struct:
-			if src.Type() == reflectTypeTime {
+			if src.Elem().Type() == reflectTypeTime {
 				dst.Set(src)
 				return nil
 			}

--- a/resource/object_test.go
+++ b/resource/object_test.go
@@ -19,6 +19,7 @@ type ComplexTestObject struct {
 	SlicePointer *[]int          // Weird, but valid, types
 	MapPointer   *map[string]int // Weird, but valid, types
 	Timestamp    time.Time       // Times won't be copied right if you try to copy them as a struct (they'll become 0)
+	TimePointer  *time.Time
 }
 
 type ComplexTestObjectChild struct {
@@ -36,6 +37,7 @@ func TestCopyObjectInto(t *testing.T) {
 		"b": 2,
 	}
 	var ncto *ComplexTestObject
+	tm := time.Date(2020, time.January, 1, 2, 3, 4, 5, time.UTC)
 	tests := []struct {
 		name string
 		in   any
@@ -122,6 +124,7 @@ func TestCopyObjectInto(t *testing.T) {
 			SlicePointer: &si,
 			MapPointer:   &mi,
 			Timestamp:    time.Now(),
+			TimePointer:  &tm,
 		},
 		out: &ComplexTestObject{},
 	}}


### PR DESCRIPTION
Previous PR to fix `resource.CopyObject` and `resource.CopyObjectInto` for `time.Time` elements (https://github.com/grafana/grafana-app-sdk/pull/744) had a small bug with `*time.Time` types, and the addition to the test only tested `time.Time`. Added a `*time.Time` element to the test, and fixed the bug where it improperly checked if the pointer is of type `time.Time`, rather than the dereferenced pointer.