### PR TITLE
[codegen] Fix Generated Kind Client Subresource Update

### DIFF
--- a/codegen/templates/resourceclient.tmpl
+++ b/codegen/templates/resourceclient.tmpl
@@ -82,7 +82,7 @@ func (c *{{.KindName}}Client) Patch(ctx context.Context, identifier resource.Ide
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 {{ range .Subresources }}
-func (c *{{$.KindName}}Client) Update{{ .FieldName }}(ctx context.Context, new{{ .FieldName }} {{$.KindPrefix}}{{ .FieldName }}, opts resource.UpdateOptions) (*{{$.KindName}}, error) {
+func (c *{{$.KindName}}Client) Update{{ .FieldName }}(ctx context.Context, identifier resource.Identifier, new{{ .FieldName }} {{$.KindPrefix}}{{ .FieldName }}, opts resource.UpdateOptions) (*{{$.KindName}}, error) {
 	return c.client.Update(ctx, &{{$.KindName}}{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       {{$.KindPrefix}}Kind().Kind(),
@@ -90,6 +90,8 @@ func (c *{{$.KindName}}Client) Update{{ .FieldName }}(ctx context.Context, new{{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace: identifier.Namespace,
+			Name: identifier.Name,
 		},
 		{{ .FieldName }}: new{{ .FieldName }},
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *CustomKindClient) Patch(ctx context.Context, identifier resource.Identi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus CustomKindStatus, opts resource.UpdateOptions) (*CustomKind, error) {
+func (c *CustomKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus CustomKindStatus, opts resource.UpdateOptions) (*CustomKind, error) {
 	return c.client.Update(ctx, &CustomKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       CustomKindKind().Kind(),
@@ -84,6 +84,8 @@ func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus CustomKin
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *CustomKindClient) Patch(ctx context.Context, identifier resource.Identi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus CustomKindStatus, opts resource.UpdateOptions) (*CustomKind, error) {
+func (c *CustomKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus CustomKindStatus, opts resource.UpdateOptions) (*CustomKind, error) {
 	return c.client.Update(ctx, &CustomKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       CustomKindKind().Kind(),
@@ -84,6 +84,8 @@ func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus CustomKin
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *TestKind2Client) Patch(ctx context.Context, identifier resource.Identif
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *TestKind2Client) UpdateStatus(ctx context.Context, newStatus TestKind2Status, opts resource.UpdateOptions) (*TestKind2, error) {
+func (c *TestKind2Client) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus TestKind2Status, opts resource.UpdateOptions) (*TestKind2, error) {
 	return c.client.Update(ctx, &TestKind2{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKind2Kind().Kind(),
@@ -84,6 +84,8 @@ func (c *TestKind2Client) UpdateStatus(ctx context.Context, newStatus TestKind2S
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *TestKindClient) Patch(ctx context.Context, identifier resource.Identifi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
+func (c *TestKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
 	return c.client.Update(ctx, &TestKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKindKind().Kind(),
@@ -84,6 +84,8 @@ func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindSta
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *TestKindClient) Patch(ctx context.Context, identifier resource.Identifi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
+func (c *TestKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
 	return c.client.Update(ctx, &TestKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKindKind().Kind(),
@@ -84,6 +84,8 @@ func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindSta
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_client_gen.go.txt
@@ -82,7 +82,7 @@ func (c *TestKindClient) Patch(ctx context.Context, identifier resource.Identifi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
+func (c *TestKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
 	return c.client.Update(ctx, &TestKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKindKind().Kind(),
@@ -90,6 +90,8 @@ func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindSta
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *CustomKindClient) Patch(ctx context.Context, identifier resource.Identi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus Status, opts resource.UpdateOptions) (*CustomKind, error) {
+func (c *CustomKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus Status, opts resource.UpdateOptions) (*CustomKind, error) {
 	return c.client.Update(ctx, &CustomKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind().Kind(),
@@ -84,6 +84,8 @@ func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus Status, o
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_client_gen.go.txt
@@ -76,7 +76,7 @@ func (c *CustomKindClient) Patch(ctx context.Context, identifier resource.Identi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus Status, opts resource.UpdateOptions) (*CustomKind, error) {
+func (c *CustomKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus Status, opts resource.UpdateOptions) (*CustomKind, error) {
 	return c.client.Update(ctx, &CustomKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind().Kind(),
@@ -84,6 +84,8 @@ func (c *CustomKindClient) UpdateStatus(ctx context.Context, newStatus Status, o
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{

--- a/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
+++ b/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
@@ -82,7 +82,7 @@ func (c *TestKindClient) Patch(ctx context.Context, identifier resource.Identifi
 	return c.client.Patch(ctx, identifier, req, opts)
 }
 
-func (c *TestKindClient) UpdateMysubresource(ctx context.Context, newMysubresource TestKindMysubresource, opts resource.UpdateOptions) (*TestKind, error) {
+func (c *TestKindClient) UpdateMysubresource(ctx context.Context, identifier resource.Identifier, newMysubresource TestKindMysubresource, opts resource.UpdateOptions) (*TestKind, error) {
 	return c.client.Update(ctx, &TestKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKindKind().Kind(),
@@ -90,6 +90,8 @@ func (c *TestKindClient) UpdateMysubresource(ctx context.Context, newMysubresour
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Mysubresource: newMysubresource,
 	}, resource.UpdateOptions{
@@ -97,7 +99,7 @@ func (c *TestKindClient) UpdateMysubresource(ctx context.Context, newMysubresour
 		ResourceVersion: opts.ResourceVersion,
 	})
 }
-func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
+func (c *TestKindClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus TestKindStatus, opts resource.UpdateOptions) (*TestKind, error) {
 	return c.client.Update(ctx, &TestKind{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TestKindKind().Kind(),
@@ -105,6 +107,8 @@ func (c *TestKindClient) UpdateStatus(ctx context.Context, newStatus TestKindSta
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
 		},
 		Status: newStatus,
 	}, resource.UpdateOptions{


### PR DESCRIPTION
Include `resource.Identifier` in generated kind clients' subresource update methods