### PR TITLE
[AppManifest] Use Versions instead of Kinds for the top-level field

### DIFF
--- a/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
+++ b/app/appmanifest/v1alpha1/appmanifest_spec_gen.go
@@ -3,32 +3,51 @@
 package v1alpha1
 
 // +k8s:openapi-gen=true
-type AppManifestManifestKind struct {
-	Kind       string                           `json:"kind"`
-	Scope      string                           `json:"scope"`
-	Conversion bool                             `json:"conversion"`
-	Versions   []AppManifestManifestKindVersion `json:"versions"`
+type AppManifestManifestVersion struct {
+	// Name is the version name string, such as "v1" or "v1alpha1"
+	Name string `json:"name"`
+	// Served dictates whether this version is served by the API server.
+	// A version cannot be removed from a manifest until it is no longer served.
+	Served *bool `json:"served,omitempty"`
+	// Kinds is a list of all the kinds served in this version.
+	// Generally, kinds should exist in each version unless they have been deprecated (and no longer exist in a newer version)
+	// or newly added (and didn't exist for older versions).
+	Kinds []AppManifestManifestVersionKind `json:"kinds"`
 }
 
-// NewAppManifestManifestKind creates a new AppManifestManifestKind object.
-func NewAppManifestManifestKind() *AppManifestManifestKind {
-	return &AppManifestManifestKind{
-		Versions: []AppManifestManifestKindVersion{},
+// NewAppManifestManifestVersion creates a new AppManifestManifestVersion object.
+func NewAppManifestManifestVersion() *AppManifestManifestVersion {
+	return &AppManifestManifestVersion{
+		Served: (func(input bool) *bool { return &input })(true),
+		Kinds:  []AppManifestManifestVersionKind{},
 	}
 }
 
 // +k8s:openapi-gen=true
-type AppManifestManifestKindVersion struct {
-	Name                     string                                `json:"name"`
+type AppManifestManifestVersionKind struct {
+	// Kind is the name of the kind. This should begin with a capital letter and be CamelCased
+	Kind string `json:"kind"`
+	// Plural is the plural version of `kind`. This is optional and defaults to the kind + "s" if not present.
+	Plural *string `json:"plural,omitempty"`
+	// Scope dictates the scope of the kind. This field must be the same for all versions of the kind.
+	// Different values will result in an error or undefined behavior.
+	Scope                    AppManifestManifestVersionKindScope   `json:"scope"`
 	Admission                *AppManifestAdmissionCapabilities     `json:"admission,omitempty"`
-	Schema                   AppManifestManifestKindVersionSchema  `json:"schema"`
+	Schema                   AppManifestManifestVersionKindSchema  `json:"schema"`
 	SelectableFields         []string                              `json:"selectableFields,omitempty"`
 	AdditionalPrinterColumns []AppManifestAdditionalPrinterColumns `json:"additionalPrinterColumns,omitempty"`
+	// Conversion indicates whether this kind supports custom conversion behavior exposed by the Convert method in the App.
+	// It may not prevent automatic conversion behavior between versions of the kind when set to false
+	// (for example, CRDs will always support simple conversion, and this flag enables webhook conversion).
+	// This field should be the same for all versions of the kind. Different values will result in an error or undefined behavior.
+	Conversion *bool `json:"conversion,omitempty"`
 }
 
-// NewAppManifestManifestKindVersion creates a new AppManifestManifestKindVersion object.
-func NewAppManifestManifestKindVersion() *AppManifestManifestKindVersion {
-	return &AppManifestManifestKindVersion{}
+// NewAppManifestManifestVersionKind creates a new AppManifestManifestVersionKind object.
+func NewAppManifestManifestVersionKind() *AppManifestManifestVersionKind {
+	return &AppManifestManifestVersionKind{
+		Conversion: (func(input bool) *bool { return &input })(false),
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -78,7 +97,7 @@ func NewAppManifestMutationCapability() *AppManifestMutationCapability {
 }
 
 // +k8s:openapi-gen=true
-type AppManifestManifestKindVersionSchema map[string]interface{}
+type AppManifestManifestVersionKindSchema map[string]interface{}
 
 // +k8s:openapi-gen=true
 type AppManifestAdditionalPrinterColumns struct {
@@ -153,9 +172,13 @@ func NewAppManifestOperatorWebhookProperties() *AppManifestOperatorWebhookProper
 
 // +k8s:openapi-gen=true
 type AppManifestSpec struct {
-	AppName string                    `json:"appName"`
-	Group   string                    `json:"group"`
-	Kinds   []AppManifestManifestKind `json:"kinds"`
+	AppName string `json:"appName"`
+	Group   string `json:"group"`
+	// Versions is the list of versions for this manifest, in order.
+	Versions []AppManifestManifestVersion `json:"versions"`
+	// PreferredVersion is the preferred version for API use. If empty, it will use the version of the last entry in versions.
+	// For CRDs, this also dictates which version is used for storage.
+	PreferredVersion *string `json:"preferredVersion,omitempty"`
 	// ExtraPermissions contains additional permissions needed for an app's backend component to operate.
 	// Apps implicitly have all permissions for kinds they managed (defined in `kinds`).
 	ExtraPermissions *AppManifestV1alpha1SpecExtraPermissions `json:"extraPermissions,omitempty"`
@@ -174,7 +197,7 @@ type AppManifestSpec struct {
 // NewAppManifestSpec creates a new AppManifestSpec object.
 func NewAppManifestSpec() *AppManifestSpec {
 	return &AppManifestSpec{
-		Kinds:       []AppManifestManifestKind{},
+		Versions:    []AppManifestManifestVersion{},
 		DryRunKinds: (func(input bool) *bool { return &input })(false),
 	}
 }
@@ -191,3 +214,11 @@ func NewAppManifestV1alpha1SpecExtraPermissions() *AppManifestV1alpha1SpecExtraP
 		AccessKinds: []AppManifestKindPermission{},
 	}
 }
+
+// +k8s:openapi-gen=true
+type AppManifestManifestVersionKindScope string
+
+const (
+	AppManifestManifestVersionKindScopeNamespaced AppManifestManifestVersionKindScope = "Namespaced"
+	AppManifestManifestVersionKindScopeCluster    AppManifestManifestVersionKindScope = "Cluster"
+)

--- a/app/appmanifest/v1alpha1/conversion_test.go
+++ b/app/appmanifest/v1alpha1/conversion_test.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/app"
 )
 
 func TestAppManifestSpec_ToManifestData(t *testing.T) {
@@ -32,8 +33,8 @@ func TestAppManifestSpec_ToManifestData(t *testing.T) {
 
 	t.Run("bad schema data", func(t *testing.T) {
 		v1alpha1 := AppManifestSpec{
-			Kinds: []AppManifestManifestKind{{
-				Versions: []AppManifestManifestKindVersion{{
+			Versions: []AppManifestManifestVersion{{
+				Kinds: []AppManifestManifestVersionKind{{
 					Schema: map[string]interface{}{
 						"openAPIV3Schema": "foo", // Bad OpenAPI document, conversion will fail when loading the openAPI
 					},

--- a/app/appmanifest/v1alpha1/generated_code_test.go
+++ b/app/appmanifest/v1alpha1/generated_code_test.go
@@ -30,6 +30,9 @@ func TestAppManifestKind_Read(t *testing.T) {
 	require.Nil(t, err)
 	schema := make(map[string]interface{})
 	require.Nil(t, json.Unmarshal(schemaBytes, &schema))
+	plural := "issues"
+	served := true
+	preferred := "v1"
 	assert.Equal(t, &AppManifest{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppManifest",
@@ -40,13 +43,16 @@ func TestAppManifestKind_Read(t *testing.T) {
 			CreationTimestamp: metav1.NewTime(tm.Local()),
 		},
 		Spec: AppManifestSpec{
-			AppName: "issue-tracker-project",
-			Group:   "issuetrackerproject.ext.grafana.com",
-			Kinds: []AppManifestManifestKind{{
-				Kind:  "Issue",
-				Scope: "Namespaced",
-				Versions: []AppManifestManifestKindVersion{{
-					Name:   "v1",
+			AppName:          "issue-tracker-project",
+			Group:            "issuetrackerproject.ext.grafana.com",
+			PreferredVersion: &preferred,
+			Versions: []AppManifestManifestVersion{{
+				Name:   "v1",
+				Served: &served,
+				Kinds: []AppManifestManifestVersionKind{{
+					Kind:   "Issue",
+					Plural: &plural,
+					Scope:  "Namespaced",
 					Schema: schema,
 				}},
 			}},

--- a/app/appmanifest/v1alpha1/testfiles/manifest-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/manifest-01.json
@@ -8,13 +8,16 @@
   "spec": {
     "appName": "issue-tracker-project",
     "group": "issuetrackerproject.ext.grafana.com",
-    "kinds": [
+    "preferredVersion": "v1",
+    "versions": [
       {
-        "kind": "Issue",
-        "scope": "Namespaced",
-        "versions": [
+        "name": "v1",
+        "served": true,
+        "kinds": [
           {
-            "name": "v1",
+            "kind": "Issue",
+            "plural": "issues",
+            "scope": "Namespaced",
             "schema": {
               "spec": {
                 "description": "spec is the schema of our resource.\nWe could include `status` or `metadata` top-level fields here as well,\nbut `status` is for state information, which we don't need to track,\nand `metadata` is for kind/schema-specific custom metadata in addition to the existing\ncommon metadata, and we don't need to track any specific custom metadata.",
@@ -84,8 +87,7 @@
               }
             }
           }
-        ],
-        "conversion": false
+        ]
       }
     ]
   },

--- a/app/appmanifest/v1alpha1/testfiles/spec-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/spec-01.json
@@ -9,13 +9,16 @@
       "mutationPath": "/mutate"
     }
   },
-  "kinds": [
+  "preferredVersion": "v1",
+  "versions": [
     {
-      "kind": "Issue",
-      "scope": "Namespaced",
-      "versions": [
+      "name": "v1",
+      "served": true,
+      "kinds": [
         {
-          "name": "v1",
+          "kind": "Issue",
+          "plural": "issues",
+          "scope": "Namespaced",
           "schema": {
             "spec": {
               "description": "spec is the schema of our resource.\nWe could include `status` or `metadata` top-level fields here as well,\nbut `status` is for state information, which we don't need to track,\nand `metadata` is for kind/schema-specific custom metadata in addition to the existing\ncommon metadata, and we don't need to track any specific custom metadata.",
@@ -85,8 +88,7 @@
             }
           }
         }
-      ],
-      "conversion": false
+      ]
     }
   ]
 }

--- a/app/definitions/app-manifest-manifest.json
+++ b/app/definitions/app-manifest-manifest.json
@@ -63,19 +63,44 @@
                                     "group": {
                                         "type": "string"
                                     },
-                                    "kinds": {
+                                    "operator": {
+                                        "description": "Operator has information about the operator being run for the app, if there is one.\nWhen present, it can indicate to the API server the URL and paths for webhooks, if applicable.\nThis is only required if you run your app as an operator and any of your kinds support webhooks for validation,\nmutation, or conversion.",
+                                        "properties": {
+                                            "url": {
+                                                "description": "URL is the URL of the operator's HTTPS endpoint, including port if non-standard (443).\nIt should be a URL which the API server can access.",
+                                                "type": "string"
+                                            },
+                                            "webhooks": {
+                                                "description": "Webhooks contains information about the various webhook paths.",
+                                                "properties": {
+                                                    "conversionPath": {
+                                                        "default": "/convert",
+                                                        "type": "string"
+                                                    },
+                                                    "mutationPath": {
+                                                        "default": "/mutate",
+                                                        "type": "string"
+                                                    },
+                                                    "validationPath": {
+                                                        "default": "/validate",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "preferredVersion": {
+                                        "description": "PreferredVersion is the preferred version for API use. If empty, it will use the version of the last entry in versions.\nFor CRDs, this also dictates which version is used for storage.",
+                                        "type": "string"
+                                    },
+                                    "versions": {
+                                        "description": "Versions is the list of versions for this manifest, in order.",
                                         "items": {
                                             "properties": {
-                                                "conversion": {
-                                                    "type": "boolean"
-                                                },
-                                                "kind": {
-                                                    "type": "string"
-                                                },
-                                                "scope": {
-                                                    "type": "string"
-                                                },
-                                                "versions": {
+                                                "kinds": {
+                                                    "description": "Kinds is a list of all the kinds served in this version.\nGenerally, kinds should exist in each version unless they have been deprecated (and no longer exist in a newer version)\nor newly added (and didn't exist for older versions).",
                                                     "items": {
                                                         "properties": {
                                                             "additionalPrinterColumns": {
@@ -163,12 +188,31 @@
                                                                 },
                                                                 "type": "object"
                                                             },
-                                                            "name": {
+                                                            "conversion": {
+                                                                "default": false,
+                                                                "description": "Conversion indicates whether this kind supports custom conversion behavior exposed by the Convert method in the App.\nIt may not prevent automatic conversion behavior between versions of the kind when set to false\n(for example, CRDs will always support simple conversion, and this flag enables webhook conversion).\nThis field should be the same for all versions of the kind. Different values will result in an error or undefined behavior.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the name of the kind. This should begin with a capital letter and be CamelCased",
+                                                                "type": "string"
+                                                            },
+                                                            "plural": {
+                                                                "description": "Plural is the plural version of `kind`. This is optional and defaults to the kind + \"s\" if not present.",
                                                                 "type": "string"
                                                             },
                                                             "schema": {
                                                                 "type": "object",
                                                                 "x-kubernetes-preserve-unknown-fields": true
+                                                            },
+                                                            "scope": {
+                                                                "default": "Namespaced",
+                                                                "description": "Scope dictates the scope of the kind. This field must be the same for all versions of the kind.\nDifferent values will result in an error or undefined behavior.",
+                                                                "enum": [
+                                                                    "Namespaced",
+                                                                    "Cluster"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "selectableFields": {
                                                                 "items": {
@@ -178,57 +222,37 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "name",
+                                                            "kind",
+                                                            "scope",
                                                             "schema"
                                                         ],
                                                         "type": "object"
                                                     },
                                                     "type": "array"
+                                                },
+                                                "name": {
+                                                    "description": "Name is the version name string, such as \"v1\" or \"v1alpha1\"",
+                                                    "type": "string"
+                                                },
+                                                "served": {
+                                                    "default": true,
+                                                    "description": "Served dictates whether this version is served by the API server.\nA version cannot be removed from a manifest until it is no longer served.",
+                                                    "type": "boolean"
                                                 }
                                             },
                                             "required": [
-                                                "kind",
-                                                "scope",
-                                                "conversion",
-                                                "versions"
+                                                "name",
+                                                "kinds"
                                             ],
                                             "type": "object"
                                         },
                                         "type": "array"
-                                    },
-                                    "operator": {
-                                        "description": "Operator has information about the operator being run for the app, if there is one.\nWhen present, it can indicate to the API server the URL and paths for webhooks, if applicable.\nThis is only required if you run your app as an operator and any of your kinds support webhooks for validation,\nmutation, or conversion.",
-                                        "properties": {
-                                            "url": {
-                                                "description": "URL is the URL of the operator's HTTPS endpoint, including port if non-standard (443).\nIt should be a URL which the API server can access.",
-                                                "type": "string"
-                                            },
-                                            "webhooks": {
-                                                "description": "Webhooks contains information about the various webhook paths.",
-                                                "properties": {
-                                                    "conversionPath": {
-                                                        "default": "/convert",
-                                                        "type": "string"
-                                                    },
-                                                    "mutationPath": {
-                                                        "default": "/mutate",
-                                                        "type": "string"
-                                                    },
-                                                    "validationPath": {
-                                                        "default": "/validate",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
                                     }
                                 },
                                 "required": [
                                     "appName",
                                     "group",
-                                    "kinds"
+                                    "versions"
                                 ],
                                 "type": "object"
                             },

--- a/app/definitions/appmanifest.apps.grafana.com.json
+++ b/app/definitions/appmanifest.apps.grafana.com.json
@@ -62,19 +62,44 @@
                                     "group": {
                                         "type": "string"
                                     },
-                                    "kinds": {
+                                    "operator": {
+                                        "description": "Operator has information about the operator being run for the app, if there is one.\nWhen present, it can indicate to the API server the URL and paths for webhooks, if applicable.\nThis is only required if you run your app as an operator and any of your kinds support webhooks for validation,\nmutation, or conversion.",
+                                        "properties": {
+                                            "url": {
+                                                "description": "URL is the URL of the operator's HTTPS endpoint, including port if non-standard (443).\nIt should be a URL which the API server can access.",
+                                                "type": "string"
+                                            },
+                                            "webhooks": {
+                                                "description": "Webhooks contains information about the various webhook paths.",
+                                                "properties": {
+                                                    "conversionPath": {
+                                                        "default": "/convert",
+                                                        "type": "string"
+                                                    },
+                                                    "mutationPath": {
+                                                        "default": "/mutate",
+                                                        "type": "string"
+                                                    },
+                                                    "validationPath": {
+                                                        "default": "/validate",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "preferredVersion": {
+                                        "description": "PreferredVersion is the preferred version for API use. If empty, it will use the version of the last entry in versions.\nFor CRDs, this also dictates which version is used for storage.",
+                                        "type": "string"
+                                    },
+                                    "versions": {
+                                        "description": "Versions is the list of versions for this manifest, in order.",
                                         "items": {
                                             "properties": {
-                                                "conversion": {
-                                                    "type": "boolean"
-                                                },
-                                                "kind": {
-                                                    "type": "string"
-                                                },
-                                                "scope": {
-                                                    "type": "string"
-                                                },
-                                                "versions": {
+                                                "kinds": {
+                                                    "description": "Kinds is a list of all the kinds served in this version.\nGenerally, kinds should exist in each version unless they have been deprecated (and no longer exist in a newer version)\nor newly added (and didn't exist for older versions).",
                                                     "items": {
                                                         "properties": {
                                                             "additionalPrinterColumns": {
@@ -162,12 +187,31 @@
                                                                 },
                                                                 "type": "object"
                                                             },
-                                                            "name": {
+                                                            "conversion": {
+                                                                "default": false,
+                                                                "description": "Conversion indicates whether this kind supports custom conversion behavior exposed by the Convert method in the App.\nIt may not prevent automatic conversion behavior between versions of the kind when set to false\n(for example, CRDs will always support simple conversion, and this flag enables webhook conversion).\nThis field should be the same for all versions of the kind. Different values will result in an error or undefined behavior.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the name of the kind. This should begin with a capital letter and be CamelCased",
+                                                                "type": "string"
+                                                            },
+                                                            "plural": {
+                                                                "description": "Plural is the plural version of `kind`. This is optional and defaults to the kind + \"s\" if not present.",
                                                                 "type": "string"
                                                             },
                                                             "schema": {
                                                                 "type": "object",
                                                                 "x-kubernetes-preserve-unknown-fields": true
+                                                            },
+                                                            "scope": {
+                                                                "default": "Namespaced",
+                                                                "description": "Scope dictates the scope of the kind. This field must be the same for all versions of the kind.\nDifferent values will result in an error or undefined behavior.",
+                                                                "enum": [
+                                                                    "Namespaced",
+                                                                    "Cluster"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "selectableFields": {
                                                                 "items": {
@@ -177,57 +221,37 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "name",
+                                                            "kind",
+                                                            "scope",
                                                             "schema"
                                                         ],
                                                         "type": "object"
                                                     },
                                                     "type": "array"
+                                                },
+                                                "name": {
+                                                    "description": "Name is the version name string, such as \"v1\" or \"v1alpha1\"",
+                                                    "type": "string"
+                                                },
+                                                "served": {
+                                                    "default": true,
+                                                    "description": "Served dictates whether this version is served by the API server.\nA version cannot be removed from a manifest until it is no longer served.",
+                                                    "type": "boolean"
                                                 }
                                             },
                                             "required": [
-                                                "kind",
-                                                "scope",
-                                                "conversion",
-                                                "versions"
+                                                "name",
+                                                "kinds"
                                             ],
                                             "type": "object"
                                         },
                                         "type": "array"
-                                    },
-                                    "operator": {
-                                        "description": "Operator has information about the operator being run for the app, if there is one.\nWhen present, it can indicate to the API server the URL and paths for webhooks, if applicable.\nThis is only required if you run your app as an operator and any of your kinds support webhooks for validation,\nmutation, or conversion.",
-                                        "properties": {
-                                            "url": {
-                                                "description": "URL is the URL of the operator's HTTPS endpoint, including port if non-standard (443).\nIt should be a URL which the API server can access.",
-                                                "type": "string"
-                                            },
-                                            "webhooks": {
-                                                "description": "Webhooks contains information about the various webhook paths.",
-                                                "properties": {
-                                                    "conversionPath": {
-                                                        "default": "/convert",
-                                                        "type": "string"
-                                                    },
-                                                    "mutationPath": {
-                                                        "default": "/mutate",
-                                                        "type": "string"
-                                                    },
-                                                    "validationPath": {
-                                                        "default": "/validate",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
                                     }
                                 },
                                 "required": [
                                     "appName",
                                     "group",
-                                    "kinds"
+                                    "versions"
                                 ],
                                 "type": "object"
                             },

--- a/app/manifest.cue
+++ b/app/manifest.cue
@@ -3,7 +3,7 @@ package app
 manifest: {
 	appName: "app-manifest"
 	groupOverride: "apps.grafana.com"
-	kinds: [appManifest]
+	kinds: [appManifestKind]
 	extraPermissions: {
 		accessKinds: [{
 			group: "apiextensions.k8s.io",
@@ -13,17 +13,19 @@ manifest: {
 	}
 }
 
-appManifest: {
+appManifestKind: {
 	kind: "AppManifest"
 	scope: "Cluster"
 	codegen: {
 		ts: enabled: false
 	}
+	versions: {
+		"v1alpha1": appManifestv1alpha1
+	}
 	current: "v1alpha1"
-	versions: {}
 }
 
-appManifest: versions: v1alpha1: {
+appManifestv1alpha1: {
 	schema: {
 		#AdditionalPrinterColumns: {
 			// name is a human readable name for the column.
@@ -56,21 +58,37 @@ appManifest: versions: v1alpha1: {
 			validation?: #ValidationCapability
 			mutation?: #MutationCapability
 		}
-		#ManifestKindVersionSchema: {
+		#ManifestVersionKindSchema: {
 			[string]: _
 		}
-		#ManifestKindVersion: {
-			name: string
+		#ManifestVersionKind: {
+			// Kind is the name of the kind. This should begin with a capital letter and be CamelCased
+			kind: string
+			// Plural is the plural version of `kind`. This is optional and defaults to the kind + "s" if not present.
+			plural?: string
+			// Scope dictates the scope of the kind. This field must be the same for all versions of the kind.
+			// Different values will result in an error or undefined behavior.
+			scope: *"Namespaced" | "Cluster"
 			admission?: #AdmissionCapabilities
-			schema: #ManifestKindVersionSchema
+			schema: #ManifestVersionKindSchema
 			selectableFields?: [...string]
 			additionalPrinterColumns?: [...#AdditionalPrinterColumns]
+			// Conversion indicates whether this kind supports custom conversion behavior exposed by the Convert method in the App.
+			// It may not prevent automatic conversion behavior between versions of the kind when set to false
+			// (for example, CRDs will always support simple conversion, and this flag enables webhook conversion).
+			// This field should be the same for all versions of the kind. Different values will result in an error or undefined behavior.
+			conversion?: bool | *false
 		}
-		#ManifestKind: {
-			kind: string
-			scope: string
-			conversion: bool
-			versions: [...#ManifestKindVersion]
+		#ManifestVersion: {
+			// Name is the version name string, such as "v1" or "v1alpha1"
+			name: string
+			// Served dictates whether this version is served by the API server.
+			// A version cannot be removed from a manifest until it is no longer served.
+			served?: bool | *true
+			// Kinds is a list of all the kinds served in this version.
+			// Generally, kinds should exist in each version unless they have been deprecated (and no longer exist in a newer version)
+			// or newly added (and didn't exist for older versions).
+			kinds: [...#ManifestVersionKind]
 		}
 		#KindPermission: {
 			group: string
@@ -92,7 +110,11 @@ appManifest: versions: v1alpha1: {
 		spec: {
 			appName: string
 			group: string
-			kinds: [...#ManifestKind]
+			// Versions is the list of versions for this manifest, in order.
+			versions: [...#ManifestVersion]
+			// PreferredVersion is the preferred version for API use. If empty, it will use the version of the last entry in versions.
+			// For CRDs, this also dictates which version is used for storage.
+			preferredVersion?: string
 			// ExtraPermissions contains additional permissions needed for an app's backend component to operate.
 			// Apps implicitly have all permissions for kinds they managed (defined in `kinds`).
 			extraPermissions?: {

--- a/app/manifest.go
+++ b/app/manifest.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/common"
@@ -77,8 +78,11 @@ type ManifestData struct {
 	// Group is the group used for all kinds maintained by this app.
 	// This is usually "<AppName>.ext.grafana.com"
 	Group string `json:"group" yaml:"group"`
-	// Kinds is a list of all Kinds maintained by this App
-	Kinds []ManifestKind `json:"kinds,omitempty" yaml:"kinds,omitempty"`
+	// Versions is a list of versions supported by this App
+	Versions []ManifestVersion `json:"versions" yaml:"versions"`
+	// PreferredVersion is the preferred version for API use. If empty, it will use the latest from versions.
+	// For CRDs, this also dictates which version is used for storage.
+	PreferredVersion string `json:"preferredVersion" yaml:"preferredVersion"`
 	// Permissions is the extra permissions for non-owned kinds this app needs to operate its backend.
 	// It may be nil if no extra permissions are required.
 	ExtraPermissions *Permissions `json:"extraPermissions,omitempty" yaml:"extraPermissions,omitempty"`
@@ -89,22 +93,65 @@ type ManifestData struct {
 	Operator *ManifestOperatorInfo `json:"operator,omitempty" yaml:"operator,omitempty"`
 }
 
-// ManifestKind is the manifest for a particular kind, including its Kind, Scope, and Versions
-type ManifestKind struct {
-	// Kind is the name of the kind
-	Kind string `json:"kind" yaml:"kind"`
-	// Scope if the scope of the kind, typically restricted to "Namespaced" or "Cluster"
-	Scope string `json:"scope" yaml:"scope"`
-	// Versions is the set of versions for the kind. This list should be ordered as a series of progressively later versions.
-	Versions []ManifestKindVersion `json:"versions" yaml:"versions"`
-	// Conversion is true if the app has a conversion capability for this kind
-	Conversion bool `json:"conversion" yaml:"conversion"`
+// Validate validates the ManifestData to ensure that the kind data across all Versions is consistent
+func (m *ManifestData) Validate() error {
+	type kindData struct {
+		kind       string
+		plural     string
+		scope      string
+		conversion bool
+		version    string
+	}
+	var errs error
+	kinds := make(map[string]kindData)
+	for _, version := range m.Versions {
+		for _, kind := range version.Kinds {
+			if k, ok := kinds[kind.Kind]; !ok {
+				k = kindData{
+					kind:       kind.Kind,
+					plural:     kind.Plural,
+					scope:      kind.Scope,
+					conversion: kind.Conversion,
+					version:    version.Name,
+				}
+				kinds[kind.Kind] = k
+			} else {
+				if k.plural != kind.Plural {
+					errs = multierror.Append(errs, fmt.Errorf("kind '%s' has a different plural in versions '%s' and '%s'", kind.Kind, k.version, version.Name))
+				}
+				if k.scope != kind.Scope {
+					errs = multierror.Append(errs, fmt.Errorf("kind '%s' has a different scope in versions '%s' and '%s'", kind.Kind, k.version, version.Name))
+				}
+				if k.conversion != kind.Conversion {
+					errs = multierror.Append(errs, fmt.Errorf("kind '%s' conversion does not match in versions '%s' and '%s'", kind.Kind, k.version, version.Name))
+				}
+			}
+		}
+	}
+	return errs
 }
 
-// ManifestKindVersion contains details for a version of a kind in a Manifest
-type ManifestKindVersion struct {
-	// Name is the version string name, such as "v1"
-	Name string `yaml:"name" json:"name"`
+type ManifestVersion struct {
+	// Name is the version name string, such as "v1" or "v1alpha1"
+	Name string `json:"name" yaml:"name"`
+	// Served dictates whether this version is served by the API server.
+	// A version cannot be removed from a manifest until it is no longer served.
+	Served bool `json:"served" yaml:"served"`
+	// Kinds is a list of all the kinds served in this version.
+	// Generally, kinds should exist in each version unless they have been deprecated (and no longer exist in a newer version)
+	// or newly added (and didn't exist for older versions).
+	Kinds []ManifestVersionKind `json:"kinds" yaml:"kinds"`
+}
+
+// ManifestVersionKind contains details for a version of a kind in a Manifest
+type ManifestVersionKind struct {
+	// Kind is the name of the kind. This should begin with a capital letter and be CamelCased
+	Kind string `json:"kind" yaml:"kind"`
+	// Plural is the plural version of `kind`. This is optional and defaults to the kind + "s" if not present.
+	Plural string `json:"plural,omitempty" yaml:"plural,omitempty"`
+	// Scope dictates the scope of the kind. This field must be the same for all versions of the kind.
+	// Different values will result in an error or undefined behavior.
+	Scope string `json:"scope" yaml:"scope"`
 	// Admission is the collection of admission capabilities for this version.
 	// If nil, no admission capabilities exist for the version.
 	Admission *AdmissionCapabilities `json:"admission,omitempty" yaml:"admission,omitempty"`
@@ -115,6 +162,11 @@ type ManifestKindVersion struct {
 	SelectableFields []string `json:"selectableFields,omitempty" yaml:"selectableFields,omitempty"`
 	// CustomRoutes is a map of of path patterns to custom routes for this version.
 	CustomRoutes map[string]spec3.PathProps `json:"customRoutes,omitempty" yaml:"customRoutes,omitempty"`
+	// Conversion indicates whether this kind supports custom conversion behavior exposed by the Convert method in the App.
+	// It may not prevent automatic conversion behavior between versions of the kind when set to false
+	// (for example, CRDs will always support simple conversion, and this flag enables webhook conversion).
+	// This field should be the same for all versions of the kind. Different values will result in an error or undefined behavior.
+	Conversion bool `json:"conversion" yaml:"conversion"`
 }
 
 // AdmissionCapabilities is the collection of admission capabilities of a kind

--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -200,11 +200,11 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 	}
 	// Slightly hacky multiple generators as an intermediary while we move to a better system.
 	// Both still source from a Manifest, but generatorForKinds supplies []Kind to jennies, vs AppManifest
-	generatorForKinds, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(true, cfg.GenOperatorState), modFS)
+	generatorForKinds, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(cuekind.ParseConfig{GenOperatorState: cfg.GenOperatorState}), modFS)
 	if err != nil {
 		return nil, err
 	}
-	generatorForManifest, err := codegen.NewGenerator[codegen.AppManifest](parser.ManifestParser(cfg.GenOperatorState), modFS)
+	generatorForManifest, err := codegen.NewGenerator[codegen.AppManifest](parser.ManifestParser(cuekind.ParseConfig{GenOperatorState: cfg.GenOperatorState}), modFS)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func postGenerateFilesCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (
 	if err != nil {
 		return nil, err
 	}
-	generator, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(true, cfg.GenOperatorState), modFS)
+	generator, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(cuekind.ParseConfig{GenOperatorState: cfg.GenOperatorState}), modFS)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -424,11 +424,11 @@ func projectAddComponent(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		generator, err = codegen.NewGenerator[codegen.Kind](parser.KindParser(true, genOperatorState), os.DirFS(sourcePath))
+		generator, err = codegen.NewGenerator[codegen.Kind](parser.KindParser(cuekind.ParseConfig{GenOperatorState: genOperatorState}), os.DirFS(sourcePath))
 		if err != nil {
 			return err
 		}
-		manifestParser = parser.ManifestParser(genOperatorState)
+		manifestParser = parser.ManifestParser(cuekind.ParseConfig{GenOperatorState: genOperatorState})
 	default:
 		return fmt.Errorf("unknown kind format '%s'", format)
 	}

--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -210,7 +210,7 @@ func projectLocalEnvGenerate(cmd *cobra.Command, _ []string) error {
 			if err != nil {
 				return nil, err
 			}
-			generator, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(true, genOperatorState), os.DirFS(sourcePath))
+			generator, err := codegen.NewGenerator[codegen.Kind](parser.KindParser(cuekind.ParseConfig{GenOperatorState: genOperatorState}), os.DirFS(sourcePath))
 			if err != nil {
 				return nil, err
 			}
@@ -777,7 +777,7 @@ func updateLocalConfigFromManifest(config *localEnvConfig, format string, cuePat
 		if err != nil {
 			return err
 		}
-		generator, err := codegen.NewGenerator[codegen.AppManifest](parser.ManifestParser(true), os.DirFS(cuePath))
+		generator, err := codegen.NewGenerator[codegen.AppManifest](parser.ManifestParser(cuekind.ParseConfig{GenOperatorState: true}), os.DirFS(cuePath))
 		if err != nil {
 			return err
 		}
@@ -794,15 +794,15 @@ func updateLocalConfigFromManifest(config *localEnvConfig, format string, cuePat
 			if md.Kind != "AppManifest" {
 				continue
 			}
-			for _, k := range md.Spec.Kinds {
-				if k.Conversion {
-					config.Webhooks.Converting = true
-				}
-				for _, v := range k.Versions {
-					if v.Admission != nil && v.Admission.SupportsAnyValidation() {
+			for _, v := range md.Spec.Versions {
+				for _, k := range v.Kinds {
+					if k.Conversion {
+						config.Webhooks.Converting = true
+					}
+					if k.Admission != nil && k.Admission.SupportsAnyValidation() {
 						config.Webhooks.Validating = true
 					}
-					if v.Admission != nil && v.Admission.SupportsAnyMutation() {
+					if k.Admission != nil && k.Admission.SupportsAnyMutation() {
 						config.Webhooks.Mutating = true
 					}
 				}

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -27,7 +27,7 @@ func TestCRDGenerator(t *testing.T) {
 
 	parser, err := NewParser()
 	require.Nil(t, err)
-	kinds, err := parser.KindParser(true, true).Parse(os.DirFS(TestCUEDirectory), "customManifest", "testManifest")
+	kinds, err := parser.KindParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "customManifest", "testManifest")
 	require.Nil(t, err)
 
 	t.Run("JSON", func(t *testing.T) {
@@ -55,9 +55,9 @@ func TestResourceGenerator(t *testing.T) {
 
 	parser, err := NewParser()
 	require.Nil(t, err)
-	kinds, err := parser.KindParser(true, true).Parse(os.DirFS(TestCUEDirectory), "customManifest")
+	kinds, err := parser.KindParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "customManifest")
 	require.Nil(t, err)
-	sameGroupKinds, err := parser.KindParser(true, true).Parse(os.DirFS(TestCUEDirectory), "testManifest")
+	sameGroupKinds, err := parser.KindParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "testManifest")
 	require.Nil(t, err)
 
 	t.Run("group by kind", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestTypeScriptResourceGenerator(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("versioned", func(t *testing.T) {
-		kinds, err := parser.KindParser(true, true).Parse(os.DirFS(TestCUEDirectory), "customManifest")
+		kinds, err := parser.KindParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "customManifest")
 		require.Nil(t, err)
 		files, err := TypeScriptResourceGenerator().Generate(kinds...)
 		require.Nil(t, err)
@@ -114,7 +114,7 @@ func TestManifestGenerator(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("resource", func(t *testing.T) {
-		kinds, err := parser.ManifestParser(true).Parse(os.DirFS(TestCUEDirectory), "testManifest")
+		kinds, err := parser.ManifestParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "testManifest")
 		require.Nil(t, err)
 		files, err := ManifestGenerator(yaml.Marshal, "yaml", true).Generate(kinds...)
 		require.Nil(t, err)
@@ -131,7 +131,7 @@ func TestManifestGoGenerator(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("group by group", func(t *testing.T) {
-		kinds, err := parser.ManifestParser(true).Parse(os.DirFS(TestCUEDirectory), "testManifest")
+		kinds, err := parser.ManifestParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "testManifest")
 		require.Nil(t, err)
 		files, err := ManifestGoGenerator("groupbygroup", true, "codegen-tests", "pkg/generated", true).Generate(kinds...)
 		require.Nil(t, err)
@@ -143,7 +143,7 @@ func TestManifestGoGenerator(t *testing.T) {
 	})
 
 	t.Run("group by kind", func(t *testing.T) {
-		kinds, err := parser.ManifestParser(true).Parse(os.DirFS(TestCUEDirectory), "customManifest")
+		kinds, err := parser.ManifestParser(ParseConfig{GenOperatorState: true}).Parse(os.DirFS(TestCUEDirectory), "customManifest")
 		require.Nil(t, err)
 		files, err := ManifestGoGenerator("groupbykind", true, "codegen-tests", "pkg/generated", false).Generate(kinds...)
 		require.Nil(t, err)

--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -44,7 +44,7 @@ func (m *ManifestGenerator) Generate(appManifest codegen.AppManifest) (codejen.F
 	}
 
 	if manifestData.Group == "" {
-		if len(manifestData.Kinds) > 0 {
+		if len(manifestData.Versions) > 0 {
 			// API Resource kinds that have no group are not allowed, error at this point
 			return nil, fmt.Errorf("all APIResource kinds must have a non-empty group")
 		}
@@ -94,7 +94,7 @@ func (g *ManifestGoGenerator) Generate(appManifest codegen.AppManifest) (codejen
 	}
 
 	if manifestData.Group == "" {
-		if len(manifestData.Kinds) > 0 {
+		if len(manifestData.Versions) > 0 {
 			// API Resource kinds that have no group are not allowed, error at this point
 			return nil, fmt.Errorf("all APIResource kinds must have a non-empty group")
 		}
@@ -139,7 +139,9 @@ func (g *ManifestGoGenerator) Generate(appManifest codegen.AppManifest) (codejen
 //nolint:revive,gocognit
 func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.ManifestData, error) {
 	manifest := app.ManifestData{
-		Kinds: make([]app.ManifestKind, 0),
+		AppName:  m.Properties().AppName,
+		Group:    m.Properties().FullGroup,
+		Versions: make([]app.ManifestVersion, 0),
 	}
 
 	manifest.AppName = m.Name()
@@ -149,45 +151,31 @@ func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.Manifes
 	hasAnyMutation := false
 	hasAnyConversion := false
 
-	for _, kind := range m.Kinds() {
-		// TODO
-		if manifest.AppName == "" {
-			manifest.AppName = kind.Properties().Group
+	for _, version := range m.Versions() {
+		ver := app.ManifestVersion{
+			Name:   version.Name(),
+			Served: version.Properties().Served,
+			Kinds:  make([]app.ManifestVersionKind, len(version.Kinds())),
 		}
-		if manifest.Group == "" {
-			manifest.Group = kind.Properties().Group
-		}
-		if kind.Properties().Group == "" {
-			return nil, fmt.Errorf("all APIResource kinds must have a non-empty group")
-		}
-		if kind.Properties().Group != manifest.Group {
-			return nil, fmt.Errorf("all kinds must have the same group %q", manifest.Group)
-		}
+		for i, kind := range version.Kinds() {
+			if kind.Conversion {
+				hasAnyConversion = true
+			}
 
-		mkind := app.ManifestKind{
-			Kind:       kind.Name(),
-			Scope:      kind.Properties().Scope,
-			Conversion: kind.Properties().Conversion,
-			Versions:   make([]app.ManifestKindVersion, 0, len(kind.Versions())),
-		}
-		if kind.Properties().Conversion {
-			hasAnyConversion = true
-		}
-
-		for _, version := range kind.Versions() {
-			mver, err := processKindVersion(version, mkind.Kind, includeSchemas)
+			mvkind, err := processKindVersion(kind, version.Name(), includeSchemas)
 			if err != nil {
 				return nil, err
 			}
-			if len(version.Validation.Operations) > 0 {
+			if len(kind.Validation.Operations) > 0 {
 				hasAnyValidation = true
 			}
-			if len(version.Mutation.Operations) > 0 {
+			if len(kind.Mutation.Operations) > 0 {
 				hasAnyMutation = true
 			}
-			mkind.Versions = append(mkind.Versions, mver)
+
+			ver.Kinds[i] = mvkind
 		}
-		manifest.Kinds = append(manifest.Kinds, mkind)
+		manifest.Versions = append(manifest.Versions, ver)
 	}
 
 	if len(m.Properties().ExtraPermissions.AccessKinds) > 0 {
@@ -225,14 +213,17 @@ func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.Manifes
 }
 
 //nolint:revive
-func processKindVersion(version codegen.KindVersion, kindName string, includeSchemas bool) (app.ManifestKindVersion, error) {
-	mver := app.ManifestKindVersion{
-		Name: version.Version,
+func processKindVersion(vk codegen.VersionedKind, version string, includeSchema bool) (app.ManifestVersionKind, error) {
+	mver := app.ManifestVersionKind{
+		Kind:       vk.Kind,
+		Plural:     vk.PluralName,
+		Scope:      vk.Scope,
+		Conversion: vk.Conversion,
 	}
-	if len(version.Mutation.Operations) > 0 {
-		operations, err := sanitizeAdmissionOperations(version.Mutation.Operations)
+	if len(vk.Mutation.Operations) > 0 {
+		operations, err := sanitizeAdmissionOperations(vk.Mutation.Operations)
 		if err != nil {
-			return app.ManifestKindVersion{}, fmt.Errorf("mutation operations error: %w", err)
+			return app.ManifestVersionKind{}, fmt.Errorf("mutation operations error: %w", err)
 		}
 		mver.Admission = &app.AdmissionCapabilities{
 			Mutation: &app.MutationCapability{
@@ -240,40 +231,50 @@ func processKindVersion(version codegen.KindVersion, kindName string, includeSch
 			},
 		}
 	}
-	if len(version.Validation.Operations) > 0 {
+	if len(vk.Validation.Operations) > 0 {
 		if mver.Admission == nil {
 			mver.Admission = &app.AdmissionCapabilities{}
 		}
-		operations, err := sanitizeAdmissionOperations(version.Validation.Operations)
+		operations, err := sanitizeAdmissionOperations(vk.Validation.Operations)
 		if err != nil {
-			return app.ManifestKindVersion{}, fmt.Errorf("validation operations error: %w", err)
+			return app.ManifestVersionKind{}, fmt.Errorf("validation operations error: %w", err)
 		}
 		mver.Admission.Validation = &app.ValidationCapability{
 			Operations: operations,
 		}
 	}
-	if len(version.CustomRoutes) > 0 {
+	if len(vk.CustomRoutes) > 0 {
 		mver.CustomRoutes = make(map[string]spec3.PathProps)
-		for sourcePath, sourceMethodsMap := range version.CustomRoutes {
+		for sourcePath, sourceMethodsMap := range vk.CustomRoutes {
 			targetPathProps, err := buildPathPropsFromMethods(sourcePath, sourceMethodsMap)
 			if err != nil {
-				return app.ManifestKindVersion{}, fmt.Errorf("custom routes error for path '%s': %w", sourcePath, err)
+				return app.ManifestVersionKind{}, fmt.Errorf("custom routes error for path '%s': %w", sourcePath, err)
 			}
 			mver.CustomRoutes[sourcePath] = targetPathProps
 		}
 	}
 	// Only include CRD schemas if told to (there is a bug with recursive schemas and CRDs)
-	if includeSchemas {
-		crd, err := KindVersionToCRDSpecVersion(version, kindName, true)
+	if includeSchema {
+		crd, err := KindVersionToCRDSpecVersion(codegen.KindVersion{
+			Version:                  version,
+			Schema:                   vk.Schema,
+			Codegen:                  vk.Codegen,
+			Served:                   vk.Served,
+			SelectableFields:         vk.SelectableFields,
+			Validation:               vk.Validation,
+			Mutation:                 vk.Mutation,
+			AdditionalPrinterColumns: vk.AdditionalPrinterColumns,
+			CustomRoutes:             vk.CustomRoutes,
+		}, vk.Kind, true)
 		if err != nil {
-			return app.ManifestKindVersion{}, err
+			return app.ManifestVersionKind{}, err
 		}
 		mver.Schema, err = app.VersionSchemaFromMap(crd.Schema)
 		if err != nil {
-			return app.ManifestKindVersion{}, fmt.Errorf("version schema error: %w", err)
+			return app.ManifestVersionKind{}, fmt.Errorf("version schema error: %w", err)
 		}
 	}
-	mver.SelectableFields = version.SelectableFields
+	mver.SelectableFields = vk.SelectableFields
 	return mver, nil
 }
 

--- a/codegen/manifest.go
+++ b/codegen/manifest.go
@@ -1,8 +1,11 @@
 package codegen
 
+import "cuelang.org/go/cue"
+
 type AppManifest interface {
 	Name() string
 	Kinds() []Kind
+	Versions() []Version
 	Properties() AppManifestProperties
 }
 
@@ -12,6 +15,7 @@ type AppManifestProperties struct {
 	FullGroup        string                                `json:"fullGroup"`
 	ExtraPermissions AppManifestPropertiesExtraPermissions `json:"extraPermissions"`
 	OperatorURL      *string                               `json:"operatorURL,omitempty"`
+	PreferredVersion string                                `json:"preferredVersion"`
 }
 
 type AppManifestPropertiesExtraPermissions struct {
@@ -25,8 +29,8 @@ type AppManifestKindPermission struct {
 }
 
 type SimpleManifest struct {
-	Props    AppManifestProperties
-	AllKinds []Kind
+	Props       AppManifestProperties
+	AllVersions []Version
 }
 
 func (m *SimpleManifest) Name() string {
@@ -38,5 +42,105 @@ func (m *SimpleManifest) Properties() AppManifestProperties {
 }
 
 func (m *SimpleManifest) Kinds() []Kind {
-	return m.AllKinds
+	kinds := make(map[string]*AnyKind)
+	for _, version := range m.AllVersions {
+		for _, kind := range version.Kinds() {
+			k, ok := kinds[kind.Kind]
+			if !ok {
+				k = &AnyKind{
+					Props: KindProperties{
+						Kind:                   kind.Kind,
+						Group:                  m.Props.FullGroup,
+						ManifestGroup:          m.Props.Group,
+						MachineName:            kind.MachineName,
+						PluralMachineName:      kind.PluralMachineName,
+						PluralName:             kind.PluralName,
+						Current:                m.Props.PreferredVersion,
+						Scope:                  kind.Scope,
+						Validation:             kind.Validation,
+						Mutation:               kind.Mutation,
+						Conversion:             kind.Conversion,
+						ConversionWebhookProps: kind.ConversionWebhookProps,
+						Codegen:                kind.Codegen,
+					},
+					AllVersions: make([]KindVersion, 0),
+				}
+			}
+			k.AllVersions = append(k.AllVersions, KindVersion{
+				Version:                  version.Name(),
+				Schema:                   kind.Schema,
+				Codegen:                  kind.Codegen,
+				Served:                   kind.Served,
+				SelectableFields:         kind.SelectableFields,
+				Validation:               kind.Validation,
+				Mutation:                 kind.Mutation,
+				AdditionalPrinterColumns: kind.AdditionalPrinterColumns,
+				CustomRoutes:             kind.CustomRoutes,
+			})
+			kinds[kind.Kind] = k
+		}
+	}
+	ret := make([]Kind, 0, len(kinds))
+	for _, k := range kinds {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
+func (m *SimpleManifest) Versions() []Version {
+	return m.AllVersions
+}
+
+type VersionProperties struct {
+	Name    string                `json:"name"`
+	Served  bool                  `json:"served"`
+	Codegen KindCodegenProperties `json:"codegen"`
+}
+
+type Version interface {
+	Name() string
+	Properties() VersionProperties
+	Kinds() []VersionedKind
+}
+
+type SimpleVersion struct {
+	Props    VersionProperties
+	AllKinds []VersionedKind
+}
+
+func (v *SimpleVersion) Name() string {
+	return v.Props.Name
+}
+
+func (v *SimpleVersion) Properties() VersionProperties {
+	return v.Props
+}
+
+func (v *SimpleVersion) Kinds() []VersionedKind {
+	return v.AllKinds
+}
+
+type VersionedKind struct {
+	// Kind is the unique-within-the-group name of the kind
+	Kind string `json:"kind"`
+	// MachineName is the machine version of the Kind, which follows the regex: /^[a-z]+[a-z0-9]*$/
+	MachineName string `json:"machineName"`
+	// PluralMachineName is the plural of the MachineName
+	PluralMachineName string `json:"pluralMachineName"`
+	// PluralName is the plural of the Kind
+	PluralName             string                      `json:"pluralName"`
+	Scope                  string                      `json:"scope"`
+	Validation             KindAdmissionCapability     `json:"validation"`
+	Mutation               KindAdmissionCapability     `json:"mutation"`
+	Conversion             bool                        `json:"conversion"`
+	ConversionWebhookProps ConversionWebhookProperties `json:"conversionWebhookProps"`
+	// Codegen contains code-generation directives for the codegen pipeline
+	Codegen                  KindCodegenProperties     `json:"codegen"`
+	Served                   bool                      `json:"served"`
+	SelectableFields         []string                  `json:"selectableFields"`
+	AdditionalPrinterColumns []AdditionalPrinterColumn `json:"additionalPrinterColumns"`
+	// Schema is the CUE schema for the version
+	// This should eventually be changed to JSONSchema/OpenAPI(/AST?)
+	Schema       cue.Value                         `json:"schema"` // TODO: this should eventually be OpenAPI/JSONSchema (ast or bytes?)
+	CustomRoutes map[string]map[string]CustomRoute `json:"customRoutes"`
 }

--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -120,23 +120,25 @@ OperationProps: spec3.OperationProps{
     },{{ end }}
 },{{ end }}
 
-var ({{ range .ManifestData.Kinds }}{{$k:=.}}{{ range .Versions }}{{ if .Schema }}
-    rawSchema{{$k.Kind}}{{$.ToPackageName .Name}} = []byte({{$.ToJSONBacktickString .Schema}})
-    versionSchema{{$k.Kind}}{{$.ToPackageName .Name}} app.VersionSchema
-    _ = json.Unmarshal(rawSchema{{$k.Kind}}{{$.ToPackageName .Name}}, &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}}){{end}}{{end}}{{end}}
+var ({{ range .ManifestData.Versions }}{{$v:=.}}{{ range .Kinds }}{{ if .Schema }}
+    rawSchema{{.Kind}}{{$.ToPackageName $v.Name}} = []byte({{$.ToJSONBacktickString .Schema}})
+    versionSchema{{.Kind}}{{$.ToPackageName $v.Name}} app.VersionSchema
+    _ = json.Unmarshal(rawSchema{{.Kind}}{{$.ToPackageName $v.Name}}, &versionSchema{{.Kind}}{{$.ToPackageName $v.Name}}){{end}}{{end}}{{end}}
 )
 
 var appManifestData = app.ManifestData{
     AppName: "{{.ManifestData.AppName}}",
     Group: "{{.ManifestData.Group}}",
-    Kinds: []app.ManifestKind{ {{ range .ManifestData.Kinds }}{{$k:=.}}
+    Versions: []app.ManifestVersion{ {{ range .ManifestData.Versions }}{{$v:=.}}
         {
-            Kind: "{{.Kind}}",
-            Scope: "{{.Scope}}",
-            Conversion: {{.Conversion}},
-            Versions: []app.ManifestKindVersion{ {{ range .Versions }}
+            Name: "{{.Name}}",
+            Served: {{.Served}},
+            Kinds: []app.ManifestVersionKind{ {{ range .Kinds }}
             {
-                Name: "{{.Name}}", {{ if .Admission }}
+                Kind: "{{.Kind}}",
+                Plural: "{{.Plural}}",
+                Scope: "{{.Scope}}",
+                Conversion: {{.Conversion}}, {{ if .Admission }}
                 Admission: &app.AdmissionCapabilities{
                     {{ if .Admission.Validation }} Validation: &app.ValidationCapability{
                         {{ if .Admission.Validation.Operations }} Operations: []app.AdmissionOperation{
@@ -149,7 +151,7 @@ var appManifestData = app.ManifestData{
                         {{ end }} }, {{ end }}
                     }, {{ end }}
                 }, {{ end }}{{ if .Schema }}
-                Schema: &versionSchema{{$k.Kind}}{{$.ToPackageName .Name}},{{end}}{{ if .SelectableFields }}
+                Schema: &versionSchema{{.Kind}}{{$.ToPackageName $v.Name}},{{end}}{{ if .SelectableFields }}
                 SelectableFields: []string{ {{ range .SelectableFields }}
                     "{{.}}",{{ end }}
                 },{{end}}{{ if .CustomRoutes }}
@@ -194,8 +196,8 @@ func RemoteManifest() app.Manifest {
     return app.NewAPIServerManifest("{{ .ManifestData.AppName }}")
 }
 
-var kindVersionToGoType = map[string]resource.Kind { {{ range .ManifestData.Kinds }}{{$k:=.}}{{ range .Versions }}
-    "{{ $k.Kind }}/{{ .Name }}": {{ if $.KindsAreGrouped }}{{ $.ToPackageName .Name}}.{{ $.GoKindName $k.Kind }}Kind(){{ else }}{{ $.KindToPackageName $k.Kind }}{{ $.ToPackageName .Name }}.Kind(){{ end }},{{ end }}{{ end }}
+var kindVersionToGoType = map[string]resource.Kind { {{ range .ManifestData.Versions }}{{$v:=.}}{{ range .Kinds }}
+    "{{ .Kind }}/{{ $v.Name }}": {{ if $.KindsAreGrouped }}{{ $.ToPackageName $v.Name}}.{{ $.GoKindName .Kind }}Kind(){{ else }}{{ $.KindToPackageName .Kind }}{{ $.ToPackageName $v.Name }}.Kind(){{ end }},{{ end }}{{ end }}
 }
 
 // ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -447,17 +447,15 @@ func (m ManifestGoFileMetadata) Packages() []string {
 	pkgs := make([]string, 0)
 	if m.KindsAreGrouped {
 		gvs := make(map[string]string)
-		for _, k := range m.ManifestData.Kinds {
-			for _, v := range k.Versions {
-				gvs[fmt.Sprintf("%s/%s", m.GroupToPackageName(m.ManifestData.Group), ToPackageName(v.Name))] = ToPackageName(v.Name)
-			}
+		for _, v := range m.ManifestData.Versions {
+			gvs[fmt.Sprintf("%s/%s", m.GroupToPackageName(m.ManifestData.Group), ToPackageName(v.Name))] = ToPackageName(v.Name)
 		}
 		for pkg, alias := range gvs {
 			pkgs = append(pkgs, fmt.Sprintf("%s \"%s\"", alias, filepath.Join(m.Repo, m.CodegenPath, pkg)))
 		}
 	} else {
-		for _, k := range m.ManifestData.Kinds {
-			for _, v := range k.Versions {
+		for _, v := range m.ManifestData.Versions {
+			for _, k := range v.Kinds {
 				pkgs = append(pkgs, fmt.Sprintf("%s%s \"%s\"", m.KindToPackageName(k.Kind), ToPackageName(v.Name), filepath.Join(m.Repo, m.CodegenPath, m.KindToPackageName(k.Kind), ToPackageName(v.Name))))
 			}
 		}

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
@@ -7,13 +7,15 @@
     "spec": {
         "appName": "custom-app",
         "group": "customapp.ext.grafana.com",
-        "kinds": [
+        "versions": [
             {
-                "kind": "CustomKind",
-                "scope": "Namespaced",
-                "versions": [
+                "name": "v0-0",
+                "served": true,
+                "kinds": [
                     {
-                        "name": "v0-0",
+                        "kind": "CustomKind",
+                        "plural": "CustomKinds",
+                        "scope": "Namespaced",
                         "schema": {
                             "spec": {
                                 "properties": {
@@ -75,10 +77,19 @@
                                 },
                                 "type": "object"
                             }
-                        }
-                    },
+                        },
+                        "conversion": false
+                    }
+                ]
+            },
+            {
+                "name": "v1-0",
+                "served": true,
+                "kinds": [
                     {
-                        "name": "v1-0",
+                        "kind": "CustomKind",
+                        "plural": "CustomKinds",
+                        "scope": "Namespaced",
                         "schema": {
                             "spec": {
                                 "properties": {
@@ -297,11 +308,12 @@
                                 "type": "object",
                                 "x-kubernetes-preserve-unknown-fields": true
                             }
-                        }
+                        },
+                        "conversion": false
                     }
-                ],
-                "conversion": false
+                ]
             }
-        ]
+        ],
+        "preferredVersion": ""
     }
 }

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
@@ -5,11 +5,13 @@ metadata:
 spec:
     appName: custom-app
     group: customapp.ext.grafana.com
-    kinds:
-        - kind: CustomKind
-          scope: Namespaced
-          versions:
-            - name: v0-0
+    versions:
+        - name: v0-0
+          served: true
+          kinds:
+            - kind: CustomKind
+              plural: CustomKinds
+              scope: Namespaced
               schema:
                 spec:
                     properties:
@@ -58,7 +60,13 @@ spec:
                                 Any operator which consumes this kind SHOULD add its state evaluation information to this field.
                             type: object
                     type: object
-            - name: v1-0
+              conversion: false
+        - name: v1-0
+          served: true
+          kinds:
+            - kind: CustomKind
+              plural: CustomKinds
+              scope: Namespaced
               schema:
                 spec:
                     properties:
@@ -213,4 +221,5 @@ spec:
                         - statusField1
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-          conversion: false
+              conversion: false
+    preferredVersion: ""

--- a/codegen/testing/golden_generated/manifest/go/groupbygroup/customapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/manifest/go/groupbygroup/customapp_manifest.go.txt
@@ -28,20 +28,31 @@ var (
 var appManifestData = app.ManifestData{
 	AppName: "custom-app",
 	Group:   "customapp.ext.grafana.com",
-	Kinds: []app.ManifestKind{
+	Versions: []app.ManifestVersion{
 		{
-			Kind:       "CustomKind",
-			Scope:      "Namespaced",
-			Conversion: false,
-			Versions: []app.ManifestKindVersion{
+			Name:   "v0-0",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name:   "v0-0",
-					Schema: &versionSchemaCustomKindv0_0,
+					Kind:       "CustomKind",
+					Plural:     "CustomKinds",
+					Scope:      "Namespaced",
+					Conversion: false,
+					Schema:     &versionSchemaCustomKindv0_0,
 				},
+			},
+		},
 
+		{
+			Name:   "v1-0",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name:   "v1-0",
-					Schema: &versionSchemaCustomKindv1_0,
+					Kind:       "CustomKind",
+					Plural:     "CustomKinds",
+					Scope:      "Namespaced",
+					Conversion: false,
+					Schema:     &versionSchemaCustomKindv1_0,
 				},
 			},
 		},

--- a/codegen/testing/golden_generated/manifest/go/groupbygroup/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/manifest/go/groupbygroup/testapp_manifest.go.txt
@@ -23,28 +23,30 @@ var (
 	rawSchemaTestKindv1      = []byte(`{"spec":{"properties":{"stringField":{"type":"string"}},"required":["stringField"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaTestKindv1  app.VersionSchema
 	_                        = json.Unmarshal(rawSchemaTestKindv1, &versionSchemaTestKindv1)
+	rawSchemaTestKind2v1     = []byte(`{"spec":{"properties":{"testField":{"type":"string"}},"required":["testField"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
+	versionSchemaTestKind2v1 app.VersionSchema
+	_                        = json.Unmarshal(rawSchemaTestKind2v1, &versionSchemaTestKind2v1)
 	rawSchemaTestKindv2      = []byte(`{"spec":{"properties":{"intField":{"format":"int64","type":"integer"},"stringField":{"type":"string"},"timeField":{"format":"date-time","type":"string"}},"required":["stringField","intField","timeField"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaTestKindv2  app.VersionSchema
 	_                        = json.Unmarshal(rawSchemaTestKindv2, &versionSchemaTestKindv2)
 	rawSchemaTestKindv3      = []byte(`{"spec":{"properties":{"boolField":{"type":"boolean"},"intField":{"format":"int64","type":"integer"},"stringField":{"type":"string"},"timeField":{"format":"date-time","type":"string"}},"required":["stringField","intField","timeField","boolField"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaTestKindv3  app.VersionSchema
 	_                        = json.Unmarshal(rawSchemaTestKindv3, &versionSchemaTestKindv3)
-	rawSchemaTestKind2v1     = []byte(`{"spec":{"properties":{"testField":{"type":"string"}},"required":["testField"],"type":"object"},"status":{"properties":{"additionalFields":{"description":"additionalFields is reserved for future use","type":"object","x-kubernetes-preserve-unknown-fields":true},"operatorStates":{"additionalProperties":{"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"description":"details contains any extra information that is operator-specific","type":"object","x-kubernetes-preserve-unknown-fields":true},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
-	versionSchemaTestKind2v1 app.VersionSchema
-	_                        = json.Unmarshal(rawSchemaTestKind2v1, &versionSchemaTestKind2v1)
 )
 
 var appManifestData = app.ManifestData{
 	AppName: "test-app",
 	Group:   "testapp.ext.grafana.com",
-	Kinds: []app.ManifestKind{
+	Versions: []app.ManifestVersion{
 		{
-			Kind:       "TestKind",
-			Scope:      "Namespaced",
-			Conversion: true,
-			Versions: []app.ManifestKindVersion{
+			Name:   "v1",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name: "v1",
+					Kind:       "TestKind",
+					Plural:     "TestKinds",
+					Scope:      "Namespaced",
+					Conversion: true,
 					Admission: &app.AdmissionCapabilities{
 						Validation: &app.ValidationCapability{
 							Operations: []app.AdmissionOperation{
@@ -57,15 +59,26 @@ var appManifestData = app.ManifestData{
 				},
 
 				{
-					Name: "v2",
+					Kind:       "TestKind2",
+					Plural:     "TestKind2s",
+					Scope:      "Namespaced",
+					Conversion: false,
+					Schema:     &versionSchemaTestKind2v1,
+				},
+			},
+		},
+
+		{
+			Name:   "v2",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
+				{
+					Kind:       "TestKind",
+					Plural:     "TestKinds",
+					Scope:      "Namespaced",
+					Conversion: true,
 					Admission: &app.AdmissionCapabilities{
 						Validation: &app.ValidationCapability{
-							Operations: []app.AdmissionOperation{
-								app.AdmissionOperationCreate,
-								app.AdmissionOperationUpdate,
-							},
-						},
-						Mutation: &app.MutationCapability{
 							Operations: []app.AdmissionOperation{
 								app.AdmissionOperationCreate,
 								app.AdmissionOperationUpdate,
@@ -74,17 +87,20 @@ var appManifestData = app.ManifestData{
 					},
 					Schema: &versionSchemaTestKindv2,
 				},
+			},
+		},
 
+		{
+			Name:   "v3",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name: "v3",
+					Kind:       "TestKind",
+					Plural:     "TestKinds",
+					Scope:      "Namespaced",
+					Conversion: true,
 					Admission: &app.AdmissionCapabilities{
 						Validation: &app.ValidationCapability{
-							Operations: []app.AdmissionOperation{
-								app.AdmissionOperationCreate,
-								app.AdmissionOperationUpdate,
-							},
-						},
-						Mutation: &app.MutationCapability{
 							Operations: []app.AdmissionOperation{
 								app.AdmissionOperationCreate,
 								app.AdmissionOperationUpdate,
@@ -244,25 +260,13 @@ var appManifestData = app.ManifestData{
 				},
 			},
 		},
-
-		{
-			Kind:       "TestKind2",
-			Scope:      "Namespaced",
-			Conversion: false,
-			Versions: []app.ManifestKindVersion{
-				{
-					Name:   "v1",
-					Schema: &versionSchemaTestKind2v1,
-				},
-			},
-		},
 	},
 	Operator: &app.ManifestOperatorInfo{
 		URL: "https://foo.bar:8443",
 		Webhooks: &app.ManifestOperatorWebhookProperties{
 			ConversionPath: "/convert",
 			ValidationPath: "/validate",
-			MutationPath:   "/mutate",
+			MutationPath:   "",
 		},
 	},
 }
@@ -277,9 +281,9 @@ func RemoteManifest() app.Manifest {
 
 var kindVersionToGoType = map[string]resource.Kind{
 	"TestKind/v1":  v1.TestKindKind(),
+	"TestKind2/v1": v1.TestKind2Kind(),
 	"TestKind/v2":  v2.TestKindKind(),
 	"TestKind/v3":  v3.TestKindKind(),
-	"TestKind2/v1": v1.TestKind2Kind(),
 }
 
 // ManifestGoTypeAssociator returns the associated resource.Kind instance for a given Kind and Version, if one exists.

--- a/codegen/testing/golden_generated/manifest/go/groupbykind/customapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/manifest/go/groupbykind/customapp_manifest.go.txt
@@ -28,20 +28,31 @@ var (
 var appManifestData = app.ManifestData{
 	AppName: "custom-app",
 	Group:   "customapp.ext.grafana.com",
-	Kinds: []app.ManifestKind{
+	Versions: []app.ManifestVersion{
 		{
-			Kind:       "CustomKind",
-			Scope:      "Namespaced",
-			Conversion: false,
-			Versions: []app.ManifestKindVersion{
+			Name:   "v0-0",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name:   "v0-0",
-					Schema: &versionSchemaCustomKindv0_0,
+					Kind:       "CustomKind",
+					Plural:     "CustomKinds",
+					Scope:      "Namespaced",
+					Conversion: false,
+					Schema:     &versionSchemaCustomKindv0_0,
 				},
+			},
+		},
 
+		{
+			Name:   "v1-0",
+			Served: true,
+			Kinds: []app.ManifestVersionKind{
 				{
-					Name:   "v1-0",
-					Schema: &versionSchemaCustomKindv1_0,
+					Kind:       "CustomKind",
+					Plural:     "CustomKinds",
+					Scope:      "Namespaced",
+					Conversion: false,
+					Schema:     &versionSchemaCustomKindv1_0,
 				},
 			},
 		},

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
@@ -7,13 +7,15 @@
     "spec": {
         "appName": "test-app",
         "group": "testapp.ext.grafana.com",
-        "kinds": [
+        "versions": [
             {
-                "kind": "TestKind",
-                "scope": "Namespaced",
-                "versions": [
+                "name": "v1",
+                "served": true,
+                "kinds": [
                     {
-                        "name": "v1",
+                        "kind": "TestKind",
+                        "plural": "TestKinds",
+                        "scope": "Namespaced",
                         "admission": {
                             "validation": {
                                 "operations": [
@@ -79,18 +81,85 @@
                                 },
                                 "type": "object"
                             }
-                        }
+                        },
+                        "conversion": true
                     },
                     {
-                        "name": "v2",
+                        "kind": "TestKind2",
+                        "plural": "TestKind2s",
+                        "scope": "Namespaced",
+                        "schema": {
+                            "spec": {
+                                "properties": {
+                                    "testField": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "testField"
+                                ],
+                                "type": "object"
+                            },
+                            "status": {
+                                "properties": {
+                                    "additionalFields": {
+                                        "description": "additionalFields is reserved for future use",
+                                        "type": "object",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "operatorStates": {
+                                        "additionalProperties": {
+                                            "properties": {
+                                                "descriptiveState": {
+                                                    "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
+                                                    "type": "string"
+                                                },
+                                                "details": {
+                                                    "description": "details contains any extra information that is operator-specific",
+                                                    "type": "object",
+                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                },
+                                                "lastEvaluation": {
+                                                    "description": "lastEvaluation is the ResourceVersion last evaluated",
+                                                    "type": "string"
+                                                },
+                                                "state": {
+                                                    "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
+                                                    "enum": [
+                                                        "success",
+                                                        "in_progress",
+                                                        "failed"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "lastEvaluation",
+                                                "state"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "conversion": false
+                    }
+                ]
+            },
+            {
+                "name": "v2",
+                "served": true,
+                "kinds": [
+                    {
+                        "kind": "TestKind",
+                        "plural": "TestKinds",
+                        "scope": "Namespaced",
                         "admission": {
                             "validation": {
-                                "operations": [
-                                    "CREATE",
-                                    "UPDATE"
-                                ]
-                            },
-                            "mutation": {
                                 "operations": [
                                     "CREATE",
                                     "UPDATE"
@@ -164,18 +233,21 @@
                                 },
                                 "type": "object"
                             }
-                        }
-                    },
+                        },
+                        "conversion": true
+                    }
+                ]
+            },
+            {
+                "name": "v3",
+                "served": true,
+                "kinds": [
                     {
-                        "name": "v3",
+                        "kind": "TestKind",
+                        "plural": "TestKinds",
+                        "scope": "Namespaced",
                         "admission": {
                             "validation": {
-                                "operations": [
-                                    "CREATE",
-                                    "UPDATE"
-                                ]
-                            },
-                            "mutation": {
                                 "operations": [
                                     "CREATE",
                                     "UPDATE"
@@ -378,80 +450,13 @@
                                     }
                                 }
                             }
-                        }
+                        },
+                        "conversion": true
                     }
-                ],
-                "conversion": true
-            },
-            {
-                "kind": "TestKind2",
-                "scope": "Namespaced",
-                "versions": [
-                    {
-                        "name": "v1",
-                        "schema": {
-                            "spec": {
-                                "properties": {
-                                    "testField": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "testField"
-                                ],
-                                "type": "object"
-                            },
-                            "status": {
-                                "properties": {
-                                    "additionalFields": {
-                                        "description": "additionalFields is reserved for future use",
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
-                                    },
-                                    "operatorStates": {
-                                        "additionalProperties": {
-                                            "properties": {
-                                                "descriptiveState": {
-                                                    "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
-                                                    "type": "string"
-                                                },
-                                                "details": {
-                                                    "description": "details contains any extra information that is operator-specific",
-                                                    "type": "object",
-                                                    "x-kubernetes-preserve-unknown-fields": true
-                                                },
-                                                "lastEvaluation": {
-                                                    "description": "lastEvaluation is the ResourceVersion last evaluated",
-                                                    "type": "string"
-                                                },
-                                                "state": {
-                                                    "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
-                                                    "enum": [
-                                                        "success",
-                                                        "in_progress",
-                                                        "failed"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "lastEvaluation",
-                                                "state"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
-                                        "type": "object"
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
-                    }
-                ],
-                "conversion": false
+                ]
             }
         ],
+        "preferredVersion": "",
         "extraPermissions": {
             "accessKinds": [
                 {
@@ -470,7 +475,7 @@
             "webhooks": {
                 "conversionPath": "/convert",
                 "validationPath": "/validate",
-                "mutationPath": "/mutate"
+                "mutationPath": ""
             }
         }
     }

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
@@ -5,11 +5,13 @@ metadata:
 spec:
     appName: test-app
     group: testapp.ext.grafana.com
-    kinds:
-        - kind: TestKind
-          scope: Namespaced
-          versions:
-            - name: v1
+    versions:
+        - name: v1
+          served: true
+          kinds:
+            - kind: TestKind
+              plural: TestKinds
+              scope: Namespaced
               admission:
                 validation:
                     operations:
@@ -60,13 +62,64 @@ spec:
                                 Any operator which consumes this kind SHOULD add its state evaluation information to this field.
                             type: object
                     type: object
-            - name: v2
+              conversion: true
+            - kind: TestKind2
+              plural: TestKind2s
+              scope: Namespaced
+              schema:
+                spec:
+                    properties:
+                        testField:
+                            type: string
+                    required:
+                        - testField
+                    type: object
+                status:
+                    properties:
+                        additionalFields:
+                            description: additionalFields is reserved for future use
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        operatorStates:
+                            additionalProperties:
+                                properties:
+                                    descriptiveState:
+                                        description: descriptiveState is an optional more descriptive state field which has no requirements on format
+                                        type: string
+                                    details:
+                                        description: details contains any extra information that is operator-specific
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    lastEvaluation:
+                                        description: lastEvaluation is the ResourceVersion last evaluated
+                                        type: string
+                                    state:
+                                        description: |-
+                                            state describes the state of the lastEvaluation.
+                                            It is limited to three possible states for machine evaluation.
+                                        enum:
+                                            - success
+                                            - in_progress
+                                            - failed
+                                        type: string
+                                required:
+                                    - lastEvaluation
+                                    - state
+                                type: object
+                            description: |-
+                                operatorStates is a map of operator ID to operator state evaluations.
+                                Any operator which consumes this kind SHOULD add its state evaluation information to this field.
+                            type: object
+                    type: object
+              conversion: false
+        - name: v2
+          served: true
+          kinds:
+            - kind: TestKind
+              plural: TestKinds
+              scope: Namespaced
               admission:
                 validation:
-                    operations:
-                        - CREATE
-                        - UPDATE
-                mutation:
                     operations:
                         - CREATE
                         - UPDATE
@@ -123,13 +176,15 @@ spec:
                                 Any operator which consumes this kind SHOULD add its state evaluation information to this field.
                             type: object
                     type: object
-            - name: v3
+              conversion: true
+        - name: v3
+          served: true
+          kinds:
+            - kind: TestKind
+              plural: TestKinds
+              scope: Namespaced
               admission:
                 validation:
-                    operations:
-                        - CREATE
-                        - UPDATE
-                mutation:
                     operations:
                         - CREATE
                         - UPDATE
@@ -1178,57 +1233,8 @@ spec:
                     trace: null
                     servers: []
                     parameters: []
-          conversion: true
-        - kind: TestKind2
-          scope: Namespaced
-          versions:
-            - name: v1
-              schema:
-                spec:
-                    properties:
-                        testField:
-                            type: string
-                    required:
-                        - testField
-                    type: object
-                status:
-                    properties:
-                        additionalFields:
-                            description: additionalFields is reserved for future use
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                        operatorStates:
-                            additionalProperties:
-                                properties:
-                                    descriptiveState:
-                                        description: descriptiveState is an optional more descriptive state field which has no requirements on format
-                                        type: string
-                                    details:
-                                        description: details contains any extra information that is operator-specific
-                                        type: object
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    lastEvaluation:
-                                        description: lastEvaluation is the ResourceVersion last evaluated
-                                        type: string
-                                    state:
-                                        description: |-
-                                            state describes the state of the lastEvaluation.
-                                            It is limited to three possible states for machine evaluation.
-                                        enum:
-                                            - success
-                                            - in_progress
-                                            - failed
-                                        type: string
-                                required:
-                                    - lastEvaluation
-                                    - state
-                                type: object
-                            description: |-
-                                operatorStates is a map of operator ID to operator state evaluations.
-                                Any operator which consumes this kind SHOULD add its state evaluation information to this field.
-                            type: object
-                    type: object
-          conversion: false
+              conversion: true
+    preferredVersion: ""
     extraPermissions:
         accessKinds:
             - group: foo.bar
@@ -1242,4 +1248,4 @@ spec:
         webhooks:
             conversionPath: /convert
             validationPath: /validate
-            mutationPath: /mutate
+            mutationPath: ""

--- a/examples/operator/simple/reconciler/main.go
+++ b/examples/operator/simple/reconciler/main.go
@@ -29,11 +29,11 @@ var (
 	manifest = app.NewEmbeddedManifest(app.ManifestData{
 		AppName: "example-app",
 		Group:   kind.Group(),
-		Kinds: []app.ManifestKind{{
-			Kind:  kind.Kind(),
-			Scope: string(kind.Scope()),
-			Versions: []app.ManifestKindVersion{{
-				Name: kind.Version(),
+		Versions: []app.ManifestVersion{{
+			Name: kind.Version(),
+			Kinds: []app.ManifestVersionKind{{
+				Kind:  kind.Kind(),
+				Scope: string(kind.Scope()),
 			}},
 		}},
 	})
@@ -122,8 +122,8 @@ func NewApp(config app.Config) (app.App, error) {
 		Name:       "simple-reconciler-app",
 		KubeConfig: config.KubeConfig,
 		ManagedKinds: []simple.AppManagedKind{{
-			Kind:             kind,
-			Reconciler:       reconciler,
+			Kind:       kind,
+			Reconciler: reconciler,
 			ReconcileOptions: simple.BasicReconcileOptions{
 				// FIXME: Uncomment this line to turn off the opinionated logic
 				// UsePlain: true, // UsePlain = true turns off the opinionated logic.

--- a/examples/operator/simple/watcher/main.go
+++ b/examples/operator/simple/watcher/main.go
@@ -29,11 +29,11 @@ var (
 	manifest = app.NewEmbeddedManifest(app.ManifestData{
 		AppName: "example-app",
 		Group:   kind.Group(),
-		Kinds: []app.ManifestKind{{
-			Kind:  kind.Kind(),
-			Scope: string(kind.Scope()),
-			Versions: []app.ManifestKindVersion{{
-				Name: kind.Version(),
+		Versions: []app.ManifestVersion{{
+			Name: kind.Version(),
+			Kinds: []app.ManifestVersionKind{{
+				Kind:  kind.Kind(),
+				Scope: string(kind.Scope()),
 			}},
 		}},
 	})

--- a/operator/runner.go
+++ b/operator/runner.go
@@ -171,9 +171,9 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 	// Admission control
 	anyWebhooks := false
 	vkCapabilities := make(map[string]capabilities)
-	for _, kind := range manifestData.Kinds {
-		for _, version := range kind.Versions {
-			if version.Admission == nil {
+	for _, version := range manifestData.Versions {
+		for _, kind := range version.Kinds {
+			if kind.Admission == nil {
 				if kind.Conversion {
 					anyWebhooks = true
 					vkCapabilities[fmt.Sprintf("%s/%s", kind.Kind, version.Name)] = capabilities{
@@ -184,10 +184,10 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 			}
 			vkCapabilities[fmt.Sprintf("%s/%s", kind.Kind, version.Name)] = capabilities{
 				conversion: kind.Conversion,
-				mutation:   version.Admission.SupportsAnyMutation(),
-				validation: version.Admission.SupportsAnyValidation(),
+				mutation:   kind.Admission.SupportsAnyMutation(),
+				validation: kind.Admission.SupportsAnyValidation(),
 			}
-			if kind.Conversion || version.Admission.SupportsAnyMutation() || version.Admission.SupportsAnyValidation() {
+			if kind.Conversion || kind.Admission.SupportsAnyMutation() || kind.Admission.SupportsAnyValidation() {
 				anyWebhooks = true
 			}
 		}


### PR DESCRIPTION
This is part one of https://github.com/grafana/grafana-app-sdk/pull/795, broken out into a smaller subset of the changes.

# What This PR Does / Why We Need It

In kubernetes, kinds exist in a hierarchy that can be seen in the URL to access one, with `apigroup` being the top of the hierarchy, `apiversion` being the next level, and finally the kind itself being the lowest level. As such, while kinds belong to an `apigroup` (which is analogous to an App within App Platform contexts), they _also_ are localized to an `apiversion`, despite a kind with the same name (and other metadata, like scope) possibly existing in another version. This is a bit confusing, because kind data and `apiversion` are somewhat entangled: a kind shares the same information between API versions, excepting its schema (and data tied to the schema, such as table view fields and field selectors). 

Representing this kind hierarchy in a way that is understandable and usable in the manifest becomes somehwhat of a challenge. The current model is to have the manifest contain a list of kinds (`manifest.kinds`), and the kinds themselves have a list of versions they exist for. However, since APIs are versioned and the preferred use version for API discovery is at the API group + version level, and not per-kind, an App and kind's versioning should be tied together as a single vertical. This vertical looks something like:

| Version | Kinds available in version |
|-|-|
| foo.ext.grafana.app/v1 | foos, bars |
| foo.ext.grafana.app/v2 | foos, bars, foobars |
| foo.ext.grafana.app/v3 | foos, bars, foobars, barfoos |

Note that new kinds introduced do not start at `v1`, despite the current model of kind-centric versioning. Instead, new kinds _may_ exist from the earliest (or earlier) versions, but must always exist in subsequent versions, regardless of whether that particular kind has schema changes that would warrant a new version. This is to present a uniform API surface per version, consistent with behavior of kubernetes APIs and service discovery.

This PR updates the way the App Manifest is defined to put versions at a higher level than kinds--that is, it inverts the relationship of manifest->kind(s)->version(s) to be manifest->version(s)->kind(s). Each kind in the manifest now is version-specific, rather than version-agnostic with version-specific attributes (like schema) found in `versions`. A manifest that may have previously been represented as
```yaml
apiVersion: apps.grafana.com/v1alpha1
kind: AppManifest
metadata:
  name: test
spec:
  appName: test
  group: test.ext.grafana.app
  kinds: 
    - kind: Foo
      current: v2
      scope: Namespaced
      versions:
        - name: v1
          schema: { ... }
        - name: v2 
          schema: { ... }
```
Would now look like:
```yaml
apiVersion: apps.grafana.com/v1alpha1
kind: AppManifest
metadata:
  name: test
spec:
  appName: test
  group: test.ext.grafana.app
  versions:
    - name: v1
      kinds: 
        - kind: Foo
          scope: Namespaced
          schema: { ... }
    - name: v2
      kinds:
        - kind: Foo
          scope: Namespaced
          schema: { ... }
  preferredVersion: v2 # this can now be omitted and defaults to latest
```

This does introduce redundancy that didn't exist before in the kind-centric model for kind-level fields (for example, the `scope` in the above example--other fields are `conversion` and `plural`). To combat discrepancies causing problems, a `Validate` method has been introduced to `app.ManifestData` which can be called prior to using the data to ensure no inconsistencies exist (this can also be done on ingress of the manifest kind in environments where the manifest is deployed as an API server kind).

This PR does not yet change the input manifest for codegen, focusing only on the output to reduce number of changes.