### PR TITLE
Fix nil pointer panic when no rolebindings are present when roles are

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -293,6 +293,9 @@ func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.Manifes
 			bindings = &defaultBindings
 		}
 	}
+	if bindings == nil {
+		bindings = &codegen.AppManifestPropertiesRoleBindings{}
+	}
 	manifest.Roles = make(map[string]app.ManifestRole)
 	for k, v := range roles {
 		converted := app.ManifestRole{


### PR DESCRIPTION
## What Changed? Why?

Fix nil pointer panic when no rolebindings are present when roles are (roles can be set to an empty map)

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
