### PR TITLE
[codegen] Fix package import path in generated manifest go file

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -104,11 +104,12 @@ func (g *ManifestGoGenerator) Generate(appManifest codegen.AppManifest) (codejen
 
 	buf := bytes.Buffer{}
 	err = templates.WriteManifestGoFile(templates.ManifestGoFileMetadata{
-		Package:         g.Package,
-		Repo:            g.ProjectRepo,
-		CodegenPath:     g.CodegenPath,
-		KindsAreGrouped: !g.GroupByKind,
-		ManifestData:    *manifestData,
+		Package:              g.Package,
+		Repo:                 g.ProjectRepo,
+		CodegenPath:          g.CodegenPath,
+		KindsAreGrouped:      !g.GroupByKind,
+		ManifestData:         *manifestData,
+		CodegenManifestGroup: appManifest.Properties().Group,
 	}, &buf)
 	if err != nil {
 		return nil, err

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -390,11 +390,12 @@ func WriteOperatorConfig(out io.Writer) error {
 }
 
 type ManifestGoFileMetadata struct {
-	Package         string
-	Repo            string
-	CodegenPath     string
-	KindsAreGrouped bool
-	ManifestData    app.ManifestData
+	Package              string
+	Repo                 string
+	CodegenPath          string
+	KindsAreGrouped      bool
+	ManifestData         app.ManifestData
+	CodegenManifestGroup string
 }
 
 func (ManifestGoFileMetadata) ToAdmissionOperationName(input app.AdmissionOperation) string {
@@ -449,7 +450,7 @@ func (m ManifestGoFileMetadata) Packages() []string {
 		gvs := make(map[string]string)
 		for _, k := range m.ManifestData.Kinds {
 			for _, v := range k.Versions {
-				gvs[fmt.Sprintf("%s/%s", m.GroupToPackageName(m.ManifestData.Group), ToPackageName(v.Name))] = ToPackageName(v.Name)
+				gvs[fmt.Sprintf("%s/%s", m.GroupToPackageName(m.CodegenManifestGroup), ToPackageName(v.Name))] = ToPackageName(v.Name)
 			}
 		}
 		for pkg, alias := range gvs {


### PR DESCRIPTION
Fix discrepency where the package imported by the manifest go file for a group is based on the manifest's full group's first component, but the package path determined by the kind codegen uses the manifest short group from the CUE (which is a variant of the appName). Use the kind codegen's package name in the manifest go file.

Prior to this, the group used in the manifest go import statement was just the first dot-separated component of the full manifest group, which was fine in most cases where the full group was auto-created from the "short" group which is just `LOWER(REPLACE(appName, "-", ""))`, and the full group was just that short group + `ext.grafana.(com|app)`. However, if `groupOverride` is used and the full group is set to something which does not begin with the short group (appName) (for example, and appName `foo` and the `groupOverride` being `bar.foo.ext.grafana.com`), the generated path use in the manifest go file would be incorrect (`bar` instead of `foo` in our example).

This is noted [here](https://github.com/grafana/grafana/pull/106111#discussion_r2110383415) as an issue when generating code for grafana's `apps/alerting/notifications`, as the app is `alerting`, but the fullgroup is `notifications.alerting.grafana.app`.