### PR TITLE
Allow Subresource Patching in PatchOptions and k8s.Client

### DIFF
--- a/resource/client.go
+++ b/resource/client.go
@@ -93,6 +93,14 @@ type PatchOptions struct {
 	// DryRun will perform a server-side dry-run of the request, if set to true.
 	// The server will return the result of the patch, but will not actually apply it.
 	DryRun bool
+	// Subresource can be set to a non-empty subresource field name to update that subresource,
+	// instead of the main object. It is not enough for a path in the patch request to use the subresource,
+	// this field must also be set to the subresource explicitly, as they are considered
+	// two distinct obejects for the purposes of mutation.
+	// If the subresource has not been set in any prior request, it will be empty,
+	// and a patch request should set the **entire object** (with the "/<subresource>" path),
+	// rather than a component of the subresource, as a JSON patch cannot alter an absent object.
+	Subresource string
 }
 
 type DeleteOptionsPropagationPolicy string


### PR DESCRIPTION
Add a `Subresource` field to `PatchOptions` similar in behavior to the `Subresource` field in `UpdateOptions`, to allow a `Patch` request to patch a subresource.

Noted in godoc that for an empty subresource, the entire subresource must be set in the patch request. Otherwise, kubernetes responds with a 422 status and a message of "the server rejected our request due to an error in our request" (with no other details).