### PR TITLE
[apiserver] Fix bug with multiple calls to GetOpenAPIDefinitions for custom routes

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -250,8 +250,21 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 		return nil, err
 	}
 
+	goModule := cfg.Codegen.GoModule
+	if goModule == "" {
+		goModule, err = getGoModule("go.mod")
+		if err != nil {
+			return nil, fmt.Errorf("unable to load go module from ./go.mod: %w. Set config.codegen.goModule with a value", err)
+		}
+	}
+
+	goModGenPath := cfg.Codegen.GoModGenPath
+	if goModGenPath == "" {
+		goModGenPath = cfg.Codegen.GoGenPath
+	}
+
 	// Resource
-	resourceFiles, err := generatorForKinds.Generate(cuekind.ResourceGenerator(cfg.Codegen.GoModule, cfg.Codegen.GoModGenPath, cfg.GroupKinds()), cfg.ManifestSelectors...)
+	resourceFiles, err := generatorForKinds.Generate(cuekind.ResourceGenerator(goModule, goModGenPath, cfg.GroupKinds()), cfg.ManifestSelectors...)
 	if err != nil {
 		return nil, err
 	}
@@ -281,19 +294,6 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 		for i, f := range crdFiles {
 			crdFiles[i].RelativePath = filepath.Join(cfg.Definitions.Path, f.RelativePath)
 		}
-	}
-
-	goModule := cfg.Codegen.GoModule
-	if goModule == "" {
-		goModule, err = getGoModule("go.mod")
-		if err != nil {
-			return nil, fmt.Errorf("unable to load go module from ./go.mod: %w. Set config.codegen.goModule with a value", err)
-		}
-	}
-
-	goModGenPath := cfg.Codegen.GoModGenPath
-	if goModGenPath == "" {
-		goModGenPath = cfg.Codegen.GoGenPath
 	}
 
 	// Backwards-compatibility for manifests written to the base generated path

--- a/examples/apiserver/apis/example/v0alpha1/testkind_client_gen.go
+++ b/examples/apiserver/apis/example/v0alpha1/testkind_client_gen.go
@@ -3,9 +3,8 @@ package v0alpha1
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type TestKindClient struct {

--- a/examples/apiserver/apis/example/v1alpha1/getfoobar_request_body_types_gen.go
+++ b/examples/apiserver/apis/example/v1alpha1/getfoobar_request_body_types_gen.go
@@ -4,12 +4,24 @@ package v1alpha1
 
 // Test type for go naming conflicts
 type GetFoobarRequestSharedType struct {
-	Bar string `json:"bar"`
+	Bar string                          `json:"bar"`
+	Dep []GetFoobarRequestSharedTypeDep `json:"dep"`
 }
 
 // NewGetFoobarRequestSharedType creates a new GetFoobarRequestSharedType object.
 func NewGetFoobarRequestSharedType() *GetFoobarRequestSharedType {
-	return &GetFoobarRequestSharedType{}
+	return &GetFoobarRequestSharedType{
+		Dep: []GetFoobarRequestSharedTypeDep{},
+	}
+}
+
+type GetFoobarRequestSharedTypeDep struct {
+	Value string `json:"value"`
+}
+
+// NewGetFoobarRequestSharedTypeDep creates a new GetFoobarRequestSharedTypeDep object.
+func NewGetFoobarRequestSharedTypeDep() *GetFoobarRequestSharedTypeDep {
+	return &GetFoobarRequestSharedTypeDep{}
 }
 
 type GetFoobarRequestBody struct {
@@ -25,6 +37,9 @@ func NewGetFoobarRequestBody() *GetFoobarRequestBody {
 }
 func (GetFoobarRequestSharedType) OpenAPIModelName() string {
 	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarRequestSharedType"
+}
+func (GetFoobarRequestSharedTypeDep) OpenAPIModelName() string {
+	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarRequestSharedTypeDep"
 }
 func (GetFoobarRequestBody) OpenAPIModelName() string {
 	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarRequestBody"

--- a/examples/apiserver/apis/example/v1alpha1/getfoobar_response_body_types_gen.go
+++ b/examples/apiserver/apis/example/v1alpha1/getfoobar_response_body_types_gen.go
@@ -5,12 +5,25 @@ package v1alpha1
 // Test type for go naming conflicts
 // +k8s:openapi-gen=true
 type GetFoobarSharedType struct {
-	Bar string `json:"bar"`
+	Bar string                   `json:"bar"`
+	Dep []GetFoobarSharedTypeDep `json:"dep"`
 }
 
 // NewGetFoobarSharedType creates a new GetFoobarSharedType object.
 func NewGetFoobarSharedType() *GetFoobarSharedType {
-	return &GetFoobarSharedType{}
+	return &GetFoobarSharedType{
+		Dep: []GetFoobarSharedTypeDep{},
+	}
+}
+
+// +k8s:openapi-gen=true
+type GetFoobarSharedTypeDep struct {
+	Value string `json:"value"`
+}
+
+// NewGetFoobarSharedTypeDep creates a new GetFoobarSharedTypeDep object.
+func NewGetFoobarSharedTypeDep() *GetFoobarSharedTypeDep {
+	return &GetFoobarSharedTypeDep{}
 }
 
 // +k8s:openapi-gen=true
@@ -27,6 +40,9 @@ func NewGetFoobarBody() *GetFoobarBody {
 }
 func (GetFoobarSharedType) OpenAPIModelName() string {
 	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarSharedType"
+}
+func (GetFoobarSharedTypeDep) OpenAPIModelName() string {
+	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarSharedTypeDep"
 }
 func (GetFoobarBody) OpenAPIModelName() string {
 	return "com.github.grafana.grafana-app-sdk.examples.apiserver.apis.example.v1alpha1.GetFoobarBody"

--- a/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
+++ b/examples/apiserver/apis/example/v1alpha1/testkind_client_gen.go
@@ -9,9 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type TestKindClient struct {

--- a/examples/apiserver/apis/example_manifest.go
+++ b/examples/apiserver/apis/example_manifest.go
@@ -672,9 +672,37 @@ var appManifestData = app.ManifestData{
 										Type: []string{"string"},
 									},
 								},
+								"dep": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+
+													Ref: spec.MustCreateRef("#/components/schemas/getFoobarSharedTypeDep"),
+												}},
+										},
+									},
+								},
 							},
 							Required: []string{
 								"bar",
+								"dep",
+							},
+						},
+					},
+					"getFoobarSharedTypeDep": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"value": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+							},
+							Required: []string{
+								"value",
 							},
 						},
 					},

--- a/examples/apiserver/kinds/manifest.cue
+++ b/examples/apiserver/kinds/manifest.cue
@@ -139,4 +139,9 @@ v2alpha1: {
 // Test type for go naming conflicts
 #SharedType: {
 	bar: string
+	dep: [...#SharedTypeDep]
+}
+
+#SharedTypeDep: {
+	value: string
 }


### PR DESCRIPTION
## What Changed? Why?

This PR duplicates https://github.com/grafana/grafana-app-sdk/pull/1200 into `main`, with the addition of `examples/apiserver` updates which failed under the previous logic, and a fix to `grafana-app-sdk generate` to use the correct go module and path for the OpenAPI Name when unspecified.

Original PR Description:

[apiserver] Fix bug where multiple calls to GetOpenAPIDefinitions would result in custom route schemas with incorrect refs, due to both kubernetes mutating the OpenAPI objects and also the GetOpenAPIDefinitions mutating the objects. This is resolved by always copying the underlying source OpenAPI Spec and Operation objects before performing any actions on them and returning those copies, the same way non-custom-routes handles this.

### How was it tested?

Locally using the `examples/apiserver` example.

### Where did you document your changes?

N/A - bugfix

### Notes to Reviewers
