### PR TITLE
[linter] Ignore `goconst` linter in two places

### DIFF
--- a/cmd/grafana-app-sdk/project.go
+++ b/cmd/grafana-app-sdk/project.go
@@ -80,6 +80,7 @@ var projectLocalInitCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
+//nolint:goconst
 func setupProjectCmd() {
 	projectCmd.PersistentFlags().StringP("path", "p", "", "Path to project directory")
 	projectCmd.PersistentFlags().Bool("overwrite", false, "Overwrite existing files instead of prompting")

--- a/codegen/jennies/typescript.go
+++ b/codegen/jennies/typescript.go
@@ -73,7 +73,7 @@ func (*TypeScriptResourceTypes) generateObjectFile(kind codegen.Kind, version *c
 		return nil, err
 	}
 	for it.Next() {
-		if it.Selector().String() == "spec" || it.Selector().String() == "metadata" {
+		if it.Selector().String() == "spec" || it.Selector().String() == "metadata" { //nolint:goconst
 			continue
 		}
 		metadata.Subresources = append(metadata.Subresources, templates.SubresourceMetadata{


### PR DESCRIPTION
Ignore goconst linter in two places it has started objecting to only locally after the linter upgrade.