### PR TITLE
[apiserver] Fix bug with multiple calls to GetOpenAPIDefinitions for custom routes

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -1420,7 +1420,7 @@ func copySpec3Parameter(param *spec3.Parameter) *spec3.Parameter {
 	}
 	if param.Schema != nil {
 		schCpy := copySpecSchema(param.Schema)
-		param.Schema = &schCpy
+		cpy.Schema = &schCpy
 	}
 	if param.Content != nil {
 		cpy.Content = make(map[string]*spec3.MediaType)


### PR DESCRIPTION
## What Changed? Why?

[apiserver] Fix bug where multiple calls to GetOpenAPIDefinitions would result in custom route schemas with incorrect refs, due to both kubernetes mutating the OpenAPI objects and also the GetOpenAPIDefinitions mutating the objects. This is resolved by always copying the underlying source OpenAPI Spec and Operation objects before performing any actions on them and returning those copies, the same way non-custom-routes handles this.

### How was it tested?

Tested on [this PR which currently experiences the bug](https://github.com/grafana/grafana/pull/117041).

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers

This PR is targeting the `plugin-release/v0.49.0` branch so that a patch version for `v0.49.0` can be released without the changes in `main` with the `k8s.io` upgrades. Another PR will be made to main for this fix as well once this is merged.
