### PR TITLE
[Workflows] Update workflows to pass zizmor checks.

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Retrieve GitHub App secrets
       id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+      uses: grafana/shared-workflows/actions/get-vault-secrets@97c6f45f01d4bca8a3b1acfe397113ce88858a81
       with:
         repo_secrets: |
           APP_ID=grafana-go-workspace-bot:app-id
@@ -44,6 +44,7 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ steps.generate_token.outputs.token }}
+        persist-credentials: false
 
     - name: Set go version
       uses: actions/setup-go@v4

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -7,4 +7,6 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,4 +7,6 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
     - main
     - "lts/v0.24"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Go Workspace Check
@@ -17,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set go version
         uses: actions/setup-go@v5
@@ -42,6 +47,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        persist-credentials: false
     # go env
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -49,7 +55,7 @@ jobs:
         go-version-file: 'go.mod'
     # make lint
     - name: Lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
       with:
         version: v1.64.5
         only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
   release:
+    permissions:
+      contents: write
     needs: ['test']
     runs-on: ubuntu-latest
     steps:
@@ -20,14 +21,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     # Go env
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: false
     # Release
     - name: Create Release
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       # go env
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -29,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       # go env
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -49,6 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           path: 'grafana-app-sdk'
+          persist-credentials: false
       # Go env
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Which will print the version of the CLI which you have installed.
 
 ## App Design
 
-An agnotic view of an app using the SDK looks like:
+An agnostic view of an app using the SDK looks like:
 
 ![Application Using SDK Diagram](docs/diagrams/app_logic.png)
 


### PR DESCRIPTION
Update workflows to pass zizmor checks:
* Add explicit permissions block for all workflows
* use commit hashes for runners instead of version tags (hashes are the commits associated with the tags at time of writing)
* set `persist-credentials` to `false` for all checkout actions
* Set `cache: false` for goreleaser to avoid cache poisoning