### PR TITLE
[simple.App] Default AppUnmanagedKinds to not using the opinionated reconcilers/watchers

### DIFF
--- a/docs/watching-unowned-resources.md
+++ b/docs/watching-unowned-resources.md
@@ -186,6 +186,18 @@ You can still use `ManagedKinds` alongside `UnmanagedKinds` when building your a
 It's important to not add an other app's kinds to your own `ManagedKinds` list, as then the App's `ManagedKinds()` method 
 won't match up with the kinds declared in your app's Manifest, and `app.ValidateManifest` will fail.
 
+### Opinionated Watchers/Reconcilers
+
+By default, adding a Watcher or Reconciler for an unmanaged kind does not use the Opinionated variant of that 
+Watcher/Reconciler. If you wish to use the Opinionated variant (same behavior as a Managed Kind), 
+set `UseOpinionated` to `true` in the `AppUnamanagedKind.ReconcileOptions`. 
+
+Please note that the Opinionated variants add finalizers to the watched resource as part of their function, 
+so you will not only need appropriate permissions to update the Kind, but also as finalizers block deletion of the resource, 
+if you ever _stop_ watching the Kind, you must remove all of your finalizers to allow the app that manages the Kind 
+to fully process deletes. It is good practice to reach out to the team that maintains that Kind before 
+using the opinionated variants on an Unmanaged Kind.
+
 ### Permissions
 
 You'll need to make sure your app has permission to list and watch the other app's kind(s) you're using. 

--- a/docs/watching-unowned-resources.md
+++ b/docs/watching-unowned-resources.md
@@ -195,7 +195,7 @@ set `UseOpinionated` to `true` in the `AppUnamanagedKind.ReconcileOptions`.
 Please note that the Opinionated variants add finalizers to the watched resource as part of their function, 
 so you will not only need appropriate permissions to update the Kind, but also as finalizers block deletion of the resource, 
 if you ever _stop_ watching the Kind, you must remove all of your finalizers to allow the app that manages the Kind 
-to fully process deletes. It is good practice to reach out to the team that maintains that Kind before 
+to fully process deletes. Before you do this, reach out to the team that maintains that Kind before 
 using the opinionated variants on an Unmanaged Kind.
 
 ### Permissions


### PR DESCRIPTION
Default AppUnmanagedKinds to not using the opinionated reconcilers/watchers, and add a section to the watching unmanaged kinds doc on this behavior.

`AppUnmanagedKind.ReconcileOptions` has been changed from `BasicReconcileOptions` to `UnmanagedKindReconcileOptions`, which inverts the `UsePlain` boolean to `UseOpinionated` (so the default is now to _not_ use the opinionated variant).