### PR TITLE
[AppManifest] Add apiVersion, kind, metadata, and spec as required fields when calling AsKubeOpenAPI

### DIFF
--- a/app/manifest.go
+++ b/app/manifest.go
@@ -683,6 +683,7 @@ func (v *VersionSchema) AsKubeOpenAPI(gvk schema.GroupVersionKind, ref common.Re
 						},
 					},
 				},
+				Required: []string{"kind", "apiVersion", "metadata"},
 			},
 		},
 		Dependencies: make([]string, 0),
@@ -696,6 +697,9 @@ func (v *VersionSchema) AsKubeOpenAPI(gvk schema.GroupVersionKind, ref common.Re
 		sch, deps := oapi3SchemaToKubeSchema(v, ref, gvk, refKey)
 		kind.Schema.Properties[k] = sch
 		kind.Dependencies = append(kind.Dependencies, deps...)
+		if k == "spec" {
+			kind.Schema.Required = append(kind.Schema.Required, k)
+		}
 	}
 
 	// For each schema, create an entry in the result

--- a/app/manifest_test.go
+++ b/app/manifest_test.go
@@ -806,6 +806,10 @@ func TestGetCRDOpenAPISchema(t *testing.T) {
 }
 
 func kubeOpenAPIKindWithProps(gvk schema.GroupVersionKind, ref common.ReferenceCallback, props map[string]spec.SchemaProps, deps ...string) common.OpenAPIDefinition {
+	required := []string{"kind", "apiVersion", "metadata"}
+	if _, ok := props["spec"]; ok {
+		required = append(required, "spec")
+	}
 	kind := common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -832,6 +836,7 @@ func kubeOpenAPIKindWithProps(gvk schema.GroupVersionKind, ref common.ReferenceC
 						},
 					},
 				},
+				Required: required,
 			},
 		},
 		Dependencies: make([]string, 0),


### PR DESCRIPTION
Add apiVersion, kind, metadata, and spec as required fields when calling `AsKubeOpenAPI`, as these should all be required. `spec` is only added as required if present (there may be use-cases for kinds that don't have a spec).