### PR TITLE
[codegen] Only add the OpenAPIModelName function to valid recievers

### DIFF
--- a/codegen/templates/custom/OpenAPIModelName.tmpl
+++ b/codegen/templates/custom/OpenAPIModelName.tmpl
@@ -1,7 +1,9 @@
 {{- define "object_all_custom_methods" -}}
 {{ $objName := .Object.Name|formatObjectName }}
+{{- if or .Object.Type.Struct .Object.Type.Enum .Object.Type.Map -}}
 // OpenAPIModelName returns the OpenAPI model name for {{ $objName }}.
 func ({{ $objName }}) OpenAPIModelName() string {
 	return "{{ namerFunc $objName }}"
 }
+{{- end -}}
 {{- end -}}

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
@@ -49,11 +49,6 @@ func (CustomKindInnerObject2) OpenAPIModelName() string {
 // +k8s:openapi-gen=true
 type CustomKindUnionType interface{}
 
-// OpenAPIModelName returns the OpenAPI model name for CustomKindUnionType.
-func (CustomKindUnionType) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindUnionType"
-}
-
 // +k8s:openapi-gen=true
 type CustomKindType1 struct {
 	Group   string   `json:"group"`

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
@@ -49,11 +49,6 @@ func (InnerObject2) OpenAPIModelName() string {
 // +k8s:openapi-gen=true
 type UnionType interface{}
 
-// OpenAPIModelName returns the OpenAPI model name for UnionType.
-func (UnionType) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customkind.v1_0.UnionType"
-}
-
 // +k8s:openapi-gen=true
 type Type1 struct {
 	Group   string   `json:"group"`


### PR DESCRIPTION
## What Changed? Why?

[codegen] Only add the OpenAPIModelName function to structs, enums (which are string types), and map types. Other types, such as scalar or disjunction, become 'interface{}' and cannot have methods attached to them.

### How was it tested?

Codegen test output shows the function removed from the `UnionType` and `CustomKindUnionType` types, which are `interface{}` and can't have receiver methods.

### Where did you document your changes?

### Notes to Reviewers
