### PR TITLE
[codegen] Fix empty manifest package for legacy non-manifestdata manifest go file

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -271,8 +271,12 @@ func generateKindsCue(modFS fs.FS, cfg kindGenConfig, selectors ...string) (code
 		}
 	}
 
+	manifestPkg := filepath.Base(cfg.ManifestPath)
+	if cfg.ManifestPath == "" {
+		manifestPkg = filepath.Base(cfg.GoGenBasePath)
+	}
 	// Manifest
-	goManifestFiles, err := generatorForManifest.Generate(cuekind.ManifestGoGenerator(filepath.Base(cfg.ManifestPath), cfg.ManifestIncludeSchemas, cfg.GoModuleName, cfg.GoModuleGenBasePath, cfg.ManifestPath, cfg.GroupKinds), selectors...)
+	goManifestFiles, err := generatorForManifest.Generate(cuekind.ManifestGoGenerator(manifestPkg, cfg.ManifestIncludeSchemas, cfg.GoModuleName, cfg.GoModuleGenBasePath, cfg.ManifestPath, cfg.GroupKinds), selectors...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What Changed? Why?

For legacy non-`manifestdata`-package generated manifest go files, the package was being supplied as empty from the CLI, which is invalid. This fixes it to use the basename of the `--gogenpath`.

### How was it tested?

Tested in an existing project.

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers
