### PR TITLE
Add pprof endpoints to the metrics server

### DIFF
--- a/operator/metrics_server.go
+++ b/operator/metrics_server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -53,6 +54,14 @@ func (s *MetricsServer) RegisterHealthChecks(checks ...health.Check) {
 
 func (s *MetricsServer) RegisterMetricsHandler(handler http.Handler) {
 	s.mux.Handle("/metrics", handler)
+}
+
+func (s *MetricsServer) RegisterProfilingHandlers() {
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
 func (s *MetricsServer) registerHealthHandlers() {

--- a/operator/runner.go
+++ b/operator/runner.go
@@ -83,6 +83,7 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	return &op, nil
 }
 
+// RunnerConfig contains configuration information for the Runner.
 type RunnerConfig struct {
 	// WebhookConfig contains configuration information for exposing k8s webhooks.
 	// This can be empty if your App does not implement ValidatorApp, MutatorApp, or ConversionApp
@@ -102,8 +103,9 @@ type RunnerConfig struct {
 type RunnerMetricsConfig struct {
 	metrics.ExporterConfig
 	MetricsServerConfig
-	Enabled   bool
-	Namespace string
+	Namespace        string
+	Enabled          bool
+	ProfilingEnabled bool
 }
 
 type RunnerWebhookConfig struct {
@@ -240,6 +242,11 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 		}
 
 		s.metricsServer.RegisterMetricsHandler(s.metricsExporter.HTTPHandler())
+	}
+
+	// Profiles
+	if s.config.MetricsConfig.ProfilingEnabled {
+		s.metricsServer.RegisterProfilingHandlers()
 	}
 
 	// Health


### PR DESCRIPTION
### What

This commit adds pprof endpoints to the metrics server and a flag to enable them to the metrics config.

### Why

This allows operators to support conprof out-of-the-box, similarly to how metrics and traces are supported.