### PR TITLE
[apiserver] Fix OpenAPI reference replacement when the root object is an array

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -1062,6 +1062,10 @@ func (r *defaultInstaller) replaceReferencesInSchema(sch *spec.Schema, ref commo
 		d := r.replaceReferencesInSchema(sch.AdditionalProperties.Schema, ref, replaceFunc)
 		deps = append(deps, d...)
 	}
+	if sch.Items != nil && sch.Items.Schema != nil {
+		d := r.replaceReferencesInSchema(sch.Items.Schema, ref, replaceFunc)
+		deps = append(deps, d...)
+	}
 	return deps
 }
 


### PR DESCRIPTION
## What Changed? Why?

[apiserver] Fix OpenAPI reference replacement when the root object is an array type. OpenAPI for types which are themselves an array (rather than having an entry in `properties` that is an array) were not getting their `$ref` properly replaced to the fully-qualified reference.

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
