### PR TITLE
[worflows] Fix dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -44,7 +44,7 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ steps.generate_token.outputs.token }}
-        persist-credentials: false
+        persist-credentials: true
 
     - name: Set go version
       uses: actions/setup-go@v4


### PR DESCRIPTION
Turns out that it looks like the dependabot workflow needs its credentials persisted, it broke after https://github.com/grafana/grafana-app-sdk/pull/770