### PR TITLE
[codegen] Include ExtraPermissions in generated go ManifestData

### DIFF
--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -178,7 +178,18 @@ var appManifestData = app.ManifestData{
             },
             {{ end }} },
         },
-        {{ end }} },{{ if .ManifestData.Operator }}
+        {{ end }} },{{ if .ManifestData.ExtraPermissions }}
+        ExtraPermissions: &app.Permissions{
+            AccessKinds: []app.KindPermission{ {{ range .ManifestData.ExtraPermissions.AccessKinds }} 
+                {
+                    Group: "{{ .Group }}",
+                    Resource: "{{ .Resource }}",
+                    Actions: []app.KindPermissionAction{ {{ range .Actions }} 
+                        "{{ . }}",{{ end }}
+                    },
+                },{{ end }} 
+            },
+        },{{ end }}{{ if .ManifestData.Operator }}
     Operator: &app.ManifestOperatorInfo{
         URL: "{{.ManifestData.Operator.URL}}", {{ if .ManifestData.Operator.Webhooks }}
         Webhooks: &app.ManifestOperatorWebhookProperties{

--- a/codegen/testing/golden_generated/manifest/go/groupbygroup/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/manifest/go/groupbygroup/testapp_manifest.go.txt
@@ -278,6 +278,19 @@ var appManifestData = app.ManifestData{
 			},
 		},
 	},
+	ExtraPermissions: &app.Permissions{
+		AccessKinds: []app.KindPermission{
+			{
+				Group:    "foo.bar",
+				Resource: "foos",
+				Actions: []app.KindPermissionAction{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+		},
+	},
 	Operator: &app.ManifestOperatorInfo{
 		URL: "https://foo.bar:8443",
 		Webhooks: &app.ManifestOperatorWebhookProperties{


### PR DESCRIPTION
Generated go ManifestData does not currently include the ExtraPermissions section, this adds it to the generated file.