### PR TITLE
Update go.mod go version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-app-sdk
 
-go 1.24.0
+go 1.24.6
 
 retract (
 	v0.20.0 // Errors in release pipeline didn't allow the binaries to be built for this release, which can break automated workflows that depend on them

--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.24.1
-
-toolchain go1.24.2
+go 1.24.6
 
 use (
 	.

--- a/plugin/go.mod
+++ b/plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-app-sdk/plugin
 
-go 1.24.1
+go 1.24.6
 
 retract (
 	v0.18.4 // Errors in release pipeline didn't allow the binaries to be built for this release, which can break automated workflows that depend on them


### PR DESCRIPTION
Required for dependabot updates ([example PR](https://github.com/grafana/grafana-app-sdk/pull/963)).