### PR TITLE
[OpinionatedWatcher/OpinionatedReconciler] Fix overwriting of finalizers with concurrent apps watching the same kinds

### DIFF
--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/resource"
 )
 
 func TestNewOpinionatedReconciler(t *testing.T) {
@@ -34,7 +35,9 @@ func TestNewOpinionatedReconciler(t *testing.T) {
 		op, err := NewOpinionatedReconciler(client, finalizer)
 		assert.Nil(t, err)
 		assert.Equal(t, finalizer, op.finalizer)
-		assert.Equal(t, client, op.client)
+		cast, ok := op.finalizerUpdater.(*finalizerUpdater)
+		require.True(t, ok)
+		assert.Equal(t, client, cast.client)
 	})
 
 	t.Run("finzlizer too long", func(t *testing.T) {
@@ -66,6 +69,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers",
 						Operation: resource.PatchOpAdd,
 						Value:     []string{finalizer},
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				patchCalled = true
@@ -143,6 +150,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers",
 						Operation: resource.PatchOpAdd,
 						Value:     []string{finalizer},
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				patchCalled = true
@@ -188,6 +199,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers",
 						Operation: resource.PatchOpAdd,
 						Value:     []string{finalizer},
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				patchCalled = true
@@ -299,6 +314,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers",
 						Operation: resource.PatchOpAdd,
 						Value:     []string{finalizer},
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				patchCalled = true
@@ -342,6 +361,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers/0",
 						Operation: resource.PatchOpRemove,
 						Value:     nil,
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				patchCalled = true
@@ -427,6 +450,10 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 						Path:      "/metadata/finalizers/0",
 						Operation: resource.PatchOpRemove,
 						Value:     nil,
+					}, {
+						Path:      "/metadata/resourceVersion",
+						Operation: resource.PatchOpReplace,
+						Value:     object.GetResourceVersion(),
 					}},
 				}, request)
 				return patchErr

--- a/simple/app.go
+++ b/simple/app.go
@@ -599,3 +599,12 @@ func (w *watchPatcher) PatchInto(ctx context.Context, identifier resource.Identi
 	into.SetCommonMetadata(obj.GetCommonMetadata())
 	return nil
 }
+
+func (w *watchPatcher) GetInto(ctx context.Context, identifier resource.Identifier, into resource.Object) error {
+	obj, err := w.patcher.Get(ctx, identifier)
+	if err != nil {
+		return err
+	}
+	into.SetCommonMetadata(obj.GetCommonMetadata())
+	return nil
+}


### PR DESCRIPTION
The patch operation being done currently by the `operator.OpinionatedWatcher` and `operator.OpinionatedReconciler` overwrites the finalizers in the list on Add, rather than appending if there are existing finalizers. As the logic to correctly patch the finalizers, especially with multiple operators watching the same kinds, is a little more complex than a single patch request, this PR introduces the `FinalizerUpdater` interface and an unexported implementation that is used by both `operator.OpinionatedWatcher` and `operator.OpinionatedReconciler`. 

The `FinalizerUpdater` implementation now handles using resourceVersion to avoid out-of-date RV issues, and will append to or create the finalizer list as appropriate on `AddFinalizer`. It also handles a few retries with a simple backoff and jitter in case multiple operators are all reacting to the same event simultaneously.

To support the ResourceVersion mismatch get-and-repatch behavior, a `Get` method had to be added to `k8s.DynamicPatcher`, and `GetInto` to the `operator.PatchClient` interface. The `GetInto` matches the signature for the same-name method in `resource.Client`, so this should avoid being a breaking change for anyone using `NewOpinionatedWatcher`/`NewOpinionatedReconciler` directly, instead of through the `simple.App`, provided they are supplying a `resource.Client`.

This behavior was tested locally on k3d with a binary that had two operator runners in it each with their own finalizer and WIP finalizer, watching the same kind.