### PR TITLE
[codegen] Don't validate role subresources when not generating manifest schemas

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -452,6 +452,7 @@ func getRouteNames(p *spec3.PathProps) []string {
 	return routes
 }
 
+//nolint:revive
 func validateManifestRoles(manifest app.ManifestData, checkSubresources bool) error {
 	kinds := make(map[string]struct{})
 	routes := make(map[string]struct{})


### PR DESCRIPTION
## What Changed? Why?

[codegen] Don't validate role subresources when not generating manifest schemas, as when schemas aren't in the manifest, we can't check if a subresource exists (because we have no schema for the kind).

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
