### PR TITLE
Fix handling of Watch and Status objects in GenericJSONDecoder

### DIFF
--- a/k8s/negotiator.go
+++ b/k8s/negotiator.go
@@ -106,15 +106,8 @@ func (*GenericJSONDecoder) Decode(
 		}
 
 		return into, defaults, nil
-	case chk.Items != nil: // Fallback to UntypedList
-		l := &UntypedListObjectWrapper{}
-		if err := json.Unmarshal(data, l); err != nil {
-			logging.DefaultLogger.Error("error unmarshalling into *k8s.UntypedListObjectWrapper", "error", err)
-			return into, defaults, fmt.Errorf("error unmarshalling into *k8s.UntypedListObjectWrapper: %w", err)
-		}
-
-		l.items = data
-		into = l
+	case chk.Items != nil: // TODO: the codecs don't know how to handle lists yet.
+		return nil, nil, fmt.Errorf("unsupported list object")
 	case chk.Kind != "": // Fallback to UntypedObject
 		o := &UntypedObjectWrapper{}
 		if err := json.Unmarshal(data, o); err != nil {

--- a/k8s/wrappers.go
+++ b/k8s/wrappers.go
@@ -70,28 +70,6 @@ func (o *UntypedObjectWrapper) Into(into resource.Object, codec resource.Codec) 
 	return codec.Read(bytes.NewReader(o.object), into)
 }
 
-// UntypedListObjectWrapper wraps a list of UntypedObjectWrappers, and implements runtime.Object
-type UntypedListObjectWrapper struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	items           json.RawMessage
-}
-
-// DeepCopyObject copies the object
-func (o *UntypedListObjectWrapper) DeepCopyObject() runtime.Object {
-	val := reflect.ValueOf(o).Elem()
-
-	cpy := reflect.New(val.Type())
-	cpy.Elem().Set(val)
-
-	// Using the <obj>, <ok> for the type conversion ensures that it doesn't panic if it can't be converted
-	if obj, ok := cpy.Interface().(runtime.Object); ok {
-		return obj
-	}
-
-	return nil
-}
-
 // UntypedWatchObject implements runtime.Object, and keeps the Object part of a kubernetes watch event as bytes
 // when unmarshaled, so that it can later be marshaled into a concrete type with Into().
 type UntypedWatchObject struct {


### PR DESCRIPTION
### What

This commit fixes the handling of objects in the decoder by properly dispatching watch & status types.

### Why

Those types were not handled properly before, causing WatchList to sometimes fail, if watch encountered retryable errors.