### PR TITLE
[k8s.apiserver] Fix the ParameterCodec used by InstallAPIs 

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -242,7 +242,7 @@ func (r *defaultInstaller) InstallAPIs(server GenericAPIServer, optsGetter gener
 			return fmt.Errorf("failed to add to scheme: %w", err)
 		}
 	}
-	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(group, r.scheme, metav1.ParameterCodec, r.codecs)
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(group, r.scheme, runtime.NewParameterCodec(r.scheme), r.codecs)
 
 	kindsByGV, err := r.getKindsByGroupVersion()
 	if err != nil {


### PR DESCRIPTION
Fix the ParameterCodec used by InstallAPIs to use the installer scheme rather than the metav1 scheme's ParameterCodec.

This was resulting in a bug in certain situations with `CallResource` where an error would be returned that the kind couldn't be found in the scheme, this was due to the decoding using the ParameterCodec from the `metav1` package, which is based on the unexported metav1 scheme.