### PR TITLE
feat: add max selectableFields in cue

### DIFF
--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"struct"
 	"time"
+	"list"
 )
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.
@@ -165,7 +166,7 @@ Kind: S={
 			// seledtableFields is a list of additional fields which can be used in kubernetes field selectors for this version.
 			// Fields must be from the root of the schema, i.e. 'spec.foo', and have a string type.
 			// Fields cannot include custom metadata (TODO: check if we can use annotations for field selectors)
-			selectableFields: [...string]
+			selectableFields: [...string] & list.MaxItems(8)
 			validation: #AdmissionCapability | *S.validation
 			mutation:   #AdmissionCapability | *S.mutation
 			// additionalPrinterColumns is a list of additional columns to be printed in kubectl output


### PR DESCRIPTION
Currently if we try to include a lot of selectable fields, and found this by mistake while adding one more field [in this issue](https://github.com/grafana/grafana-app-sdk/issues/809) for testing, the CRD cannot be registered:

```
Build Failed: CustomResourceDefinition.apiextensions.k8s.io "foos.testapp2.ext.grafana.com" is invalid: spec.selectableFields: 
Too many: 10: must have at most 8 items
```

That's a fixed limit [defined here](https://github.com/kubernetes/apiextensions-apiserver/blob/b6ed36e4cacbad3bc2105c4a45c5ec68a8f0e74c/pkg/apis/apiextensions/validation/validation.go#L843).

Added a Cue list validation in the definition, and if somebody tries to generate code with >8 selectable fields it gives an error:
```
Error: manifest.kinds.0.versions.v1.selectableFields: invalid value ["spec.key" & string,"spec.value" & string,"spec.ownerRef.kind" & string,"spec.ownerRef.name" & string,"spec.ownerRef.apiVersion" & string,"spec.isCurrent" & string,"spec.isAlias" & string,"spec.isArchived" & string,"spec.testing" & string,"spec.deletable" & string] (does not satisfy list.MaxItems(8)): 
len(list) > MaxItems(8) (10 > 8)
```