### PR TITLE
Rename AppManifest API group from apps.grafana.com to apps.grafana.app

### DIFF
--- a/app/appmanifest/v1alpha1/appmanifest_schema_gen.go
+++ b/app/appmanifest/v1alpha1/appmanifest_schema_gen.go
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaAppManifest = resource.NewSimpleSchema("apps.grafana.com", "v1alpha1", NewAppManifest(), &AppManifestList{}, resource.WithKind("AppManifest"),
+	schemaAppManifest = resource.NewSimpleSchema("apps.grafana.app", "v1alpha1", NewAppManifest(), &AppManifestList{}, resource.WithKind("AppManifest"),
 		resource.WithPlural("appmanifests"), resource.WithScope(resource.ClusterScope))
 	kindAppManifest = resource.Kind{
 		Schema: schemaAppManifest,

--- a/app/appmanifest/v1alpha1/constants.go
+++ b/app/appmanifest/v1alpha1/constants.go
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "apps.grafana.com"
+	APIGroup = "apps.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v1alpha1"
 )

--- a/app/appmanifest/v1alpha1/generated_code_test.go
+++ b/app/appmanifest/v1alpha1/generated_code_test.go
@@ -37,7 +37,7 @@ func TestAppManifestKind_Read(t *testing.T) {
 	assert.Equal(t, &AppManifest{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppManifest",
-			APIVersion: "apps.grafana.com/v1alpha1",
+			APIVersion: "apps.grafana.app/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "issue-tracker-project",
@@ -93,14 +93,14 @@ func TestAppManifestKind_Write(t *testing.T) {
 
 func TestAppManifestKind_GroupVersionKind(t *testing.T) {
 	kind := AppManifestKind()
-	assert.Equal(t, "apps.grafana.com", kind.GroupVersionKind().Group)
+	assert.Equal(t, "apps.grafana.app", kind.GroupVersionKind().Group)
 	assert.Equal(t, "v1alpha1", kind.GroupVersionKind().Version)
 	assert.Equal(t, "AppManifest", kind.GroupVersionKind().Kind)
 }
 
 func TestAppManifestKind_GroupVersionResource(t *testing.T) {
 	kind := AppManifestKind()
-	assert.Equal(t, "apps.grafana.com", kind.GroupVersionResource().Group)
+	assert.Equal(t, "apps.grafana.app", kind.GroupVersionResource().Group)
 	assert.Equal(t, "v1alpha1", kind.GroupVersionResource().Version)
 	assert.Equal(t, "appmanifests", kind.GroupVersionResource().Resource)
 }

--- a/app/appmanifest/v1alpha1/testfiles/manifest-01.json
+++ b/app/appmanifest/v1alpha1/testfiles/manifest-01.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "apps.grafana.com/v1alpha1",
+  "apiVersion": "apps.grafana.app/v1alpha1",
   "kind": "AppManifest",
   "metadata": {
     "name": "issue-tracker-project",

--- a/app/appmanifest/v1alpha2/appmanifest_schema_gen.go
+++ b/app/appmanifest/v1alpha2/appmanifest_schema_gen.go
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaAppManifest = resource.NewSimpleSchema("apps.grafana.com", "v1alpha2", NewAppManifest(), &AppManifestList{}, resource.WithKind("AppManifest"),
+	schemaAppManifest = resource.NewSimpleSchema("apps.grafana.app", "v1alpha2", NewAppManifest(), &AppManifestList{}, resource.WithKind("AppManifest"),
 		resource.WithPlural("appmanifests"), resource.WithScope(resource.ClusterScope))
 	kindAppManifest = resource.Kind{
 		Schema: schemaAppManifest,

--- a/app/appmanifest/v1alpha2/constants.go
+++ b/app/appmanifest/v1alpha2/constants.go
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "apps.grafana.com"
+	APIGroup = "apps.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v1alpha2"
 )

--- a/app/appmanifest/v1alpha2/generated_code_test.go
+++ b/app/appmanifest/v1alpha2/generated_code_test.go
@@ -37,7 +37,7 @@ func TestAppManifestKind_Read(t *testing.T) {
 	assert.Equal(t, &AppManifest{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppManifest",
-			APIVersion: "apps.grafana.com/v1alpha2",
+			APIVersion: "apps.grafana.app/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "issue-tracker-project",
@@ -93,14 +93,14 @@ func TestAppManifestKind_Write(t *testing.T) {
 
 func TestAppManifestKind_GroupVersionKind(t *testing.T) {
 	kind := AppManifestKind()
-	assert.Equal(t, "apps.grafana.com", kind.GroupVersionKind().Group)
+	assert.Equal(t, "apps.grafana.app", kind.GroupVersionKind().Group)
 	assert.Equal(t, "v1alpha2", kind.GroupVersionKind().Version)
 	assert.Equal(t, "AppManifest", kind.GroupVersionKind().Kind)
 }
 
 func TestAppManifestKind_GroupVersionResource(t *testing.T) {
 	kind := AppManifestKind()
-	assert.Equal(t, "apps.grafana.com", kind.GroupVersionResource().Group)
+	assert.Equal(t, "apps.grafana.app", kind.GroupVersionResource().Group)
 	assert.Equal(t, "v1alpha2", kind.GroupVersionResource().Version)
 	assert.Equal(t, "appmanifests", kind.GroupVersionResource().Resource)
 }

--- a/app/appmanifest/v1alpha2/testfiles/manifest-01.json
+++ b/app/appmanifest/v1alpha2/testfiles/manifest-01.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "apps.grafana.com/v1alpha2",
+  "apiVersion": "apps.grafana.app/v1alpha2",
   "kind": "AppManifest",
   "metadata": {
     "name": "issue-tracker-project",

--- a/app/definitions/app-manifest-manifest.json
+++ b/app/definitions/app-manifest-manifest.json
@@ -1,12 +1,12 @@
 {
-    "apiVersion": "apps.grafana.com/v1alpha2",
+    "apiVersion": "apps.grafana.app/v1alpha2",
     "kind": "AppManifest",
     "metadata": {
         "name": "app-manifest"
     },
     "spec": {
         "appName": "app-manifest",
-        "group": "apps.grafana.com",
+        "group": "apps.grafana.app",
         "versions": [
             {
                 "name": "v1alpha1",

--- a/app/definitions/appmanifest.apps.grafana.app.json
+++ b/app/definitions/appmanifest.apps.grafana.app.json
@@ -2,10 +2,10 @@
     "kind": "CustomResourceDefinition",
     "apiVersion": "apiextensions.k8s.io/v1",
     "metadata": {
-        "name": "appmanifests.apps.grafana.com"
+        "name": "appmanifests.apps.grafana.app"
     },
     "spec": {
-        "group": "apps.grafana.com",
+        "group": "apps.grafana.app",
         "versions": [
             {
                 "name": "v1alpha1",

--- a/app/manifest.cue
+++ b/app/manifest.cue
@@ -14,7 +14,7 @@ config: {
 
 manifest: {
 	appName: "app-manifest"
-	groupOverride: "apps.grafana.com"
+	groupOverride: "apps.grafana.app"
 	versions: {
 		"v1alpha1": {
 			codegen: ts: enabled: false

--- a/app/manifestdata/appmanifest_manifest.go
+++ b/app/manifestdata/appmanifest_manifest.go
@@ -31,7 +31,7 @@ var (
 
 var appManifestData = app.ManifestData{
 	AppName:          "app-manifest",
-	Group:            "apps.grafana.com",
+	Group:            "apps.grafana.app",
 	PreferredVersion: "v1alpha2",
 	Versions: []app.ManifestVersion{
 		{

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "apps.grafana.com/v1alpha1",
+    "apiVersion": "apps.grafana.app/v1alpha1",
     "kind": "AppManifest",
     "metadata": {
         "name": "custom-app"

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
@@ -1,4 +1,4 @@
-apiVersion: apps.grafana.com/v1alpha1
+apiVersion: apps.grafana.app/v1alpha1
 kind: AppManifest
 metadata:
   name: custom-app

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "apps.grafana.com/v1alpha1",
+    "apiVersion": "apps.grafana.app/v1alpha1",
     "kind": "AppManifest",
     "metadata": {
         "name": "test-app"

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
@@ -1,4 +1,4 @@
-apiVersion: apps.grafana.com/v1alpha1
+apiVersion: apps.grafana.app/v1alpha1
 kind: AppManifest
 metadata:
   name: test-app

--- a/docs/app-manifest.md
+++ b/docs/app-manifest.md
@@ -8,7 +8,7 @@ This data is primarily split into three groups:
 
 The manifest is a kubernetes object, and a complete one looks something like this:
 ```yaml
-apiVersion: apps.grafana.com/v1alpha1
+apiVersion: apps.grafana.app/v1alpha1
 kind: AppManifest
 metadata:
   name: issue-tracker-project


### PR DESCRIPTION
## Summary

Renames the API group used by the AppManifest CRD from `apps.grafana.com` to `apps.grafana.app`.

## What

- Updated `groupOverride` in `app/manifest.cue` (source of truth) from `apps.grafana.com` to `apps.grafana.app`
- Regenerated all generated code via `make generate`:
  - Go constants, schemas, codecs, and client code
  - CRD JSON definition (renamed file: `appmanifest.apps.grafana.app.json`)
  - Manifest JSON definition
- Updated hand-written test files:
  - `app/appmanifest/v1alpha1/generated_code_test.go` (3 assertions)
  - `app/appmanifest/v1alpha2/generated_code_test.go` (3 assertions)
  - Test fixture JSON files in `testfiles/`
- Regenerated golden test files via `make regenerate-codegen-test-files`
- Updated documentation in `docs/app-manifest.md`

## Why

Aligning the API group naming to use `.app` instead of `.com` for consistency with Grafana's domain conventions.

## Test plan

- [x] `make lint` - passes with 0 issues
- [x] `make test` - all tests pass (v1alpha1 and v1alpha2 packages verified)
- [x] Verified no remaining references to `apps.grafana.com` in codebase
- [x] New CRD file created with correct naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)