### PR TITLE
[Local Env] Allow specifying additional volume locations in `./local/config.yaml`

### DIFF
--- a/cmd/grafana-app-sdk/templates/local/config.yaml
+++ b/cmd/grafana-app-sdk/templates/local/config.yaml
@@ -40,3 +40,8 @@ grafanaImage: grafana/grafana-enterprise:main
 
 # Install plugins from other sources (URLS). See https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-from-other-sources
 grafanaInstallPlugins: ""
+
+# You can mount additional volumes from the local disk (aside from the already-mounted ./local/mounted-files) by specifying them here
+additionalVolumeMounts:
+#  - sourcePath: "./local/other" # Paths starting with a ./ or no leading slash are relative to the project root. Start with / for an absolute path
+#    mountPath: "/tmp/k3d/other" # The destination volume path. Best practice is to use /tmp/k3d as the starting point. The default volume mount for ./local/mounted-files is /tmp/k3d/mounted-files

--- a/cmd/grafana-app-sdk/templates/local/generated/k3d-config.json
+++ b/cmd/grafana-app-sdk/templates/local/generated/k3d-config.json
@@ -30,6 +30,11 @@
         "server:*"
       ],
       "volume": "{{.ProjectRoot}}/local/mounted-files:/tmp/k3d/mounted-files"
-    }
+    }{{ range .AdditionalVolumes }},{
+      "nodeFilters": [
+        "server:*"
+      ],
+      "volume": "{{.SourcePath}}:{{.MountPath}}"
+    }{{ end }}
   ]
 }


### PR DESCRIPTION
Allow specifying additional volume locations to mount in the k3d deployment in `./local/config.yaml`, which get turned into 'volumes' entries in the generated `./local/generated/k3d-config.json`. Allows resolving of local paths into absolute ones (as absolute paths are required by k3d).