### PR TITLE
Use hard-coded manifest config in local generation manifest generator

### DIFF
--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -915,9 +915,9 @@ func updateLocalConfigFromManifest(envCfg *localEnvConfig, baseConfig *config.Co
 		}
 
 		fs, err := generator.Generate(cuekind.ManifestGenerator(
-			cfg.Definitions.Encoding,
-			cfg.Definitions.ManifestSchemas,
-			cfg.Definitions.ManifestVersion),
+			"json",
+			false,
+			"v1alpha1"),
 			cfg.ManifestSelectors...,
 		)
 		if err != nil {


### PR DESCRIPTION
## What Changed? Why?

Use hard-coded manifest config in local generation manifest generator, as it is expected to be a certain format.

Currently, it uses the values from the loaded config, which can result in broken local generation, and if the config definition information isn't specified, a nil pointer panic.

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
