### PR TITLE
fix(k8s): ensure the installer handles multiple kinds in the same gv

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -250,8 +250,8 @@ func (r *defaultInstaller) InstallAPIs(server GenericAPIServer, optsGetter gener
 	}
 
 	for gv, kinds := range kindsByGV {
+		storage := map[string]rest.Storage{}
 		for _, kind := range kinds {
-			storage := map[string]rest.Storage{}
 			s, err := newGenericStoreForKind(r.scheme, kind.Kind, optsGetter)
 			if err != nil {
 				return fmt.Errorf("failed to create store for kind %s: %w", kind.Kind.Kind(), err)


### PR DESCRIPTION
When installing an app responsible for multiple kinds in the same group version,
the installer only created a store for the last kind it encountered.
