### PR TITLE
Replace the list of finalizers on deletion instead of removing by index

### DIFF
--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -125,11 +125,11 @@ func TestOpinionatedWatcher_Add(t *testing.T) {
 		obj.SetFinalizers([]string{o.finalizer})
 		patchErr := fmt.Errorf("I AM ERROR")
 		client.PatchIntoFunc = func(ctx context.Context, identifier resource.Identifier, request resource.PatchRequest, options resource.PatchOptions, object resource.Object) error {
-			assert.Equal(t, resource.PatchOpRemove, request.Operations[0].Operation)
+			assert.Equal(t, resource.PatchOpReplace, request.Operations[0].Operation)
 			return patchErr
 		}
 		err := o.Add(context.TODO(), obj)
-		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
+		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers", Operation: resource.PatchOpReplace, Value: []string{}}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
 		assert.Equal(t, expectedErr, err)
 	})
 
@@ -433,11 +433,11 @@ func TestOpinionatedWatcher_Update(t *testing.T) {
 		}
 		patchErr := fmt.Errorf("ICH BIN ERROR")
 		client.PatchIntoFunc = func(ctx context.Context, identifier resource.Identifier, request resource.PatchRequest, options resource.PatchOptions, object resource.Object) error {
-			assert.Equal(t, resource.PatchOpRemove, request.Operations[0].Operation)
+			assert.Equal(t, resource.PatchOpReplace, request.Operations[0].Operation)
 			return patchErr
 		}
 		err := o.Update(context.TODO(), schema.ZeroValue(), obj)
-		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
+		expectedErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers", Operation: resource.PatchOpReplace, Value: []string{}}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: obj.GetResourceVersion()}}})
 		assert.Equal(t, expectedErr, err)
 	})
 

--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -359,9 +359,9 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 				assert.Equal(t, req.Object.GetStaticMetadata().Identifier(), identifier)
 				assert.Equal(t, resource.PatchRequest{
 					Operations: []resource.PatchOperation{{
-						Path:      "/metadata/finalizers/0",
-						Operation: resource.PatchOpRemove,
-						Value:     nil,
+						Path:      "/metadata/finalizers",
+						Operation: resource.PatchOpReplace,
+						Value:     []string{},
 					}, {
 						Path:      "/metadata/resourceVersion",
 						Operation: resource.PatchOpReplace,
@@ -448,9 +448,9 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 				assert.Equal(t, req.Object.GetStaticMetadata().Identifier(), identifier)
 				assert.Equal(t, resource.PatchRequest{
 					Operations: []resource.PatchOperation{{
-						Path:      "/metadata/finalizers/0",
-						Operation: resource.PatchOpRemove,
-						Value:     nil,
+						Path:      "/metadata/finalizers",
+						Operation: resource.PatchOpReplace,
+						Value:     []string{},
 					}, {
 						Path:      "/metadata/resourceVersion",
 						Operation: resource.PatchOpReplace,
@@ -467,7 +467,7 @@ func TestOpinionatedReconciler_Reconcile(t *testing.T) {
 			},
 		}
 		res, err := op.Reconcile(ctx, req)
-		expectedPatchErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers/0", Operation: resource.PatchOpRemove}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: req.Object.GetResourceVersion()}}})
+		expectedPatchErr := NewFinalizerOperationError(patchErr, resource.PatchRequest{Operations: []resource.PatchOperation{{Path: "/metadata/finalizers", Operation: resource.PatchOpReplace, Value: []string{}}, {Path: "/metadata/resourceVersion", Operation: resource.PatchOpReplace, Value: req.Object.GetResourceVersion()}}})
 		assert.Equal(t, ReconcileResult{
 			State: map[string]any{
 				opinionatedReconcilerPatchRemoveStateKey: expectedPatchErr,


### PR DESCRIPTION
### What

Change the logic of removing the finalizer on object deletion to instead
replace the list of finalizers completely.

### Why

This fixes an issue with the API server sometimes not being able to
apply the patch, because the provided index to remove at causes an
out-of-bounds error (e.g. if some other client shrunk the list of
finalizers with a PUT / PATCH request in the meantime).