### PR TITLE
Fix dependabot workflow user check

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   update:
     runs-on: "ubuntu-latest"
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     continue-on-error: true
     steps:
     - name: Retrieve GitHub App secrets


### PR DESCRIPTION
Fix dependabot workflow user check to comply with new zizmor guidance.

Used `zizmor --fix .` to generate the new check. 