### PR TITLE
[operator] Improve Finalizer Errors

### DIFF
--- a/app/appmanifest/v1alpha1/conversion.go
+++ b/app/appmanifest/v1alpha1/conversion.go
@@ -199,11 +199,13 @@ func SpecFromManifestData(data app.ManifestData) (*AppManifestSpec, error) {
 				Conversion:       &kind.Conversion,
 			}
 			// Convert the ManifestData's Schema into CRD Schema for v1alpha1
-			sch, err := kind.Schema.AsCRDMap(k.Kind)
-			if err != nil {
-				return nil, fmt.Errorf("unable to convert %s/%s schema: %w", k.Kind, ver.Name, err)
+			if kind.Schema != nil {
+				sch, err := kind.Schema.AsCRDMap(k.Kind)
+				if err != nil {
+					return nil, fmt.Errorf("unable to convert %s/%s schema: %w", k.Kind, ver.Name, err)
+				}
+				k.Schema = sch
 			}
-			k.Schema = sch
 			if kind.Plural != "" {
 				k.Plural = &kind.Plural
 			}

--- a/app/appmanifest/v1alpha2/conversion.go
+++ b/app/appmanifest/v1alpha2/conversion.go
@@ -186,9 +186,11 @@ func SpecFromManifestData(data app.ManifestData) (*AppManifestSpec, error) {
 			k := AppManifestManifestVersionKind{
 				Kind:             kind.Kind,
 				Scope:            AppManifestManifestVersionKindScope(kind.Scope),
-				Schemas:          kind.Schema.AsOpenAPI3SchemasMap(),
 				SelectableFields: kind.SelectableFields,
 				Conversion:       &kind.Conversion,
+			}
+			if kind.Schema != nil {
+				k.Schemas = kind.Schema.AsOpenAPI3SchemasMap()
 			}
 			if kind.Plural != "" {
 				k.Plural = &kind.Plural

--- a/operator/errors.go
+++ b/operator/errors.go
@@ -1,7 +1,11 @@
 package operator
 
 import (
+	"errors"
 	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 )
@@ -33,3 +37,46 @@ func NewCannotCastError(meta resource.StaticMetadata) *CannotCastError {
 }
 
 var _ error = NewCannotCastError(resource.StaticMetadata{})
+
+type FinalizerError interface {
+	error
+	apierrors.APIStatus
+	PatchRequest() resource.PatchRequest
+}
+
+// FinalizerOperationError describes an error that occurred attempting to manipulate an object's finalizer list on the API server.
+type FinalizerOperationError struct {
+	err     error
+	request resource.PatchRequest
+}
+
+func (f *FinalizerOperationError) Error() string {
+	return f.err.Error()
+}
+
+func (f *FinalizerOperationError) Unwrap() error {
+	return f.err
+}
+
+func (f *FinalizerOperationError) Status() metav1.Status {
+	var chk apierrors.APIStatus
+	if errors.As(f.err, &chk) {
+		return chk.Status()
+	}
+	return metav1.Status{
+		Message: f.err.Error(),
+	}
+}
+
+func (f *FinalizerOperationError) PatchRequest() resource.PatchRequest {
+	return f.request
+}
+
+func NewFinalizerOperationError(err error, request resource.PatchRequest) *FinalizerOperationError {
+	return &FinalizerOperationError{
+		err:     err,
+		request: request,
+	}
+}
+
+var _ apierrors.APIStatus = &FinalizerOperationError{}

--- a/operator/finalizers.go
+++ b/operator/finalizers.go
@@ -1,0 +1,183 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"slices"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+type finalizerUpdater struct {
+	client PatchClient
+}
+
+func newFinalizerUpdater(client PatchClient) *finalizerUpdater {
+	return &finalizerUpdater{
+		client: client,
+	}
+}
+
+func (o *finalizerUpdater) AddFinalizer(ctx context.Context, object resource.Object, finalizer string) error {
+	err := o.doAddFinalizer(ctx, object, finalizer)
+	attempts := 0
+	// If we run into a conflict, retry a few times
+	for err != nil && apierrors.IsConflict(err) && attempts < 3 {
+		logging.FromContext(ctx).Debug("conflict adding finalizer, retrying after small delay", "finalizer", finalizer)
+		// Simple wait in case we've got multiple operators working on this
+		time.Sleep(time.Second*time.Duration(attempts) + o.jitter(time.Millisecond, 500))
+		// Try again with an updated object
+		err = o.client.GetInto(ctx, object.GetStaticMetadata().Identifier(), object)
+		if err != nil {
+			return fmt.Errorf("unable to get updated object to add finalizer: %w", err)
+		}
+		err = o.doAddFinalizer(ctx, object, finalizer)
+		attempts++
+	}
+	return err
+}
+
+func (o *finalizerUpdater) doAddFinalizer(ctx context.Context, object resource.Object, finalizer string) error {
+	finalizers := object.GetFinalizers()
+	if slices.Contains(finalizers, finalizer) {
+		// Finalizer already added
+		return nil
+	}
+
+	req := resource.PatchRequest{
+		Operations: []resource.PatchOperation{{
+			Operation: resource.PatchOpAdd,
+			Path:      "/metadata/finalizers",
+			Value:     []string{finalizer},
+		}, {
+			Operation: resource.PatchOpReplace,
+			Path:      "/metadata/resourceVersion",
+			Value:     object.GetResourceVersion(),
+		}},
+	}
+	if len(finalizers) > 0 {
+		req = resource.PatchRequest{
+			Operations: []resource.PatchOperation{{
+				Operation: resource.PatchOpAdd,
+				Path:      "/metadata/finalizers/-",
+				Value:     finalizer,
+			}, {
+				Operation: resource.PatchOpReplace,
+				Path:      "/metadata/resourceVersion",
+				Value:     object.GetResourceVersion(),
+			}},
+		}
+	}
+
+	err := o.client.PatchInto(ctx, object.GetStaticMetadata().Identifier(), req, resource.PatchOptions{}, object)
+	if err != nil {
+		return NewFinalizerOperationError(err, req)
+	}
+	return nil
+}
+
+func (o *finalizerUpdater) ReplaceFinalizer(ctx context.Context, object resource.Object, toReplace, replaceWith string) error {
+	err := o.doReplaceFinalizer(ctx, object, toReplace, replaceWith)
+	attempts := 0
+	// If we run into a conflict, retry a few times
+	for err != nil && apierrors.IsConflict(err) && attempts < 3 {
+		logging.FromContext(ctx).Debug("conflict replacing finalizer, retrying after small delay", "toReplace", toReplace, "replaceWith", replaceWith)
+		// Simple wait in case we've got multiple operators working on this
+		time.Sleep(time.Second*time.Duration(attempts) + o.jitter(time.Millisecond, 500))
+		// Try again with an updated object
+		err = o.client.GetInto(ctx, object.GetStaticMetadata().Identifier(), object)
+		if err != nil {
+			return fmt.Errorf("unable to get updated object to add finalizer: %w", err)
+		}
+		err = o.doReplaceFinalizer(ctx, object, toReplace, replaceWith)
+		attempts++
+	}
+	return err
+}
+
+func (o *finalizerUpdater) doReplaceFinalizer(ctx context.Context, object resource.Object, toReplace, replaceWith string) error {
+	finalizers := object.GetFinalizers()
+	if slices.Contains(finalizers, replaceWith) {
+		// Finalizer already added, check if toReplace is already removed (and remove it if it's still present)
+		if slices.Contains(finalizers, toReplace) {
+			return o.doRemoveFinalizer(ctx, object, toReplace)
+		}
+		return nil
+	}
+	if !slices.Contains(finalizers, toReplace) {
+		// toReplace already removed, just add replaceWith
+		return o.doAddFinalizer(ctx, object, toReplace)
+	}
+
+	req := resource.PatchRequest{
+		Operations: []resource.PatchOperation{{
+			Operation: resource.PatchOpReplace,
+			Path:      fmt.Sprintf("/metadata/finalizers/%d", slices.Index(finalizers, toReplace)),
+			Value:     replaceWith,
+		}, {
+			Operation: resource.PatchOpReplace,
+			Path:      "/metadata/resourceVersion",
+			Value:     object.GetResourceVersion(),
+		}},
+	}
+	err := o.client.PatchInto(ctx, object.GetStaticMetadata().Identifier(), req, resource.PatchOptions{}, object)
+	if err != nil {
+		return NewFinalizerOperationError(err, req)
+	}
+	return nil
+}
+
+func (o *finalizerUpdater) RemoveFinalizer(ctx context.Context, object resource.Object, finalizer string) error {
+	err := o.doRemoveFinalizer(ctx, object, finalizer)
+	attempts := 0
+	// If we run into a conflict, retry a few times
+	for err != nil && apierrors.IsConflict(err) && attempts < 3 {
+		logging.FromContext(ctx).Debug("conflict removing finalizer, retrying after small delay", "finalizer", finalizer)
+		// Simple wait in case we've got multiple operators working on this
+		time.Sleep(time.Second*time.Duration(attempts) + o.jitter(time.Millisecond, 500))
+		// Try again with an updated object
+		err = o.client.GetInto(ctx, object.GetStaticMetadata().Identifier(), object)
+		if err != nil {
+			return fmt.Errorf("unable to get updated object to add finalizer: %w", err)
+		}
+		err = o.doRemoveFinalizer(ctx, object, finalizer)
+		attempts++
+	}
+	return err
+}
+
+func (o *finalizerUpdater) doRemoveFinalizer(ctx context.Context, object resource.Object, finalizer string) error {
+	finalizers := object.GetFinalizers()
+	if !slices.Contains(finalizers, finalizer) {
+		// Finalizer already removed
+		return nil
+	}
+
+	req := resource.PatchRequest{
+		Operations: []resource.PatchOperation{{
+			Operation: resource.PatchOpRemove,
+			Path:      fmt.Sprintf("/metadata/finalizers/%d", slices.Index(finalizers, finalizer)),
+		}, {
+			Operation: resource.PatchOpReplace,
+			Path:      "/metadata/resourceVersion",
+			Value:     object.GetResourceVersion(),
+		}},
+	}
+	err := o.client.PatchInto(ctx, object.GetStaticMetadata().Identifier(), req, resource.PatchOptions{}, object)
+	if err != nil {
+		return NewFinalizerOperationError(err, req)
+	}
+	return nil
+}
+
+// gosec linter gets mad about math/rand, but we don't need secure random for time jitter
+//
+//nolint:gosec,revive
+func (*finalizerUpdater) jitter(unit time.Duration, max int) time.Duration {
+	return time.Duration(rand.Intn(max)) * unit
+}

--- a/operator/informer_controller_test.go
+++ b/operator/informer_controller_test.go
@@ -611,6 +611,9 @@ func TestInformerController_Run_WithWatcherAndReconciler(t *testing.T) {
 		c.AddWatcher(&SimpleWatcher{
 			AddFunc: func(ctx context.Context, object resource.Object) error {
 				addCalls++
+				if addCalls >= 3 {
+					t.Fatal("Add should only be retried once based on the RetryPolicy")
+				}
 				wg.Done()
 				return errors.New("I AM ERROR")
 			},
@@ -618,6 +621,9 @@ func TestInformerController_Run_WithWatcherAndReconciler(t *testing.T) {
 		c.AddReconciler(&SimpleReconciler{
 			ReconcileFunc: func(ctx context.Context, request ReconcileRequest) (ReconcileResult, error) {
 				reconcileCalls++
+				if reconcileCalls >= 3 {
+					t.Fatal("Reconcile should only be retried once based on the RetryPolicy")
+				}
 				wg.Done()
 				return ReconcileResult{}, errors.New("ICH BIN ERROR")
 			},

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -129,7 +129,8 @@ func TestOpinionatedWatcher_Add(t *testing.T) {
 			return patchErr
 		}
 		err := o.Add(context.TODO(), obj)
-		assert.Equal(t, patchErr, err)
+		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
+		assert.Equal(t, expectedErr, err)
 	})
 
 	t.Run("deleted, pending us, delete error", func(t *testing.T) {
@@ -436,7 +437,8 @@ func TestOpinionatedWatcher_Update(t *testing.T) {
 			return patchErr
 		}
 		err := o.Update(context.TODO(), schema.ZeroValue(), obj)
-		assert.Equal(t, patchErr, err)
+		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
+		assert.Equal(t, expectedErr, err)
 	})
 
 	t.Run("delete, patch RV mismatch", func(t *testing.T) {

--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -175,10 +175,11 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		res, err := op.Reconcile(ctx, req)
-		assert.Equal(t, patchErr, err)
+		expectedPatchErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers", Operation: resource.PatchOpAdd, Value: []string{finalizer}}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: req.Object.GetResourceVersion()}}})
+		assert.Equal(t, expectedPatchErr, err)
 		assert.True(t, patchCalled)
 		assert.Equal(t, "bar", res.State["foo"])
-		assert.Equal(t, patchErr, res.State[opinionatedReconcilerPatchAddStateKey])
+		assert.Equal(t, expectedPatchErr, res.State[opinionatedReconcilerPatchAddStateKey])
 	})
 
 	t.Run("retried add from client error", func(t *testing.T) {
@@ -466,12 +467,13 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		res, err := op.Reconcile(ctx, req)
+		expectedPatchErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: req.Object.GetResourceVersion()}}})
 		assert.Equal(t, ReconcileResult{
 			State: map[string]any{
-				opinionatedReconcilerPatchRemoveStateKey: patchErr,
+				opinionatedReconcilerPatchRemoveStateKey: expectedPatchErr,
 			},
 		}, res)
-		assert.Equal(t, patchErr, err)
+		assert.Equal(t, expectedPatchErr, err)
 	})
 
 	t.Run("update with non-nil deletionTimestamp, missing finalizer", func(t *testing.T) {


### PR DESCRIPTION
This PR adds a new error type (`FinalizerError` interface, `FinalizerOperationError` implementation used by `finalizerUpdater`) which includes the patch request details. This error is now checked in all OpinionatedWatcher/OpinionatedReconciler finalizer operations to log the patch request details if an error is returned.

This error can also now be checked with `errors.As` in upstream error handlers as well for additional improved logging/error handling.