### PR TITLE
[makefile] add a `make debug` target for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ endif
 .PHONY: debug
 debug: build
 	@if [ -n "$(APP_DIR)" ]; then \
+		mkdir -p "$(APP_DIR)"; \
 		cd "$(APP_DIR)" && dlv exec "$(abspath $(BIN_DIR))/grafana-app-sdk" --headless --listen=:$(or $(PORT),12345) --api-version=2 -- $(ARGS); \
 	else \
 		cd target && dlv exec "$(abspath $(BIN_DIR))/grafana-app-sdk" --headless --listen=:$(or $(PORT),12345) --api-version=2 -- $(ARGS); \


### PR DESCRIPTION
# What Changed? Why?
Added a make target to setup the delve debugger and allow a developer to debug the sdk within a project directory of their choosing.

### Demo

https://github.com/user-attachments/assets/728befd0-982a-476f-babd-528d6f5e5b0a

