### PR TITLE
[apiserver] Fix the status strategy to return the kind's scope propererly

### DIFF
--- a/k8s/apiserver/storage.go
+++ b/k8s/apiserver/storage.go
@@ -101,7 +101,7 @@ func matchKindFunc(kind resource.Kind) func(label labels.Selector, field fields.
 }
 
 func newRegistryStatusStoreForKind(scheme *runtime.Scheme, kind resource.Kind, specStore *genericregistry.Store) *StatusREST {
-	strategy := newStatusStrategy(scheme, kind.GroupVersionKind().GroupVersion())
+	strategy := newStatusStrategy(scheme, kind.GroupVersionKind().GroupVersion(), kind.Scope() != resource.ClusterScope)
 	return newStatusREST(specStore, strategy)
 }
 

--- a/k8s/apiserver/strategy.go
+++ b/k8s/apiserver/strategy.go
@@ -127,16 +127,17 @@ type genericStatusStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 
-	gv schema.GroupVersion
+	gv         schema.GroupVersion
+	namespaced bool
 }
 
 // NewStatusStrategy creates a new genericStatusStrategy.
-func newStatusStrategy(typer runtime.ObjectTyper, gv schema.GroupVersion) *genericStatusStrategy {
-	return &genericStatusStrategy{typer, names.SimpleNameGenerator, gv}
+func newStatusStrategy(typer runtime.ObjectTyper, gv schema.GroupVersion, namespaced bool) *genericStatusStrategy {
+	return &genericStatusStrategy{typer, names.SimpleNameGenerator, gv, namespaced}
 }
 
-func (*genericStatusStrategy) NamespaceScoped() bool {
-	return true
+func (g *genericStatusStrategy) NamespaceScoped() bool {
+	return g.namespaced
 }
 
 func (g *genericStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {


### PR DESCRIPTION
## What Changed? Why?

[apiserver] Fix the status strategy to return the kind's scope properly in NamespaceScoped(), matching the generic subresource strategy logic. Without this fix, cluster-scoped resources will have errors when updating the status, as the strategy will require a namespace when non can be provided.
