### PR TITLE
[codegen] Default `make generate` to use the `--crdmanifest` flag

### DIFF
--- a/cmd/grafana-app-sdk/templates/Makefile.tmpl
+++ b/cmd/grafana-app-sdk/templates/Makefile.tmpl
@@ -58,7 +58,7 @@ compile/operator:
 
 .PHONY: generate
 generate:
-	@grafana-app-sdk generate --source kinds --format cue
+	@grafana-app-sdk generate --source kinds --format cue --crdmanifest
 
 .PHONY: local/up
 local/up: local/generate


### PR DESCRIPTION
Default `make generate` to use the --crdmanifest flag for now, as the v1alpha2 app manifest is primarily used for API servers.