### PR TITLE
CopyObjectInto: Follow pointer values and copy them instead of copying address

### DIFF
--- a/resource/object.go
+++ b/resource/object.go
@@ -261,7 +261,9 @@ func copyReflectValueInto(dst reflect.Value, src reflect.Value) error {
 			}
 			return copyReflectValueInto(dst.Elem(), src.Elem())
 		default:
-			dst.Set(src)
+			ptrCopy := reflect.New(src.Type().Elem()) // new pointer of the same _value type_ as src
+			ptrCopy.Elem().Set(src.Elem())            // copy the value src is pointing to
+			dst.Set(ptrCopy)
 		}
 	case reflect.Struct:
 		// Special case for time.Time:


### PR DESCRIPTION
Added a test case to reproduce the issue. If you had a pointer, it would copy the address and not the value it was pointing to.

PS: we used https://github.com/mitchellh/copystructure to verify the correct behavior, that it should copy the actual values.