### PR TITLE
[codegen] Include array item information in the generated go manifest routes

### DIFF
--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -148,8 +148,8 @@ func TestManifestGoGenerator(t *testing.T) {
 		files, err := ManifestGoGenerator("manifestdata", true, "codegen-tests", "pkg/generated", "manifestdata", true).Generate(kinds...)
 		require.Nil(t, err)
 		// Check number of files generated
-		// 10 -> manifest file, then the custom route response+query+body for reconcile, response body and wrapper+query+body for search in v3, +1 client per version (3)
-		require.Len(t, files, 11, "should be 11 files generated, got %d", len(files))
+		// 14 -> manifest file (1), then the custom route response+query+body for reconcile (3), response body and wrapper+query+body for search in v3 (4), request, response, and wrapper for /foobar in v3 (3), +1 client per version (3)
+		require.Len(t, files, 14, "should be 14 files generated, got %d", len(files))
 		// Check content against the golden files
 		for _, file := range files {
 			compareToGolden(t, codejen.Files{file}, "go/groupbygroup")

--- a/codegen/cuekind/testing/testkind.cue
+++ b/codegen/cuekind/testing/testkind.cue
@@ -37,6 +37,22 @@ testManifestV2: {
 testManifestV3: {
 	codegen: ts: enabled: false
 	kinds: [testKind & testKind.versions["v3"]]
+	routes: namespaced: {
+		"/foobar": {
+			"POST": {
+				#Key: {
+					name: string
+					match?: string
+				}
+				request: body: {
+					keys: [...#Key]
+				}
+				response: {
+					altered: [...#Key]
+				}
+			}
+		}
+	}
 }
 
 testKind: {
@@ -120,6 +136,9 @@ testKind: {
 							items: [...{
 								name: string
 								score: float
+								list: [...{
+									foo: string
+								}]
 							}]
 							total: int
 						}

--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -669,6 +669,17 @@ func prefixReferences(sch spec.SchemaProps, prefix string, rootSchemas map[strin
 	if sch.AdditionalProperties != nil && sch.AdditionalProperties.Schema != nil {
 		sch.AdditionalProperties.Schema.SchemaProps = prefixReferences(sch.AdditionalProperties.Schema.SchemaProps, prefix, rootSchemas)
 	}
+	if sch.Items != nil {
+		if sch.Items.Schema != nil {
+			sch.Items.Schema.SchemaProps = prefixReferences(sch.Items.Schema.SchemaProps, prefix, rootSchemas)
+		}
+		if len(sch.Items.Schemas) > 0 {
+			for idx, item := range sch.Items.Schemas {
+				item.SchemaProps = prefixReferences(item.SchemaProps, prefix, rootSchemas)
+				sch.Items.Schemas[idx] = item
+			}
+		}
+	}
 	return sch
 }
 

--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -37,7 +37,13 @@ SchemaProps: spec.SchemaProps{
     },{{ end }}{{ end }}{{ if .Required }}
     Required: []string{ {{ range .Required }}
         "{{.}}",{{ end }}
-    },{{ end }}{{ if (refString .Ref) }}
+    },{{ end }}{{ if .Items }}
+    Items: &spec.SchemaOrArray{ {{ if .Items.Schema }}
+        Schema: &spec.Schema{ {{ template "schema" .Items.Schema }} },
+        {{ else if .Items.Array }}Schemas: []spec.Schema{ {{ range .Items.Array }}
+            { {{ template "schema" . }} },{{ end }}
+        },
+        {{ end }} },{{ end }}{{ if (refString .Ref) }}
     Ref: spec.MustCreateRef("{{ .Ref | refString }}"),{{ end }}
 },{{ if .Extensions }}
 VendorExtensible: spec.VendorExtensible{

--- a/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
@@ -277,6 +277,50 @@ var appManifestData = app.ManifestData{
 																			"items": {
 																				SchemaProps: spec.SchemaProps{
 																					Type: []string{"array"},
+																					Items: &spec.SchemaOrArray{
+																						Schema: &spec.Schema{
+																							SchemaProps: spec.SchemaProps{
+																								Type: []string{"object"},
+																								Properties: map[string]spec.Schema{
+																									"list": {
+																										SchemaProps: spec.SchemaProps{
+																											Type: []string{"array"},
+																											Items: &spec.SchemaOrArray{
+																												Schema: &spec.Schema{
+																													SchemaProps: spec.SchemaProps{
+																														Type: []string{"object"},
+																														Properties: map[string]spec.Schema{
+																															"foo": {
+																																SchemaProps: spec.SchemaProps{
+																																	Type: []string{"string"},
+																																},
+																															},
+																														},
+																														Required: []string{
+																															"foo",
+																														},
+																													}},
+																											},
+																										},
+																									},
+																									"name": {
+																										SchemaProps: spec.SchemaProps{
+																											Type: []string{"string"},
+																										},
+																									},
+																									"score": {
+																										SchemaProps: spec.SchemaProps{
+																											Type: []string{"number"},
+																										},
+																									},
+																								},
+																								Required: []string{
+																									"name",
+																									"score",
+																									"list",
+																								},
+																							}},
+																					},
 																				},
 																			},
 																			"kind": {
@@ -316,9 +360,119 @@ var appManifestData = app.ManifestData{
 				},
 			},
 			Routes: app.ManifestVersionRoutes{
-				Namespaced: map[string]spec3.PathProps{},
-				Cluster:    map[string]spec3.PathProps{},
-				Schemas:    map[string]spec.Schema{},
+				Namespaced: map[string]spec3.PathProps{
+					"/foobar": {
+						Post: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "createFoobar",
+
+								RequestBody: &spec3.RequestBody{
+									RequestBodyProps: spec3.RequestBodyProps{
+
+										Required: true,
+										Content: map[string]*spec3.MediaType{
+											"application/json": {
+												MediaTypeProps: spec3.MediaTypeProps{
+													Schema: &spec.Schema{
+														SchemaProps: spec.SchemaProps{
+															Type: []string{"object"},
+															Properties: map[string]spec.Schema{
+																"keys": {
+																	SchemaProps: spec.SchemaProps{
+																		Type: []string{"array"},
+																		Items: &spec.SchemaOrArray{
+																			Schema: &spec.Schema{
+																				SchemaProps: spec.SchemaProps{
+
+																					Ref: spec.MustCreateRef("#/components/schemas/createFoobarKey"),
+																				}},
+																		},
+																	},
+																},
+															},
+															Required: []string{
+																"keys",
+															},
+														}},
+												}},
+										},
+									}},
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"altered": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/createFoobarKey"),
+																						}},
+																				},
+																			},
+																		},
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"altered",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+				},
+				Cluster: map[string]spec3.PathProps{},
+				Schemas: map[string]spec.Schema{
+					"createFoobarKey": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"match": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+							},
+							Required: []string{
+								"name",
+							},
+						},
+					},
+				},
 			},
 		},
 	},
@@ -372,6 +526,8 @@ var customRouteToGoResponseType = map[string]any{
 	"v3|TestKind|reconcile|POST": v3.CreateReconcile{},
 
 	"v3|TestKind|search|GET": v3.GetTestKindSearchResult{},
+
+	"v3||<namespace>/foobar|POST": v3.CreateFoobar{},
 }
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.
@@ -402,6 +558,8 @@ func ManifestCustomRouteQueryAssociator(kind, version, path, verb string) (goTyp
 var customRouteToGoRequestBodyType = map[string]any{
 
 	"v3|TestKind|reconcile|POST": v3.CreateReconcileRequestBody{},
+
+	"v3||<namespace>/foobar|POST": v3.CreateFoobarRequestBody{},
 }
 
 func ManifestCustomRouteRequestBodyAssociator(kind, version, path, verb string) (goType any, exists bool) {

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_request_body_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_request_body_types_gen.go.txt
@@ -1,0 +1,24 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v3
+
+type CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey struct {
+	Name  string  `json:"name"`
+	Match *string `json:"match,omitempty"`
+}
+
+// NewCreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey creates a new CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey object.
+func NewCreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey() *CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey {
+	return &CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey{}
+}
+
+type CreateFoobarRequestBody struct {
+	Keys []CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey `json:"keys"`
+}
+
+// NewCreateFoobarRequestBody creates a new CreateFoobarRequestBody object.
+func NewCreateFoobarRequestBody() *CreateFoobarRequestBody {
+	return &CreateFoobarRequestBody{
+		Keys: []CreateFoobarRequestversionsV3RoutesNamespacedFoobarPOSTKey{},
+	}
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_body_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_body_types_gen.go.txt
@@ -1,0 +1,26 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v3
+
+// +k8s:openapi-gen=true
+type VersionsV3RoutesNamespacedFoobarPOSTKey struct {
+	Name  string  `json:"name"`
+	Match *string `json:"match,omitempty"`
+}
+
+// NewVersionsV3RoutesNamespacedFoobarPOSTKey creates a new VersionsV3RoutesNamespacedFoobarPOSTKey object.
+func NewVersionsV3RoutesNamespacedFoobarPOSTKey() *VersionsV3RoutesNamespacedFoobarPOSTKey {
+	return &VersionsV3RoutesNamespacedFoobarPOSTKey{}
+}
+
+// +k8s:openapi-gen=true
+type CreateFoobarBody struct {
+	Altered []VersionsV3RoutesNamespacedFoobarPOSTKey `json:"altered"`
+}
+
+// NewCreateFoobarBody creates a new CreateFoobarBody object.
+func NewCreateFoobarBody() *CreateFoobarBody {
+	return &CreateFoobarBody{
+		Altered: []VersionsV3RoutesNamespacedFoobarPOSTKey{},
+	}
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_object_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_object_types_gen.go.txt
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v3
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type CreateFoobar struct {
+	metav1.TypeMeta  `json:",inline"`
+	CreateFoobarBody `json:",inline"`
+}
+
+func NewCreateFoobar() *CreateFoobar {
+	return &CreateFoobar{}
+}
+
+func (t *CreateFoobarBody) DeepCopyInto(dst *CreateFoobarBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *CreateFoobar) DeepCopyObject() runtime.Object {
+	dst := NewCreateFoobar()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *CreateFoobar) DeepCopyInto(dst *CreateFoobar) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.CreateFoobarBody.DeepCopyInto(&dst.CreateFoobarBody)
+}
+
+var _ runtime.Object = NewCreateFoobar()

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_gettestkindsearchresult_response_body_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_gettestkindsearchresult_response_body_types_gen.go.txt
@@ -16,12 +16,25 @@ func NewGetTestKindSearchResultBody() *GetTestKindSearchResultBody {
 }
 
 // +k8s:openapi-gen=true
+type V3GetTestKindSearchResultBodyItemsList struct {
+	Foo string `json:"foo"`
+}
+
+// NewV3GetTestKindSearchResultBodyItemsList creates a new V3GetTestKindSearchResultBodyItemsList object.
+func NewV3GetTestKindSearchResultBodyItemsList() *V3GetTestKindSearchResultBodyItemsList {
+	return &V3GetTestKindSearchResultBodyItemsList{}
+}
+
+// +k8s:openapi-gen=true
 type V3GetTestKindSearchResultBodyItems struct {
-	Name  string  `json:"name"`
-	Score float64 `json:"score"`
+	Name  string                                   `json:"name"`
+	Score float64                                  `json:"score"`
+	List  []V3GetTestKindSearchResultBodyItemsList `json:"list"`
 }
 
 // NewV3GetTestKindSearchResultBodyItems creates a new V3GetTestKindSearchResultBodyItems object.
 func NewV3GetTestKindSearchResultBodyItems() *V3GetTestKindSearchResultBodyItems {
-	return &V3GetTestKindSearchResultBodyItems{}
+	return &V3GetTestKindSearchResultBodyItems{
+		List: []V3GetTestKindSearchResultBodyItemsList{},
+	}
 }

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
@@ -449,9 +449,25 @@
                                                                     "type": "object",
                                                                     "required": [
                                                                         "name",
-                                                                        "score"
+                                                                        "score",
+                                                                        "list"
                                                                     ],
                                                                     "properties": {
+                                                                        "list": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "required": [
+                                                                                    "foo"
+                                                                                ],
+                                                                                "properties": {
+                                                                                    "foo": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "additionalProperties": false
+                                                                            }
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         },

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
@@ -287,6 +287,16 @@ spec:
                           items:
                             additionalProperties: false
                             properties:
+                              list:
+                                items:
+                                  additionalProperties: false
+                                  properties:
+                                    foo:
+                                      type: string
+                                  required:
+                                  - foo
+                                  type: object
+                                type: array
                               name:
                                 type: string
                               score:
@@ -294,6 +304,7 @@ spec:
                             required:
                             - name
                             - score
+                            - list
                             type: object
                           type: array
                         kind:


### PR DESCRIPTION
## What Changed? Why?

When go manifest files are generated, custom resource routes are constructed in the go code. When a field in the `SchemaProps` is an array type, `Items` was not being populated despite existing in the source OpenAPI being used to generate the file. This has been remedied so that the `Items` field is now populated.

Additionally, the reference from array items (`$ref`) was not being prefixed the same way other references were, causing it to point to a nonexistent entity. This has also been fixed.

### How was it tested?

Locally, using the `apiserver` example, and added codegen tests for resource routes including an array.

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers
