### PR TITLE
Upgrade generated operator Dockerfile to 1.25

### DIFF
--- a/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
+++ b/cmd/grafana-app-sdk/templates/operator_Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./


### PR DESCRIPTION
The current generated Dockerfile results in a build failure.

```
docker build -t "my-api" -f cmd/operator/Dockerfile .
[+] Building 1.9s (13/17)                                                                                                                                                  docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 382B                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                      1.1s
 => [internal] load metadata for docker.io/library/golang:1.24-alpine                                                                                                                 1.1s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                                                         0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                       0.0s
 => [builder 1/8] FROM docker.io/library/golang:1.24-alpine@sha256:ef75fa8822a4c0fb53a390548b3dc1c39639339ec3373c58f5441117e1ff46ae                                                   0.0s
 => [internal] load build context                                                                                                                                                     0.5s
 => => transferring context: 75.68kB                                                                                                                                                  0.5s
 => [runtime 1/2] FROM docker.io/library/alpine:latest@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62                                                        0.0s
 => CACHED [builder 2/8] WORKDIR /build                                                                                                                                               0.0s
 => CACHED [builder 3/8] COPY go.mod go.sum ./                                                                                                                                        0.0s
 => CACHED [builder 4/8] COPY vendor* ./vendor                                                                                                                                        0.0s
 => ERROR [builder 5/8] RUN test -f vendor/modules.txt || go mod download                                                                                                             0.2s
------
 > [builder 5/8] RUN test -f vendor/modules.txt || go mod download:
0.128 go: go.mod requires go >= 1.25.5 (running go 1.24.11; GOTOOLCHAIN=local)
------
Dockerfile:6
--------------------
   4 |     COPY go.mod go.sum ./
   5 |     COPY vendor* ./vendor
   6 | >>> RUN test -f vendor/modules.txt || go mod download
   7 |
   8 |     COPY cmd cmd
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c test -f vendor/modules.txt || go mod download" did not complete successfully: exit code: 1
make: *** [build/operator] Error 1
```