### PR TITLE
[DynamicPatcher] Use the GroupVersion from the preferred list if the info is missing in the kind

### DIFF
--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -132,7 +132,17 @@ func (d *DynamicPatcher) updatePreferred() error {
 		return err
 	}
 	for _, pref := range preferred {
+		gv, err := schema.ParseGroupVersion(pref.GroupVersion)
+		if err != nil {
+			return err
+		}
 		for _, res := range pref.APIResources {
+			if res.Version == "" {
+				res.Version = gv.Version
+			}
+			if res.Group == "" {
+				res.Group = gv.Group
+			}
 			d.preferred[schema.GroupKind{
 				Group: res.Group,
 				Kind:  res.Kind,


### PR DESCRIPTION
k8s.DynamicPatcher: Use the GroupVersion from the preferred list if the info is missing in the kind.

Ported from drive-by fix in https://github.com/grafana/grafana-app-sdk/pull/852/files#diff-b2fd55bad7a34b5d1ca36c79aef8098f5073d79207dd32444057bd68d4bf0ab6