### PR TITLE
Add local zizmor config

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# This is also used as the default configuration for the Zizmor reusable workflow.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: any # trust GitHub
+        grafana/*: any # trust Grafana


### PR DESCRIPTION
For PR's that are sourced from a fork, the zizmor check will fail without a config present in the fork's `.github` directory. There is work being done to fix this upstream in the reusable workflow itself, but for now, we need the file in the local repo so it will be present in the fork.