### PR TITLE
docs: refresh docs and minor changes

### DIFF
--- a/cmd/grafana-app-sdk/templates/local/generated/datasources/minio.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/datasources/minio.yaml
@@ -43,7 +43,7 @@ spec:
               value: minio123
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: public
-          image: minio/minio:RELEASE.2021-06-07T21-40-51Z
+          image: minio/minio:RELEASE.2025-05-24T17-08-30Z
           imagePullPolicy: IfNotPresent
           name: minio
           ports:

--- a/docs/admission-control.md
+++ b/docs/admission-control.md
@@ -21,7 +21,7 @@ func main() {
     validatingController := resource.SimpleValidatingAdmissionController{
         ValidateFunc: func(ctx context.Context, request *resource.AdmissionRequest) error {
             // Check that the name is allowed
-            if request.Object.StticMetadata().Name == "not-allowed" {
+            if request.Object.GetStaticMetadata().Name == "not-allowed" {
                 return k8s.NewSimpleAdmissionError(fmt.Errorf("name not allowed"), http.StatusBadRequest, "ERR_NAME_NOT_ALLOWED")
             }
             return nil

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ This will add a CUE file to your `--source` directory with a filled-out custom k
 
 Arguably the most important function of the CLI, as it needs to be run whenever you update your kinds, is generating code from your CUE kinds.
 
-For more details on kinds, see [Custom Kinds & CUE](custom-kinds.md).
+For more details on kinds, see [Custom Kinds & CUE](./custom-kinds/README.md).
 
 To generate code for your kinds, use 
 ```

--- a/docs/custom-kinds/managing-multiple-versions.md
+++ b/docs/custom-kinds/managing-multiple-versions.md
@@ -118,7 +118,7 @@ type MyKindConverter struct {}
 func (m *MyKindConverter) Convert(obj k8s.RawKind, targetAPIVersion string) ([]byte, error) {
     // We shouldn't ever see this, but just in case...
     if targetAPIVersion == obj.APIVersion {
-        return obj.Raw, nil
+        return nil, fmt.Errorf("conversion from a version to itself should not call the webhook: %s", targetAPIVersion)
     }
     targetGVK := schema.FromAPIVersionAndKind(targetAPIVersion, obj.Kind)
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -26,13 +26,11 @@ Custom Resource Definitions must have a **group** and **version**, which are use
 ### CRDs & grafana-app-sdk
 
 When you author kinds and use `grafana-app-sdk generate` to [generate code](code-generation.md), you'll get a CRD file for each kind as well. 
-The CRD file will contain the entire lineage expressed in openAPI format, and can be used to create your kind as a CRD in a kubernetes cluster. 
+The CRD file will contain the entire lineage expressed in openAPI format, and can be used to create your kind as a CRD in a kubernetes cluster.
 The generated `resource.Schema` is then used to identify the **group**, **version**, and **kind** of your CRD when interacting with kubernetes. 
 You can then use a `k8s.ClientRegistry` to generate clients which can translate the CRDs in the cluster into the generated go type. 
 
-The reason the client intermediary is necessary is twofold:
-1. It allows thema to be inserted at the unmarshal point
-2. The format of metadata in your authored kind doesn't exactly match kubernetes' metadata format--the kind has more metadata, which is encoded and decoded in kubernetes' annotations for the object. The client performs this translation.
+The client intermediary is necessary because the metadata format in your authored kind doesn't exactly match Kubernetes' metadata format. The kind has more metadata, which is encoded and decoded in the Kubernetes object's annotations, and the client performs this translation.
 
 You can still directly interface with the CRD's through kubernetes tooling or APIs as well, the SDK's tooling just makes understanding and updating the object's metadata simpler.
 
@@ -51,7 +49,7 @@ or even resources which your code doesn't manage, but you want to take action ba
 
 Within the SDK, there is the `operator.Operator` type, which handles one or more `operator.Controller` objects, which are intended to handle specific resources or groups of resources. An `operator.Controller` can be run on its own, as well, without being a part of an `operator.Operator`.
 The built-in `operator.Controller` object is the `operator.InformerController`, which uses a pattern of having `operator.Informer` objects which handle emitting events for add, update, or delete actions on a specific kind, and `operator.ResourceWatcher` objects which are user-defined and react to events emitted by Informers (this is very similar to the kubernetes informer pattern, just with a decoupling between the informer and the actions to take for events). A reconciler-pattern controller is also planned for the very near future. 
-For more details, see the [Operator Examples](../examples/operator) or the [Operator Package README](../operator/README.md).
+For more details, see the [Operator Examples](../examples/operator) or the [Operator Package README](../docs/operators.md).
 
 ### Running an Operator
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -17,7 +17,7 @@ but a user can easily extend this by having a new controller which implements th
 The controller offered by the SDK is the `operator.InformerController`, which is a controller that is composed of three sets of objects:
 * **Informers**, which are given a particular CRD and will notify the controller on changes - when resources change, Watchers and Reconcilers will be triggered, performing the according actions;
 * **Watchers**, which subscribe to changes for a particular CRD kind and will be notified about any changes from a relevant Informer. Multiple Watchers can watch the same resource kind, and when a change occurs, they will be called in the order they were added to the controller.;
-* **Reconcilers**, which subscribe to changes in the state of a particular CRD kind and will be noticied about any changes from a relevant Informer, its objective is to ensure that the current state of resources matches the desired state. Multiple Reconcilers can watch the same resource kind, and when a change occurs, they will be called in the order they were added to the controller.
+* **Reconcilers**, which subscribe to changes in the state of a particular CRD kind and will be notified about any changes from a relevant Informer, its objective is to ensure that the current state of resources matches the desired state. Multiple Reconcilers can watch the same resource kind, and when a change occurs, they will be called in the order they were added to the controller.
 
 A Watcher has three hooks for reacting to changes: `Add`, `Update`, and `Delete`. 
 When the relevant change occurs for the resource they watch, the appropriate hook is called. 
@@ -28,7 +28,7 @@ but there isn't a way to be sure (with a vanilla Watcher in a kubernetes-like en
 
 A Reconciler has its reconciling logic described under the `Reconcile` function.
 The `Reconcile` flow allows for explicit failure (returning an error), which uses the normal retry policy of the `operator.InformerController`, or supplying a `RetryAfter` time in response explicitly telling the `operator.InformerController` to try this exact same Reconcile action again after the request interval has passed.
-As for the watcher, the SDK also offers an _Opinionated_ reconciler, designed for kubernetes-like storage layers, called `operator.OpinionatedReconciler`, and adds some internal finalizer logic to make sure events cannot be missed during operator downtime.
+As for the reconciler, the SDK also offers an _Opinionated_ reconciler, designed for kubernetes-like storage layers, called `operator.OpinionatedReconciler`, and adds some internal finalizer logic to make sure events cannot be missed during operator downtime.
 
 Please note that it's enough to specify a Watcher or a Reconciler for a resource. The choice between the two depends on operator needs. 
 
@@ -109,4 +109,4 @@ func main() {
 ```
 
 For more details, see [Writing an App](writing-an-app.md), which goes into more details on writing an app, or [Writing a Reconciler](writing-a-reconciler.md) for details on how to write a reconciler. 
-There are also the [Operator Examples](../examples/operator), which contain two examples, a [reconciler-based operator](../examples/operator/reconciler) and a [watcher-based one](../examples/operator/watcher).
+There are also the [Operator Examples](../examples/operator), which contain two examples, a [reconciler-based operator](../examples/operator/simple/reconciler/) and a [watcher-based one](../examples/operator/simple/watcher/).

--- a/docs/tutorials/issue-tracker/01-project-init.md
+++ b/docs/tutorials/issue-tracker/01-project-init.md
@@ -17,7 +17,6 @@ Now, we could go about initializing a go module, and a cue module, and creating 
 go install github.com/grafana/grafana-app-sdk/cmd/grafana-app-sdk@latest
 ```
 If you're unfamiliar with `go install`, it's similar to `go get`, but will compile a binary for the `main` package in what it pulls, and put that in `$GOPATH/bin`. If you don't have `$GOPATH/bin` in your path, you will want to add it, otherwise the CLI commands won't work for you. You can check if the CLI was installed successfully with:
-You can then check if the install was successful by running.
 
 ```shell
 grafana-app-sdk --help

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -140,7 +140,8 @@ So, what are these new bits of code doing?
 
 ## Go Code from backend component
 
-**Important note**: the back-end part of the plugin is primarily used as a proxy to the app API server, in order to allow the user to use grafana auth to make the request to the grafana resource API, and let the plugin make the request to the API server using credentials for the API server. The final state of app platform will allow for grafana auth to be used with the API server, and direct access to the API server from outside of the back-end, so the eventual goal is to both allow and encourage the front-end to directly interact with the API server and kubernetes-style APIs.
+> [!IMPORTANT]  
+> The back-end part of the plugin is primarily used as a proxy to the app API server, in order to allow the user to use grafana auth to make the request to the grafana resource API, and let the plugin make the request to the API server using credentials for the API server. The final state of app platform will allow for grafana auth to be used with the API server, and direct access to the API server from outside of the back-end, so the eventual goal is to both allow and encourage the front-end to directly interact with the API server and kubernetes-style APIs.
 
 ### `pkg/plugin`
 
@@ -188,6 +189,8 @@ func New(namespace string, service Service) (*Plugin, error) {
 	}
 
 	p.router.Use(
+		router.NewTracingMiddleware(otel.GetTracerProvider().Tracer("tracing-middleware")),
+		router.NewLoggingMiddleware(logging.DefaultLogger),
 		kubeconfig.LoadingMiddleware(),
 		router.MiddlewareFunc(secure.Middleware))
 

--- a/docs/tutorials/issue-tracker/05-local-deployment.md
+++ b/docs/tutorials/issue-tracker/05-local-deployment.md
@@ -182,7 +182,7 @@ tilt enable grafana
 ```
 The script stops the Grafana deployment, copies the built plugin into `local/mounted-files`, and then restarts the deployment. We have to stop and restart because, if a plugin is already deployed and running, we can’t overwrite the binary while Grafana is using it. You can keep your local deployment running and iterate on your plugin by simply rebuilding and running `make local/deploy_plugin` again.
 
-TODO: should this be part of the `make local/up` command?
+<!-- TODO: should this be part of the `make local/up` command? -->
 
 OK, now grafana is all green on the dashboard, so let's take a look at the operator. 
 If we click on the `issue-tracker-project` tile to learn more about the error, it shows us the event:
@@ -332,7 +332,10 @@ with the option to extend them for custom metadata.
 
 We can also see that the operator is monitoring adds/updates/deletes to our issues if we take a look at its logs, either through the Tilt console, or via kubectl:
 ```
+$ kubectl logs -l name=issuetrackerproject-app-operator
+...
 {"time":"2024-12-04T23:44:22.388481222Z","level":"DEBUG","msg":"Added resource","name":"test-issue","traceID":"cfffb1cf88e0370ad48a185b3a321881"}
+...
 ```
 
 If we delete the issue, we'll also see that delete show up in our operator:

--- a/docs/tutorials/issue-tracker/frontend-files/main.tsx
+++ b/docs/tutorials/issue-tracker/frontend-files/main.tsx
@@ -1,11 +1,8 @@
-import React from 'react';
-import { css } from '@emotion/css';
+import React, { useState, useEffect }  from 'react';
 import { useForm } from 'react-hook-form';
-import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, Button, IconButton, Field, Input, Card, TagList } from '@grafana/ui';
+import {  Button, IconButton, Field, Input, Card, TagList } from '@grafana/ui';
 import { IssueClient } from '../api/issue_client';
 import { Issue } from '../generated/issue/v1/issue_object_gen';
-import { useState, useEffect } from 'react';
 import { PluginPage } from '@grafana/runtime';
 
 // This is used for the create new issue form
@@ -15,8 +12,6 @@ type ReactHookFormProps = {
 };
 
 function PageOne() {
-    const s = useStyles2(getStyles);
-
     let issues: Issue[] = [];
     const [issuesData, setIssuesData] = useState(issues);
     useEffect(() => {
@@ -139,9 +134,3 @@ function PageOne() {
 }
 
 export default PageOne;
-
-const getStyles = (theme: GrafanaTheme2) => ({
-    marginTop: css`
-    margin-top: ${theme.spacing(2)};
-  `,
-});


### PR DESCRIPTION
After running the tutorial found a couple of points to refresh the docs.

1. Updated the minio version to the latest, as the logs on the pod were stating:

```
You are running an older version of MinIO released 3 years ago. Update: Run `mc admin update`.
```

2. Minor typos in code examples in markdown files
3. Updated internal markdown links that were breaking
4. Changed the return of the example CRD conversion function, to follow the [K8s example](https://github.com/kubernetes/kubernetes/blob/v1.25.3/test/images/agnhost/crd-conversion-webhook/converter/example_converter.go#L36)
5. Remove Thema reference that was obsolete in the kubernetes.md