### PR TITLE
[k8s] Allow partial discovery failure for the dynamic patcher

### DIFF
--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -2,11 +2,13 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -129,7 +131,25 @@ func (d *DynamicPatcher) updatePreferred() error {
 	defer d.mux.Unlock()
 	preferred, err := d.discovery.ServerPreferredResources()
 	if err != nil {
-		return err
+		// There are errors that are "partial" errors and still return results.
+		// In those cases, we should check into the error further rather than just returning.
+		// If there are no results, return the error we got
+		if len(preferred) == 0 {
+			var statusErr *apierrors.StatusError
+			if errors.As(err, &statusErr) {
+				return statusErr
+			}
+			return fmt.Errorf("error getting preferred resources from discovery client: %w", err)
+		}
+		if cast, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
+			// Failed discovery for a number of groups. Log the failed groups
+			for group, gerr := range cast.Groups {
+				logging.DefaultLogger.Warn(fmt.Sprintf("discovery failed for GroupVersion %s", group.String()), "groupversion", group, "error", gerr)
+			}
+		} else {
+			// just log the error
+			logging.DefaultLogger.Warn("error getting preferred resources, returned partial results", "error", err)
+		}
 	}
 	for _, pref := range preferred {
 		for _, res := range pref.APIResources {


### PR DESCRIPTION
This PR is a backport of https://github.com/grafana/grafana-app-sdk/pull/900 onto `lts/v0.24`.

## Copied from [the PR to main]()

The kubernetes `dynamic.DynamicClient`'s `ServerPreferredResources` method [can return an error alongside results](https://github.com/kubernetes/client-go/blob/master/discovery/discovery_client.go#L493) to indicate that some apigroup discoveries failed, but others succeeded. To handle this, if we have any results, just log the error to the default logger, and still process the results. If there are no results, return the error.