### PR TITLE
[local dev] Properly handle multiple CRDs with aggregation

### DIFF
--- a/cmd/grafana-app-sdk/templates/local/generated/aggregator-access.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/aggregator-access.yaml
@@ -2,13 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: aggregator-access
-rules:{{ range $.CRDs }}
-  - apiGroups: ["{{.Group}}"]
+rules:{{ range $group, $versions := $.APIGroups }}
+  - apiGroups: ["{{$group}}"]
     resources: ["*"]
     verbs: ["*"]{{ end }}
   - nonResourceURLs:
-      - "/openapi/*"{{ range $.CRDs}}
-      - "/apis/{{.Group}}/*"{{ end }}
+      - "/openapi/*"{{ range $group, $versions := $.APIGroups}}
+      - "/apis/{{$group}}/*"{{ end }}
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
+++ b/cmd/grafana-app-sdk/templates/local/generated/grafana.yaml
@@ -49,7 +49,7 @@ metadata:
     name: grafana
 data:
   apiservices.yaml: |
-    {{ range $.CRDs }}{{$crd := .}}{{range .Versions}}- group: {{$crd.Group}}
+    {{ range $group, $versions := $.APIGroups }}{{range $versions}}- group: {{$group}}
       version: {{.}}
       host: kubernetes.default.svc
       port: 443


### PR DESCRIPTION
Currently, when a project has multiple CRDs, the aggregation template(s) for local dev loop through the CRDs instead of API groups, and improperly add the same API group multiple times. This PR has those templates instead loop over API groups to avoid this duplication (which can cause errors).