### PR TITLE
Kind: Support GVK+GVR without pointer reciever

### DIFF
--- a/resource/kind.go
+++ b/resource/kind.go
@@ -72,7 +72,7 @@ func (k *Kind) Write(obj Object, out io.Writer, encoding KindEncoding) error {
 }
 
 // GroupVersionKind is a convenience method that assembles a schema.GroupVersionKind from Group(), Version(), and Kind()
-func (k *Kind) GroupVersionKind() schema.GroupVersionKind {
+func (k Kind) GroupVersionKind() schema.GroupVersionKind {
 	if k.Schema == nil {
 		return schema.GroupVersionKind{}
 	}
@@ -84,7 +84,7 @@ func (k *Kind) GroupVersionKind() schema.GroupVersionKind {
 }
 
 // GroupVersionResource is a convenience method that assembles a schema.GroupVersionResource from Group(), Version(), and Plural()
-func (k *Kind) GroupVersionResource() schema.GroupVersionResource {
+func (k Kind) GroupVersionResource() schema.GroupVersionResource {
 	if k.Schema == nil {
 		return schema.GroupVersionResource{}
 	}

--- a/resource/kind_test.go
+++ b/resource/kind_test.go
@@ -25,6 +25,11 @@ func TestKind_GroupVersionKind(t *testing.T) {
 		Version: k.Schema.Version(),
 		Kind:    k.Schema.Kind(),
 	}, gvk)
+
+	require.Equal(t, gvk, Kind{
+		Schema: k.Schema,
+		Codecs: k.Codecs,
+	}.GroupVersionResource(), "GVK does not require pointer")
 }
 
 func TestKind_GroupVersionResource(t *testing.T) {
@@ -40,6 +45,11 @@ func TestKind_GroupVersionResource(t *testing.T) {
 		Version:  k.Schema.Version(),
 		Resource: k.Schema.Plural(),
 	}, gvr)
+
+	require.Equal(t, gvr, Kind{
+		Schema: k.Schema,
+		Codecs: k.Codecs,
+	}.GroupVersionResource(), "GVR does not require pointer")
 }
 
 func TestJSONCodec_Read(t *testing.T) {

--- a/resource/kind_test.go
+++ b/resource/kind_test.go
@@ -29,7 +29,7 @@ func TestKind_GroupVersionKind(t *testing.T) {
 	require.Equal(t, gvk, Kind{
 		Schema: k.Schema,
 		Codecs: k.Codecs,
-	}.GroupVersionResource(), "GVK does not require pointer")
+	}.GroupVersionKind(), "GVK does not require pointer")
 }
 
 func TestKind_GroupVersionResource(t *testing.T) {


### PR DESCRIPTION
There are a few places jumping some hoops to get the GVR from a manifest:
https://github.com/grafana/grafana/blob/v12.2.0/pkg/api/short_url.go#L119

Ideally:
```
    gvr := schema.GroupVersionResource{
		Group:    v1alpha1.ShortURLKind().Group(),
		Version:  v1alpha1.ShortURLKind().Version(),
		Resource: v1alpha1.ShortURLKind().Plural(),
	}
	return &shortURLK8sHandler{
		gvr:   ...
```
with this change, we could use:
```
	return &shortURLK8sHandler{
		gvr:   v1alpha1.ShortURLKind().GroupVersionResource()
```

Most references to [.Plural()](https://github.com/search?q=repo%3Agrafana%2Fgrafana%20Plural()&type=code) really wants the GVR
