### PR TITLE
Add Custom Subresource Request Method to Clients

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -239,6 +239,16 @@ func (c *Client) Watch(ctx context.Context, namespace string, options resource.W
 	return c.client.watch(ctx, namespace, c.schema.Plural(), c.schema.ZeroValue(), options, c.codec)
 }
 
+// SubresourceRequest makes a request to an arbitrary subresource of the object identified by identifier.
+// Verb and Path should be included in the options.
+func (c *Client) SubresourceRequest(ctx context.Context, identifier resource.Identifier, opts resource.CustomRouteRequestOptions) ([]byte, error) {
+	if c.schema.Scope() == resource.ClusterScope && identifier.Namespace != resource.NamespaceAll {
+		return nil, fmt.Errorf("cannot watch resources with schema scope \"%s\" in namespace \"%s\", must be NamespaceAll (\"%s\")",
+			resource.ClusterScope, identifier.Namespace, resource.NamespaceAll)
+	}
+	return c.client.customRouteRequest(ctx, identifier.Namespace, c.schema.Plural(), identifier.Name, opts)
+}
+
 // Metrics returns the prometheus collectors used by this Client for registration with a prometheus exporter
 func (c *Client) PrometheusCollectors() []prometheus.Collector {
 	return c.client.metrics()

--- a/k8s/gvclient.go
+++ b/k8s/gvclient.go
@@ -440,6 +440,46 @@ func (g *groupVersionClient) list(ctx context.Context, namespace, plural string,
 	return rawToListWithParser(raw, into, itemParser)
 }
 
+func (g *groupVersionClient) customRouteRequest(ctx context.Context, namespace, plural, name string, request resource.CustomRouteRequestOptions) ([]byte, error) {
+	ctx, span := GetTracer().Start(ctx, "kubernetes-custom-route")
+	defer span.End()
+	req := g.client.Verb(request.Verb)
+	if plural != "" {
+		req = req.Resource(plural).Name(name).SubResource(request.Path)
+	} else {
+		req = req.Resource(request.Path)
+	}
+	if namespace != "" {
+		req = req.Namespace(namespace)
+	}
+	if request.Body != nil {
+		req.Body(request.Body)
+	}
+	for k, v := range request.Query {
+		for _, vv := range v {
+			req = req.Param(k, vv)
+		}
+	}
+	sc := 0
+	start := time.Now()
+	raw, err := req.Do(ctx).StatusCode(&sc).Raw()
+	g.logRequestDuration(time.Since(start), sc, request.Verb, plural, request.Path)
+	span.SetAttributes(
+		attribute.Int("http.response.status_code", sc),
+		attribute.String("http.request.method", http.MethodGet),
+		attribute.String("server.address", req.URL().Hostname()),
+		attribute.String("server.port", req.URL().Port()),
+		attribute.String("url.full", req.URL().String()),
+	)
+	g.incRequestCounter(sc, request.Verb, plural, request.Path)
+	if err != nil {
+		err = ParseKubernetesError(raw, sc, err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	return raw, nil
+}
+
 //nolint:revive
 func (g *groupVersionClient) watch(ctx context.Context, namespace, plural string,
 	exampleObject resource.Object, options resource.WatchOptions, codec resource.Codec) (*WatchResponse, error) {

--- a/resource/client.go
+++ b/resource/client.go
@@ -2,6 +2,8 @@ package resource
 
 import (
 	"context"
+	"io"
+	"net/url"
 )
 
 const NamespaceAll = ""
@@ -158,6 +160,13 @@ type WatchEvent struct {
 	Object Object
 }
 
+type CustomRouteRequestOptions struct {
+	Path  string
+	Verb  string
+	Body  io.ReadCloser
+	Query url.Values
+}
+
 // Client is any object which interfaces with schema Objects.
 // A single client should work on a per-Schema basis,
 // where each instance of a client operates on a specific (group, version, kind).
@@ -202,6 +211,10 @@ type Client interface {
 
 	// Watch makes a watch request to the provided namespace, and returns an object which implements WatchResponse
 	Watch(ctx context.Context, namespace string, options WatchOptions) (WatchResponse, error)
+
+	// SubresourceRequest makes a request to a resource's subresource path using the provided verb.
+	// It returns the raw bytes of the response, or an error if the request returns an error.
+	SubresourceRequest(ctx context.Context, identifier Identifier, req CustomRouteRequestOptions) ([]byte, error)
 }
 
 // SchemalessClient is a Schema-agnostic version of the Client interface.

--- a/resource/namespaced_client.go
+++ b/resource/namespaced_client.go
@@ -66,3 +66,12 @@ func (c *NamespacedClient[T, L]) Delete(ctx context.Context, uid string, opts De
 		Name:      uid,
 	}, opts)
 }
+
+// SubresourceRequest makes a request to a resource's subresource path using the provided verb.
+// It returns the raw bytes of the response, or an error if the request returns an error.
+func (c *NamespacedClient[T, L]) SubresourceRequest(ctx context.Context, uid string, opts CustomRouteRequestOptions) ([]byte, error) {
+	return c.cli.SubresourceRequest(ctx, Identifier{
+		Namespace: c.namespace,
+		Name:      uid,
+	}, opts)
+}

--- a/resource/store_test.go
+++ b/resource/store_test.go
@@ -944,18 +944,19 @@ func (g *mockClientGenerator) ClientFor(s Kind) (Client, error) {
 }
 
 type mockClient struct {
-	GetFunc        func(ctx context.Context, identifier Identifier) (Object, error)
-	GetIntoFunc    func(ctx context.Context, identifier Identifier, into Object) error
-	CreateFunc     func(ctx context.Context, identifier Identifier, obj Object, options CreateOptions) (Object, error)
-	CreateIntoFunc func(ctx context.Context, identifier Identifier, obj Object, options CreateOptions, into Object) error
-	UpdateFunc     func(ctx context.Context, identifier Identifier, obj Object, options UpdateOptions) (Object, error)
-	UpdateIntoFunc func(ctx context.Context, identifier Identifier, obj Object, options UpdateOptions, into Object) error
-	PatchFunc      func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions) (Object, error)
-	PatchIntoFunc  func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions, into Object) error
-	DeleteFunc     func(ctx context.Context, identifier Identifier, options DeleteOptions) error
-	ListFunc       func(ctx context.Context, namespace string, options ListOptions) (ListObject, error)
-	ListIntoFunc   func(ctx context.Context, namespace string, options ListOptions, into ListObject) error
-	WatchFunc      func(ctx context.Context, namespace string, options WatchOptions) (WatchResponse, error)
+	GetFunc                func(ctx context.Context, identifier Identifier) (Object, error)
+	GetIntoFunc            func(ctx context.Context, identifier Identifier, into Object) error
+	CreateFunc             func(ctx context.Context, identifier Identifier, obj Object, options CreateOptions) (Object, error)
+	CreateIntoFunc         func(ctx context.Context, identifier Identifier, obj Object, options CreateOptions, into Object) error
+	UpdateFunc             func(ctx context.Context, identifier Identifier, obj Object, options UpdateOptions) (Object, error)
+	UpdateIntoFunc         func(ctx context.Context, identifier Identifier, obj Object, options UpdateOptions, into Object) error
+	PatchFunc              func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions) (Object, error)
+	PatchIntoFunc          func(ctx context.Context, identifier Identifier, patch PatchRequest, options PatchOptions, into Object) error
+	DeleteFunc             func(ctx context.Context, identifier Identifier, options DeleteOptions) error
+	ListFunc               func(ctx context.Context, namespace string, options ListOptions) (ListObject, error)
+	ListIntoFunc           func(ctx context.Context, namespace string, options ListOptions, into ListObject) error
+	WatchFunc              func(ctx context.Context, namespace string, options WatchOptions) (WatchResponse, error)
+	SubresourceRequestFunc func(ctx context.Context, identifier Identifier, options CustomRouteRequestOptions) ([]byte, error)
 }
 
 func (c *mockClient) Get(ctx context.Context, identifier Identifier) (Object, error) {
@@ -1027,6 +1028,12 @@ func (c *mockClient) ListInto(ctx context.Context, namespace string, options Lis
 func (c *mockClient) Watch(ctx context.Context, namespace string, options WatchOptions) (WatchResponse, error) {
 	if c.WatchFunc != nil {
 		return c.WatchFunc(ctx, namespace, options)
+	}
+	return nil, nil
+}
+func (c *mockClient) SubresourceRequest(ctx context.Context, identifier Identifier, options CustomRouteRequestOptions) ([]byte, error) {
+	if c.SubresourceRequestFunc != nil {
+		return c.SubresourceRequestFunc(ctx, identifier, options)
 	}
 	return nil, nil
 }

--- a/resource/typedclient.go
+++ b/resource/typedclient.go
@@ -127,3 +127,9 @@ func (c *TypedClient[T, L]) Patch(ctx context.Context, id Identifier, req PatchR
 func (c *TypedClient[T, L]) Delete(ctx context.Context, id Identifier, opts DeleteOptions) error {
 	return c.cli.Delete(ctx, id, opts)
 }
+
+// SubresourceRequest makes a request to a resource's subresource path using the provided verb.
+// It returns the raw bytes of the response, or an error if the request returns an error.
+func (c *TypedClient[T, L]) SubresourceRequest(ctx context.Context, id Identifier, opts CustomRouteRequestOptions) ([]byte, error) {
+	return c.cli.SubresourceRequest(ctx, id, opts)
+}


### PR DESCRIPTION
Now that arbitrary custom subresources are supported for API server apps, we need to update the `resource.Client` (and other clients built on top of it) to allow for making arbitrary subresource requests. This PR introduces a new method:
```go
SubresourceRequest(context.Context, resource.Identifier, resource.CustomRouteRequestOptions) ([]byte, error)
```
to `resource.Client` (and similar methods to `resource.TypedClient` and `resource.NamespacedClient`), and implements it in `k8s.Client`. The underlying implementation in `k8s.gvclient` can also be used for custom resource routes once implemented.

Another improvement to be made in a subsequent PR will be to generate go clients for each kind that include dedicated, strongly-typed methods for handling each custom subresource.