### PR TITLE
[apiserver] Set a default 'produces' in created WebServices

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -122,7 +122,7 @@ func (k *KubernetesGenericAPIServer) InstallAPIGroup(apiGroupInfo *genericapiser
 		}
 		if !found {
 			ws := new(restful.WebService)
-			ws.Path(fmt.Sprintf("/apis/%s/%s", gv.Group, gv.Version))
+			ws.Path(fmt.Sprintf("/apis/%s/%s", gv.Group, gv.Version)).Produces("application/json")
 			k.Handler.GoRestfulContainer.Add(ws)
 		}
 	}


### PR DESCRIPTION
## What Changed? Why?

[apiserver] Set a default 'produces' in created WebServices so that attached routes will still have responses if no 'produces' is present. Currently, routes for apps' versions which have no kinds need to create a WebService for the APIGroup and version, and the created WebService doesn't have any default `Produces` value. WebServices created by k8s when installing kinds automatically populate this field, and it is inherited in all attached routes. Since app-sdk routes don't specify a Produces, if they are attached to a WebService created by the app-sdk and not k8s, they have no produced MIME types and k8s doesn't include a response body in the generated OpenAPI.

Longer-term, we should also allow an app author to specify a set of MIME types their custom routes produce, which can be used with `Produces` on the route builder to overwrite the default.

### How was it tested?

Tested against the quotas app in grafana, which has no kinds and had OpenAPI that did not include the schema in their route responses.

### Where did you document your changes?

### Notes to Reviewers
