### PR TITLE
[codegen] Set storage=true on single-version CRDs

### DIFF
--- a/codegen/jennies/crd.go
+++ b/codegen/jennies/crd.go
@@ -78,6 +78,12 @@ func (c *crdGenerator) Generate(kind codegen.Kind) (*codejen.File, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Check for edge case that results in CRDs that may not work with discovery, but should still be allowed to work.
+		// If there is only one version, storage must always be true.
+		if len(kind.Versions()) == 1 {
+			v.Storage = true
+		}
 		resource.Spec.Versions = append(resource.Spec.Versions, v)
 	}
 


### PR DESCRIPTION
If a CRD only has one version, regardless of the preferredVersion in the manifest, set storage=true for that version.