### PR TITLE
Add EventTimeout option and use contextual `cache.ListWatch` methods

### DIFF
--- a/codegen/templates/app/app.tmpl
+++ b/codegen/templates/app/app.tmpl
@@ -1,11 +1,9 @@
 package {{.PackageName}}
 
 import (
-    "context"
     "fmt"
 
 	"github.com/grafana/grafana-app-sdk/app"
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana-app-sdk/simple"
 
 	generated "{{.Repo}}/{{.CodegenPath}}"
@@ -28,12 +26,6 @@ func New(cfg app.Config) (app.App, error) {
 	config := simple.AppConfig{
 		Name:           "{{.ProjectName}}",
 		KubeConfig:     cfg.KubeConfig,
-		InformerConfig: simple.AppInformerConfig{
-		    ErrorHandler: func(ctx context.Context, err error) {
-                // FIXME: add your own error handling here
-                logging.FromContext(ctx).With("error",err).Error("Informer processing error")
-            },
-		},
 		ManagedKinds: []simple.AppManagedKind{ {{ range $key, $val := .GVToKindAll }}{{ range $val }}
 		    {
 		        Kind: {{if $.KindsAreGrouped }}{{$.ToPackageNameVariable ($key.String)}}.{{.Kind}}Kind(){{else}}{{ $.ToPackageName .MachineName }}{{ $.ToPackageName $key.Version}}.Kind(){{end}}, {{ if eq $key.Version .Current }}

--- a/operator/informer_concurrent.go
+++ b/operator/informer_concurrent.go
@@ -27,6 +27,7 @@ type ConcurrentInformer struct {
 	mtx sync.RWMutex
 }
 
+// ConcurrentInformerOptions are options for the ConcurrentInformer.
 type ConcurrentInformerOptions struct {
 	// ErrorHandler is a user-specified error handling function. If left nil, DefaultErrorHandler will be used.
 	ErrorHandler func(context.Context, error)
@@ -44,12 +45,12 @@ func NewConcurrentInformer(inf Informer, opts ConcurrentInformerOptions) (
 		errorHandler:         DefaultErrorHandler,
 		informer:             inf,
 		watchers:             make([]*concurrentWatcher, 0),
-		maxConcurrentWorkers: 1,
+		maxConcurrentWorkers: 10,
 	}
 	if opts.ErrorHandler != nil {
 		ci.errorHandler = opts.ErrorHandler
 	}
-	if opts.MaxConcurrentWorkers > 1 {
+	if opts.MaxConcurrentWorkers > 0 {
 		ci.maxConcurrentWorkers = opts.MaxConcurrentWorkers
 	}
 

--- a/operator/informer_customcache.go
+++ b/operator/informer_customcache.go
@@ -24,53 +24,83 @@ import (
 
 var _ Informer = &CustomCacheInformer{}
 
-const processorBufferSize = 1024
+// MemcachedInformerOptions are the options for the MemcachedInformer.
+type MemcachedInformerOptions struct {
+	CustomCacheInformerOptions
+	// ServerAddrs is a list of addresses for the memcached servers.
+	ServerAddrs []string
+	// ServerSelector is a server selector for the memcached client.
+	// If present, it overrides Addrs and is used to determine the memcached servers to connect to.
+	ServerSelector MemcachedServerSelector
+}
 
+// NewMemcachedInformer creates a new CustomCacheInformer which uses memcached as its custom cache.
+// This is analogous to calling NewCustomCacheInformer with a MemcachedStore as the store, using the default memcached options.
+// To set additional memcached options, use NewCustomCacheInformer and NewMemcachedStore.
+func NewMemcachedInformer(
+	kind resource.Kind, client ListWatchClient, opts MemcachedInformerOptions,
+) (*CustomCacheInformer, error) {
+	c, err := NewMemcachedStore(kind, MemcachedStoreConfig{
+		Addrs:          opts.ServerAddrs,
+		ServerSelector: opts.ServerSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCustomCacheInformer(
+		c, NewListerWatcher(client, kind, opts.ListWatchOptions), kind, opts.CustomCacheInformerOptions,
+	), nil
+}
+
+// CustomCacheInformer is an informer that uses a custom cache.Store to store the state of the resources.
 type CustomCacheInformer struct {
-	// CacheResyncInterval is the interval at which the informer will emit CacheResync events for all resources in the cache.
-	// This is distinct from a full resync, as no information is fetched from the API server.
-	// Changes to this value after run() is called will not take effect.
-	CacheResyncInterval time.Duration
-	// ErrorHandler is called if the informer encounters an error which does not stop the informer from running,
-	// but may stop it from processing a given event.
-	ErrorHandler func(context.Context, error)
-
 	started       bool
 	startedLock   sync.Mutex
 	store         cache.Store
 	controller    cache.Controller
 	listerWatcher cache.ListerWatcher
+	opts          CustomCacheInformerOptions
 	objectType    resource.Object
 	processor     *informerProcessor
 	schema        resource.Kind
 	runContext    context.Context
 }
 
-type MemcachedInformerOptions struct {
-	Addrs []string
-	// ServerSelector is a server selector for the memcached client.
-	// If present, it overrides Addrs and is used to determine the memcached servers to connect to.
-	ServerSelector   MemcachedServerSelector
-	ListWatchOptions ListWatchOptions
-}
+const processorBufferSize = 1024
 
-// NewMemcachedInformer creates a new CustomCacheInformer which uses memcached as its custom cache.
-// This is analogous to calling NewCustomCacheInformer with a MemcachedStore as the store, using the default memcached options.
-// To set additional memcached options, use NewCustomCacheInformer and NewMemcachedStore.
-func NewMemcachedInformer(kind resource.Kind, client ListWatchClient, opts MemcachedInformerOptions) (*CustomCacheInformer, error) {
-	c, err := NewMemcachedStore(kind, MemcachedStoreConfig{
-		Addrs:          opts.Addrs,
-		ServerSelector: opts.ServerSelector,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return NewCustomCacheInformer(c, NewListerWatcher(client, kind, opts.ListWatchOptions), kind), nil
+// CustomCacheInformerOptions are the options for the CustomCacheInformer.
+type CustomCacheInformerOptions struct {
+	InformerOptions
+	// ProcessorBufferSize is the size of the buffer for the informer processor.
+	// This is the number of events that can be buffered before the processor is blocked.
+	// An empty value will use the default of 1024.
+	ProcessorBufferSize int
 }
 
 // NewCustomCacheInformer returns a new CustomCacheInformer using the provided cache.Store and cache.ListerWatcher.
 // To use ListWatchOptions, use NewListerWatcher to get a cache.ListerWatcher.
-func NewCustomCacheInformer(store cache.Store, lw cache.ListerWatcher, kind resource.Kind) *CustomCacheInformer {
+func NewCustomCacheInformer(
+	store cache.Store, lw cache.ListerWatcher, kind resource.Kind, opts CustomCacheInformerOptions,
+) *CustomCacheInformer {
+	if opts.ProcessorBufferSize == 0 {
+		opts.ProcessorBufferSize = processorBufferSize
+	}
+
+	if opts.EventTimeout > 0 {
+		opts.EventTimeout = opts.CacheResyncInterval
+	}
+
+	if opts.CacheResyncInterval > 0 && opts.EventTimeout > opts.CacheResyncInterval {
+		opts.EventTimeout = opts.CacheResyncInterval
+	}
+
+	if opts.ErrorHandler == nil {
+		opts.ErrorHandler = func(ctx context.Context, err error) {
+			logging.FromContext(ctx).Error("error processing informer event", "component", "CustomCacheInformer", "error", err)
+		}
+	}
+
 	return &CustomCacheInformer{
 		store:         store,
 		listerWatcher: lw,
@@ -79,9 +109,7 @@ func NewCustomCacheInformer(store cache.Store, lw cache.ListerWatcher, kind reso
 		// objectType:    kind.ZeroValue(),
 		processor: newInformerProcessor(),
 		schema:    kind,
-		ErrorHandler: func(ctx context.Context, err error) {
-			logging.FromContext(ctx).Error("error processing informer event", "component", "CustomCacheInformer", "error", err)
-		},
+		opts:      opts,
 	}
 }
 
@@ -95,12 +123,24 @@ func (c *CustomCacheInformer) PrometheusCollectors() []prometheus.Collector {
 
 // AddEventHandler adds the provided ResourceWatcher to the list of handlers to have events reported to.
 func (c *CustomCacheInformer) AddEventHandler(handler ResourceWatcher) error {
-	c.processor.addListener(newInformerProcessorListener(toResourceEventHandlerFuncs(handler, c.toResourceObject, c.errorHandler, func() context.Context {
-		if c.runContext != nil {
-			return c.runContext
-		}
-		return context.Background()
-	}), processorBufferSize))
+	c.processor.addListener(
+		newInformerProcessorListener(
+			toResourceEventHandlerFuncs(
+				handler, c.toResourceObject, c.errorHandler, func() (context.Context, context.CancelFunc) {
+					if c.runContext != nil {
+						return c.runContext, func() {}
+					}
+
+					if c.opts.EventTimeout > 0 {
+						return context.WithTimeout(context.Background(), c.opts.EventTimeout)
+					}
+
+					return context.WithCancel(context.Background())
+				},
+			),
+			processorBufferSize,
+		),
+	)
 	return nil
 }
 
@@ -122,7 +162,7 @@ func (c *CustomCacheInformer) Run(ctx context.Context) error {
 		c.startedLock.Lock()
 		defer c.startedLock.Unlock()
 
-		c.controller = newInformer(c.listerWatcher, c.objectType, c.CacheResyncInterval, c, c.store, nil)
+		c.controller = newInformer(c.listerWatcher, c.objectType, c.opts.CacheResyncInterval, c, c.store, nil)
 		c.started = true
 	}()
 
@@ -203,17 +243,19 @@ func (c *CustomCacheInformer) toResourceObject(obj any) (resource.Object, error)
 }
 
 func (c *CustomCacheInformer) errorHandler(ctx context.Context, err error) {
-	if c.ErrorHandler != nil {
-		c.ErrorHandler(ctx, err)
+	if c.opts.ErrorHandler == nil {
+		return
 	}
+
+	c.opts.ErrorHandler(ctx, err)
 }
 
 // NewListerWatcher returns a cache.ListerWatcher for the provided resource.Schema that uses the given ListWatchClient.
 // The List and Watch requests will always use the provided namespace and labelFilters.
 func NewListerWatcher(client ListWatchClient, sch resource.Schema, filterOptions ListWatchOptions) cache.ListerWatcher {
 	return &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			ctx, span := GetTracer().Start(context.Background(), "informer-list")
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			ctx, span := GetTracer().Start(ctx, "informer-list")
 			defer span.End()
 			span.SetAttributes(
 				attribute.String("kind.name", sch.Kind()),
@@ -234,8 +276,8 @@ func NewListerWatcher(client ListWatchClient, sch resource.Schema, filterOptions
 			}
 			return &resp, nil
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			ctx, span := GetTracer().Start(context.Background(), "informer-watch")
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			ctx, span := GetTracer().Start(ctx, "informer-watch")
 			defer span.End()
 			span.SetAttributes(
 				attribute.String("kind.name", sch.Kind()),
@@ -252,13 +294,6 @@ func NewListerWatcher(client ListWatchClient, sch resource.Schema, filterOptions
 				TimeoutSeconds:       options.TimeoutSeconds,
 				SendInitialEvents:    options.SendInitialEvents,
 			}
-			// TODO: can't defer the cancel call for the context, because it should only be canceled if the
-			// _caller_ of WatchFunc finishes with the WatchResponse before the timeout elapses...
-			// Seems to be a limitation of the kubernetes implementation here
-			/* if options.TimeoutSeconds != nil {
-				timeout := time.Duration(*options.TimeoutSeconds) * time.Second
-				ctx, cancel = context.WithTimeout(ctx, timeout)
-			}*/
 			watchResp, err := client.Watch(ctx, filterOptions.Namespace, opts)
 			if err != nil {
 				return nil, err
@@ -271,16 +306,24 @@ func NewListerWatcher(client ListWatchClient, sch resource.Schema, filterOptions
 				watch: watchResp,
 				ch:    make(chan watch.Event),
 			}
-			go w.start()
+			go w.run(ctx)
 			return w, nil
 		},
 	}
 }
 
-func toResourceEventHandlerFuncs(handler ResourceWatcher, transformer func(any) (resource.Object, error), errorHandler func(context.Context, error), contextProvider func() context.Context) *cache.ResourceEventHandlerFuncs {
+func toResourceEventHandlerFuncs(
+	handler ResourceWatcher,
+	transformer func(any) (resource.Object, error),
+	errorHandler func(context.Context, error),
+	ctxProvider func() (context.Context, context.CancelFunc),
+) *cache.ResourceEventHandlerFuncs {
 	return &cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			ctx, span := GetTracer().Start(contextProvider(), "informer-event-add")
+			ctx, cancel := ctxProvider()
+			defer cancel()
+
+			ctx, span := GetTracer().Start(ctx, "informer-event-add")
 			defer span.End()
 			cast, err := transformer(obj)
 			if err != nil {
@@ -303,7 +346,10 @@ func toResourceEventHandlerFuncs(handler ResourceWatcher, transformer func(any) 
 			}
 		},
 		UpdateFunc: func(oldObj, newObj any) {
-			ctx, span := GetTracer().Start(contextProvider(), "informer-event-update")
+			ctx, cancel := ctxProvider()
+			defer cancel()
+
+			ctx, span := GetTracer().Start(ctx, "informer-event-update")
 			defer span.End()
 			cOld, err := transformer(oldObj)
 			if err != nil {
@@ -333,7 +379,10 @@ func toResourceEventHandlerFuncs(handler ResourceWatcher, transformer func(any) 
 			}
 		},
 		DeleteFunc: func(obj any) {
-			ctx, span := GetTracer().Start(contextProvider(), "informer-event-delete")
+			ctx, cancel := ctxProvider()
+			defer cancel()
+
+			ctx, span := GetTracer().Start(ctx, "informer-event-delete")
 			defer span.End()
 			cast, err := transformer(obj)
 			if err != nil {

--- a/operator/informer_customcache_test.go
+++ b/operator/informer_customcache_test.go
@@ -29,7 +29,7 @@ func TestCustomCacheInformer_Run(t *testing.T) {
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				return nil, fmt.Errorf("I AM ERROR")
 			},
-		}, untypedKind)
+		}, untypedKind, CustomCacheInformerOptions{})
 		ctx, cancel := context.WithCancel(context.Background())
 		stopped := false
 		go func() {
@@ -54,7 +54,7 @@ func TestCustomCacheInformer_Run_DistributeEvents(t *testing.T) {
 				events: events,
 			}, nil
 		},
-	}, untypedKind)
+	}, untypedKind, CustomCacheInformerOptions{})
 	addObj := &resource.UntypedObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       "default",
@@ -134,7 +134,7 @@ func TestCustomCacheInformer_Run_ManyEvents(t *testing.T) {
 				events: events,
 			}, nil
 		},
-	}, untypedKind)
+	}, untypedKind, CustomCacheInformerOptions{})
 	numHandlers := 100
 	addWG := sync.WaitGroup{}
 	updateWG := sync.WaitGroup{}
@@ -199,7 +199,7 @@ func TestCustomCacheInformer_Run_CacheState(t *testing.T) {
 				events: events,
 			}, nil
 		},
-	}, untypedKind)
+	}, untypedKind, CustomCacheInformerOptions{})
 	wg := sync.WaitGroup{}
 	inf.AddEventHandler(&SimpleWatcher{
 		AddFunc: func(ctx context.Context, object resource.Object) error {

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -42,6 +42,9 @@ type InformerOptions struct {
 	// This is distinct from a full resync, as no information is fetched from the API server.
 	// Changes to this value after run() is called will not take effect.
 	CacheResyncInterval time.Duration
+	// MaxConcurrentWorkers is the maximum number of concurrent workers to run for the informer.
+	// This is only used by informers which support concurrent processing of events.
+	MaxConcurrentWorkers uint64
 	// EventTimeout is the timeout for an event to be processed.
 	// If an event is not processed within this timeout, it will be dropped.
 	// The timeout cannot be larger than the cache resync interval, if it is,

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -22,7 +22,6 @@ var (
 // KubernetesBasedInformer is a k8s apimachinery-based informer. It wraps a k8s cache.SharedIndexInformer,
 // and works most optimally with a client that has a Watch response that implements KubernetesCompatibleWatch.
 type KubernetesBasedInformer struct {
-	ErrorHandler        func(context.Context, error)
 	SharedIndexInformer cache.SharedIndexInformer
 	// HealthCheckIgnoreSync will set the KubernetesBasedInformer HealthCheck to return ok once the informer is started,
 	// rather than waiting for the informer to finish with its initial list sync.
@@ -30,16 +29,28 @@ type KubernetesBasedInformer struct {
 	HealthCheckIgnoreSync bool
 	schema                resource.Kind
 	runContext            context.Context
+	eventTimeout          time.Duration
+	errorHandlerFn        func(context.Context, error)
 	healthCheckName       string
 }
 
-type KubernetesBasedInformerOptions struct {
+// InformerOptions are generic options for all Informer implementations.
+type InformerOptions struct {
 	// ListWatchOptions are the options for filtering the watch based on namespace and other compatible filters.
 	ListWatchOptions ListWatchOptions
 	// CacheResyncInterval is the interval at which the informer will emit CacheResync events for all resources in the cache.
 	// This is distinct from a full resync, as no information is fetched from the API server.
-	// An empty value will disable cache resyncs.
+	// Changes to this value after run() is called will not take effect.
 	CacheResyncInterval time.Duration
+	// EventTimeout is the timeout for an event to be processed.
+	// If an event is not processed within this timeout, it will be dropped.
+	// The timeout cannot be larger than the cache resync interval, if it is,
+	// the cache resync interval will be used instead.
+	// An empty value will disable event timeouts.
+	EventTimeout time.Duration
+	// ErrorHandler is called if the informer encounters an error which does not stop the informer from running,
+	// but may stop it from processing a given event.
+	ErrorHandler func(context.Context, error)
 	// HealthCheckIgnoreSync will set the KubernetesBasedInformer HealthCheck to return ok once the informer is started,
 	// rather than waiting for the informer to finish with its initial list sync.
 	// You may want to set this to `true` if you have a particularly long initial sync period and don't want readiness checks failing.
@@ -48,10 +59,26 @@ type KubernetesBasedInformerOptions struct {
 
 // NewKubernetesBasedInformer creates a new KubernetesBasedInformer for the provided kind and options,
 // using the ListWatchClient provided to do its List and Watch requests applying provided labelFilters if it is not empty.
-func NewKubernetesBasedInformer(sch resource.Kind, client ListWatchClient, options KubernetesBasedInformerOptions) (
-	*KubernetesBasedInformer, error) {
+func NewKubernetesBasedInformer(
+	sch resource.Kind, client ListWatchClient, options InformerOptions,
+) (*KubernetesBasedInformer, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client cannot be nil")
+	}
+
+	var timeout time.Duration
+	if options.EventTimeout > 0 {
+		timeout = options.EventTimeout
+	}
+	if options.CacheResyncInterval > 0 && options.CacheResyncInterval < timeout {
+		timeout = options.CacheResyncInterval
+	}
+
+	var errorHandler func(context.Context, error)
+	if options.ErrorHandler != nil {
+		errorHandler = options.ErrorHandler
+	} else {
+		errorHandler = DefaultErrorHandler
 	}
 
 	// Compute a unique name for the health check based on what the informer is watching
@@ -71,8 +98,9 @@ func NewKubernetesBasedInformer(sch resource.Kind, client ListWatchClient, optio
 	}
 
 	return &KubernetesBasedInformer{
-		schema:       sch,
-		ErrorHandler: DefaultErrorHandler,
+		schema:         sch,
+		eventTimeout:   timeout,
+		errorHandlerFn: errorHandler,
 		SharedIndexInformer: cache.NewSharedIndexInformer(
 			NewListerWatcher(client, sch, options.ListWatchOptions),
 			nil,
@@ -93,12 +121,22 @@ func (k *KubernetesBasedInformer) AddEventHandler(handler ResourceWatcher) error
 	// TODO: AddEventHandler returns the registration handle which should be supplied to RemoveEventHandler
 	// but we don't currently call the latter. We should add RemoveEventHandler to the informer API
 	// and let controller call it when appropriate.
-	_, err := k.SharedIndexInformer.AddEventHandler(toResourceEventHandlerFuncs(handler, k.toResourceObject, k.errorHandler, func() context.Context {
-		if k.runContext != nil {
-			return k.runContext
-		}
-		return context.Background()
-	}))
+	_, err := k.SharedIndexInformer.AddEventHandler(
+		toResourceEventHandlerFuncs(
+			handler, k.toResourceObject, k.errorHandler,
+			func() (context.Context, context.CancelFunc) {
+				if k.runContext != nil {
+					return k.runContext, func() {}
+				}
+
+				if k.eventTimeout > 0 {
+					return context.WithTimeout(context.Background(), k.eventTimeout)
+				}
+
+				return context.WithCancel(context.Background())
+			},
+		),
+	)
 
 	return err
 }
@@ -139,8 +177,8 @@ func (k *KubernetesBasedInformer) toResourceObject(obj any) (resource.Object, er
 }
 
 func (k *KubernetesBasedInformer) errorHandler(ctx context.Context, err error) {
-	if k.ErrorHandler != nil {
-		k.ErrorHandler(ctx, err)
+	if k.errorHandlerFn != nil {
+		k.errorHandlerFn(ctx, err)
 	}
 }
 
@@ -201,18 +239,24 @@ type watchWrapper struct {
 	ch    chan watch.Event
 }
 
-func (w *watchWrapper) start() {
-	for e := range w.watch.WatchEvents() {
-		w.ch <- watch.Event{
-			Type:   watch.EventType(e.EventType),
-			Object: e.Object,
+func (w *watchWrapper) run(ctx context.Context) {
+	defer close(w.ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-w.watch.WatchEvents():
+			w.ch <- watch.Event{
+				Type:   watch.EventType(e.EventType),
+				Object: e.Object,
+			}
 		}
 	}
 }
 
 func (w *watchWrapper) Stop() {
 	w.watch.Stop()
-	close(w.ch)
 }
 
 func (w *watchWrapper) ResultChan() <-chan watch.Event {

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -40,7 +40,8 @@ type InformerOptions struct {
 	ListWatchOptions ListWatchOptions
 	// CacheResyncInterval is the interval at which the informer will emit CacheResync events for all resources in the cache.
 	// This is distinct from a full resync, as no information is fetched from the API server.
-	// Changes to this value after run() is called will not take effect.
+	// Changes to this value after Run() is called will not take effect.
+	// An empty value will disable cache resyncs.
 	CacheResyncInterval time.Duration
 	// MaxConcurrentWorkers is the maximum number of concurrent workers to run for the informer.
 	// This is only used by informers which support concurrent processing of events.

--- a/operator/informer_kubernetes_test.go
+++ b/operator/informer_kubernetes_test.go
@@ -14,7 +14,7 @@ func TestKubernetesBasedInformer_HealthCheckName(t *testing.T) {
 	tests := []struct {
 		name     string
 		kind     resource.Kind
-		opts     KubernetesBasedInformerOptions
+		opts     InformerOptions
 		expected string
 	}{{
 		name:     "simple",
@@ -23,7 +23,7 @@ func TestKubernetesBasedInformer_HealthCheckName(t *testing.T) {
 	}, {
 		name: "labels",
 		kind: untypedKind,
-		opts: KubernetesBasedInformerOptions{
+		opts: InformerOptions{
 			ListWatchOptions: ListWatchOptions{
 				LabelFilters: []string{"foz=baz", "a=b"},
 			},
@@ -32,7 +32,7 @@ func TestKubernetesBasedInformer_HealthCheckName(t *testing.T) {
 	}, {
 		name: "fieldSelectors",
 		kind: untypedKind,
-		opts: KubernetesBasedInformerOptions{
+		opts: InformerOptions{
 			ListWatchOptions: ListWatchOptions{
 				FieldSelectors: []string{"bar=foo", "b=a"},
 			},
@@ -41,7 +41,7 @@ func TestKubernetesBasedInformer_HealthCheckName(t *testing.T) {
 	}, {
 		name: "labels and fieldSelectors",
 		kind: untypedKind,
-		opts: KubernetesBasedInformerOptions{
+		opts: InformerOptions{
 			ListWatchOptions: ListWatchOptions{
 				LabelFilters:   []string{"foz=baz", "a=b"},
 				FieldSelectors: []string{"bar=foo", "b=a"},

--- a/simple/app_test.go
+++ b/simple/app_test.go
@@ -470,7 +470,7 @@ func TestApp_ManageKind(t *testing.T) {
 		expected := errors.New("I AM ERROR")
 		a, err := NewApp(AppConfig{
 			InformerConfig: AppInformerConfig{
-				InformerSupplier: func(kind resource.Kind, clients resource.ClientGenerator, options operator.ListWatchOptions) (operator.Informer, error) {
+				InformerSupplier: func(kind resource.Kind, clients resource.ClientGenerator, options operator.InformerOptions) (operator.Informer, error) {
 					return nil, expected
 				},
 			},
@@ -492,10 +492,10 @@ func TestApp_ManageKind(t *testing.T) {
 		}
 		createTestApp(t, AppConfig{
 			InformerConfig: AppInformerConfig{
-				InformerSupplier: func(k resource.Kind, clients resource.ClientGenerator, opts operator.ListWatchOptions) (operator.Informer, error) {
+				InformerSupplier: func(k resource.Kind, clients resource.ClientGenerator, opts operator.InformerOptions) (operator.Informer, error) {
 					supplierCalled = true
 					assert.Equal(t, kind, k)
-					assert.Equal(t, options, opts)
+					assert.Equal(t, options, opts.ListWatchOptions)
 					return &mockInformer{}, nil
 				},
 			},

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -234,14 +234,18 @@ func (o *Operator) WatchKind(kind resource.Kind, watcher SyncWatcher, options op
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{
-		ListWatchOptions:    operator.ListWatchOptions{Namespace: options.Namespace, LabelFilters: options.LabelFilters, FieldSelectors: options.FieldSelectors},
+	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.InformerOptions{
+		ListWatchOptions: operator.ListWatchOptions{
+			Namespace:      options.Namespace,
+			LabelFilters:   options.LabelFilters,
+			FieldSelectors: options.FieldSelectors,
+		},
 		CacheResyncInterval: o.cacheResyncInterval,
+		ErrorHandler:        o.ErrorHandler,
 	})
 	if err != nil {
 		return err
 	}
-	inf.ErrorHandler = o.ErrorHandler
 	kindStr := o.label(kind, options)
 	err = o.controller.AddInformer(inf, kindStr)
 	if err != nil {
@@ -279,14 +283,18 @@ func (o *Operator) ReconcileKind(kind resource.Kind, reconciler operator.Reconci
 	if err != nil {
 		return err
 	}
-	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.KubernetesBasedInformerOptions{
-		ListWatchOptions:    operator.ListWatchOptions{Namespace: options.Namespace, LabelFilters: options.LabelFilters, FieldSelectors: options.FieldSelectors},
+	inf, err := operator.NewKubernetesBasedInformer(kind, client, operator.InformerOptions{
+		ListWatchOptions: operator.ListWatchOptions{
+			Namespace:      options.Namespace,
+			LabelFilters:   options.LabelFilters,
+			FieldSelectors: options.FieldSelectors,
+		},
+		ErrorHandler:        o.ErrorHandler,
 		CacheResyncInterval: o.cacheResyncInterval,
 	})
 	if err != nil {
 		return err
 	}
-	inf.ErrorHandler = o.ErrorHandler
 	kindStr := o.label(kind, options)
 	err = o.controller.AddInformer(inf, kindStr)
 	if err != nil {


### PR DESCRIPTION
### What

- **Added `EventTimeout` option** to `CustomCacheInformerOptions` and `KubernetesBasedInformerOptions`
- **Updated `ListerWatcher`** to use contextual `ListWithContextFunc` and `WatchFuncWithContext`
- **Modified `NewCustomCacheInformer` signature** to pass options via `CustomCacheInformerOptions` struct

### Why

- **EventTimeout prevents resource leaks** by dropping events that take too long to process
- **Contextual ListerWatcher improves cancellation handling** and resource cleanup during watch operations
- **Configurable options provide better control** over informer behavior without breaking existing functionality

### API Changes

⚠️ **Breaking Change**: `NewCustomCacheInformer` now requires a `CustomCacheInformerOptions` parameter:

```golang
// Before
inf := NewCustomCacheInformer(store, lw, kind)

// After  
inf := NewCustomCacheInformer(store, lw, kind, CustomCacheInformerOptions{})
```
