### PR TITLE
[AppManifest] Fix panic on `ToManifestData()` call on an AppManifest with no versions

### DIFF
--- a/app/appmanifest/v1alpha1/conversion.go
+++ b/app/appmanifest/v1alpha1/conversion.go
@@ -128,7 +128,7 @@ func (s *AppManifestSpec) ToManifestData() (app.ManifestData, error) {
 	}
 	if s.PreferredVersion != nil {
 		data.PreferredVersion = *s.PreferredVersion
-	} else {
+	} else if len(s.Versions) > 0 {
 		data.PreferredVersion = s.Versions[len(s.Versions)-1].Name
 	}
 	// Permissions

--- a/app/appmanifest/v1alpha1/conversion_test.go
+++ b/app/appmanifest/v1alpha1/conversion_test.go
@@ -36,4 +36,16 @@ func TestAppManifestSpec_ToManifestData(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, md, v1md)
 	})
+
+	t.Run("no versions", func(t *testing.T) {
+		v1alpha1 := AppManifestSpec{
+			AppName: "foo",
+		}
+		md, err := v1alpha1.ToManifestData()
+		require.NoError(t, err)
+		assert.Equal(t, app.ManifestData{
+			AppName:  "foo",
+			Versions: []app.ManifestVersion{},
+		}, md)
+	})
 }

--- a/app/appmanifest/v1alpha2/conversion.go
+++ b/app/appmanifest/v1alpha2/conversion.go
@@ -158,7 +158,7 @@ func (s *AppManifestSpec) ToManifestData() (app.ManifestData, error) {
 	}
 	if s.PreferredVersion != nil {
 		data.PreferredVersion = *s.PreferredVersion
-	} else {
+	} else if len(s.Versions) > 0 {
 		data.PreferredVersion = s.Versions[len(s.Versions)-1].Name
 	}
 	// Permissions

--- a/app/appmanifest/v1alpha2/conversion_test.go
+++ b/app/appmanifest/v1alpha2/conversion_test.go
@@ -15,14 +15,14 @@ import (
 
 func TestAppManifestSpec_ToManifestData(t *testing.T) {
 	t.Run("successful conversion", func(t *testing.T) {
-		// For v1alpha1, app.ManifestData is essentially a subset of v1alpha1.AppManifestSpec,
+		// For v1alpha2, app.ManifestData is essentially a subset of v1alpha2.AppManifestSpec,
 		// so we only need to check that the same JSON loaded for the AppManifestSpec and using ToManifestData()
 		// is identical to loading that JSON for app.ManifestData
 		file, err := os.ReadFile(filepath.Join("testfiles", "spec-01.json"))
 		require.Nil(t, err)
-		v1alpha1 := AppManifestSpec{}
+		v1alpha2 := AppManifestSpec{}
 		md := app.ManifestData{}
-		err = json.Unmarshal(file, &v1alpha1)
+		err = json.Unmarshal(file, &v1alpha2)
 		require.Nil(t, err)
 		err = json.Unmarshal(file, &md)
 		schFile, err := os.ReadFile(filepath.Join("testfiles", "schema-01.json"))
@@ -33,13 +33,13 @@ func TestAppManifestSpec_ToManifestData(t *testing.T) {
 		md.Versions[0].Kinds[0].Schema, err = app.VersionSchemaFromMap(m, md.Versions[0].Kinds[0].Kind)
 		require.Nil(t, err)
 		require.Nil(t, err)
-		v1md, err := v1alpha1.ToManifestData()
+		v1md, err := v1alpha2.ToManifestData()
 		require.Nil(t, err)
 		assert.Equal(t, md, v1md)
 	})
 
 	t.Run("bad schema data", func(t *testing.T) {
-		v1alpha1 := AppManifestSpec{
+		v1alpha2 := AppManifestSpec{
 			Versions: []AppManifestManifestVersion{{
 				Kinds: []AppManifestManifestVersionKind{{
 					Kind: "Foo",
@@ -49,7 +49,19 @@ func TestAppManifestSpec_ToManifestData(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := v1alpha1.ToManifestData()
+		_, err := v1alpha2.ToManifestData()
 		assert.Equal(t, errors.New("schemas for Foo must contain an entry named 'Foo'"), err)
+	})
+
+	t.Run("no versions", func(t *testing.T) {
+		v1alpha2 := AppManifestSpec{
+			AppName: "foo",
+		}
+		md, err := v1alpha2.ToManifestData()
+		require.NoError(t, err)
+		assert.Equal(t, app.ManifestData{
+			AppName:  "foo",
+			Versions: []app.ManifestVersion{},
+		}, md)
 	})
 }


### PR DESCRIPTION
## What Changed? Why?

If `ToManifestData` is called on a `v1alpha1.AppManifestSpec` or `v1alpha2.AppManifestSpec` that has no `PreferredVersion` and no (or empty) `Versions`, the call will result in a nil pointer panic as it tries to set `PreferredVersion` to the last element of `Versions` without checking if `Versions` is non-nil with at least one element. This PR adds a check that `Versions` has at least one element before doing this assignment.

### How was it tested?

Added test cases to the conversion tests for this scenario.

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers
