### PR TITLE
[apiserver] Allow API Installer to install APIVersions with no kinds

### DIFF
--- a/examples/apiserver/apis/example/v0alpha1/testkind_client_gen.go
+++ b/examples/apiserver/apis/example/v0alpha1/testkind_client_gen.go
@@ -3,8 +3,9 @@ package v0alpha1
 import (
 	"context"
 
-	"github.com/grafana/grafana-app-sdk/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/resource"
 )
 
 type TestKindClient struct {

--- a/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
+++ b/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
@@ -9,8 +9,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/grafana/grafana-app-sdk/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/resource"
 )
 
 type TestKindClient struct {

--- a/examples/apiserver/apis/example/v2alpha1/getexample_response_body_types_gen.go
+++ b/examples/apiserver/apis/example/v2alpha1/getexample_response_body_types_gen.go
@@ -1,0 +1,13 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v2alpha1
+
+// +k8s:openapi-gen=true
+type GetExampleBody struct {
+	Message string `json:"message"`
+}
+
+// NewGetExampleBody creates a new GetExampleBody object.
+func NewGetExampleBody() *GetExampleBody {
+	return &GetExampleBody{}
+}

--- a/examples/apiserver/apis/example/v2alpha1/getexample_response_object_types_gen.go
+++ b/examples/apiserver/apis/example/v2alpha1/getexample_response_object_types_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v2alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetExample struct {
+	metav1.TypeMeta `json:",inline"`
+	GetExampleBody  `json:",inline"`
+}
+
+func NewGetExample() *GetExample {
+	return &GetExample{}
+}
+
+func (t *GetExampleBody) DeepCopyInto(dst *GetExampleBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetExample) DeepCopyObject() runtime.Object {
+	dst := NewGetExample()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetExample) DeepCopyInto(dst *GetExample) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetExampleBody.DeepCopyInto(&dst.GetExampleBody)
+}
+
+var _ runtime.Object = NewGetExample()

--- a/examples/apiserver/apis/example_manifest.go
+++ b/examples/apiserver/apis/example_manifest.go
@@ -18,13 +18,14 @@ import (
 
 	v0alpha1 "github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v0alpha1"
 	v1alpha1 "github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v1alpha1"
+	v2alpha1 "github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v2alpha1"
 )
 
 var (
 	rawSchemaTestKindv0alpha1     = []byte(`{"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"TestKind":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"spec":{"additionalProperties":false,"properties":{"testField":{"type":"integer"}},"required":["testField"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaTestKindv0alpha1 app.VersionSchema
 	_                             = json.Unmarshal(rawSchemaTestKindv0alpha1, &versionSchemaTestKindv0alpha1)
-	rawSchemaTestKindv1alpha1     = []byte(`{"Bar":{"additionalProperties":false,"properties":{"baz":{"$ref":"#/components/schemas/Baz"},"value":{"default":"bar","type":"string"}},"required":["value","baz"],"type":"object"},"Baz":{"additionalProperties":false,"properties":{"value":{"default":10,"type":"integer"}},"required":["value"],"type":"object"},"Foo":{"additionalProperties":false,"properties":{"bar":{"$ref":"#/components/schemas/Bar"},"foo":{"default":"foo","type":"string"}},"required":["foo","bar"],"type":"object"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"TestKind":{"properties":{"mysubresource":{"$ref":"#/components/schemas/mysubresource"},"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"mysubresource":{"additionalProperties":false,"properties":{"extraValue":{"type":"string"}},"required":["extraValue"],"type":"object"},"spec":{"additionalProperties":false,"properties":{"foo":{"$ref":"#/components/schemas/Foo"},"testField":{"default":"default value","type":"string"}},"required":["testField","foo"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
+	rawSchemaTestKindv1alpha1     = []byte(`{"Bar":{"additionalProperties":false,"properties":{"baz":{"$ref":"#/components/schemas/Baz"},"value":{"default":"bar","type":"string"}},"required":["value","baz"],"type":"object"},"Baz":{"additionalProperties":false,"properties":{"value":{"default":10,"type":"integer"}},"required":["value"],"type":"object"},"Foo":{"additionalProperties":false,"properties":{"bar":{"$ref":"#/components/schemas/Bar"},"foo":{"default":"foo","type":"string"}},"required":["foo","bar"],"type":"object"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"TestKind":{"properties":{"mysubresource":{"$ref":"#/components/schemas/mysubresource"},"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"getRecursiveResponseRecursiveType":{"type":"object","required":["message"],"properties":{"message":{"type":"string"},"next":{"$ref":"#/components/schemas/getRecursiveResponseRecursiveType"}},"additionalProperties":false},"mysubresource":{"additionalProperties":false,"properties":{"extraValue":{"type":"string"}},"required":["extraValue"],"type":"object"},"spec":{"additionalProperties":false,"properties":{"foo":{"$ref":"#/components/schemas/Foo"},"testField":{"default":"default value","type":"string"}},"required":["testField","foo"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":{"additionalProperties":{},"type":"object"},"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaTestKindv1alpha1 app.VersionSchema
 	_                             = json.Unmarshal(rawSchemaTestKindv1alpha1, &versionSchemaTestKindv1alpha1)
 )
@@ -586,6 +587,68 @@ var appManifestData = app.ManifestData{
 				},
 			},
 		},
+
+		{
+			Name:   "v2alpha1",
+			Served: true,
+			Kinds:  []app.ManifestVersionKind{},
+			Routes: app.ManifestVersionRoutes{
+				Namespaced: map[string]spec3.PathProps{
+					"/example": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getExample",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"message": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"string"},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"message",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+				},
+				Cluster: map[string]spec3.PathProps{},
+				Schemas: map[string]spec.Schema{},
+			},
+		},
 	},
 }
 
@@ -619,6 +682,8 @@ var customRouteToGoResponseType = map[string]any{
 
 	"v1alpha1||<namespace>/foobar|GET": v1alpha1.GetFoobar{},
 	"v1alpha1||foobar|GET":             v1alpha1.GetClusterFoobar{},
+
+	"v2alpha1||<namespace>/example|GET": v2alpha1.GetExample{},
 }
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.

--- a/examples/apiserver/kinds/manifest.cue
+++ b/examples/apiserver/kinds/manifest.cue
@@ -10,6 +10,7 @@ manifest: {
 	versions: {
 			"v0alpha1": {kinds:[testKindv0alpha1]}
 	    "v1alpha1": v1alpha1
+	    "v2alpha1": v2alpha1
 	}
 	preferredVersion: "v1alpha1"
 	// extraPermissions contains any additional permissions your app may require to function.
@@ -95,6 +96,23 @@ v1alpha1: {
     		}
     	}
     }
+}
+
+// Version with only custom resource routes, no kinds
+v2alpha1: {
+	kinds: []
+	routes: {
+		namespaced: {
+			"/example": {
+				"GET": {
+					name: "getExample"
+					response: {
+						message: string
+					}
+				}
+			}
+		}
+	}
 }
 
 // Test type for go naming conflicts

--- a/examples/apiserver/server.go
+++ b/examples/apiserver/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/examples/apiserver/apis"
 	"github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v0alpha1"
 	"github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v1alpha1"
+	"github.com/grafana/grafana-app-sdk/examples/apiserver/apis/example/v2alpha1"
 	"github.com/grafana/grafana-app-sdk/k8s"
 	"github.com/grafana/grafana-app-sdk/k8s/apiserver"
 	"github.com/grafana/grafana-app-sdk/k8s/apiserver/cmd/server"
@@ -173,6 +174,21 @@ func NewApp(config app.Config) (app.App, error) {
 					})
 				},
 			},
+			"v2alpha1": {{
+				Namespaced: true,
+				Path:       "example",
+				Method:     "GET",
+			}: func(_ context.Context, writer app.CustomRouteResponseWriter, _ *app.CustomRouteRequest) error {
+				return json.NewEncoder(writer).Encode(v2alpha1.GetExample{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Example",
+						APIVersion: config.ManifestData.Group + "/v2alpha1",
+					},
+					GetExampleBody: v2alpha1.GetExampleBody{
+						Message: "This is a route that exists in a version which only has resource routes and no kinds",
+					},
+				})
+			}},
 		},
 	})
 }


### PR DESCRIPTION
## What Changed? Why?

Currently, attempting to install an app with no kinds, but custom resource routes, result sin an error when setting the version priority. This PR fixes the underlying problem that an app without kinds doesn't get a webservice installer, even if it has routes for a version, so doesn't get routes added. This PR also removes the "silent" failure mode of failing to install routes because the webservice to install them on cannot be found, and instead returns an error for this.

### How was it tested?

Locally, on the example apiserver.

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers
