### PR TITLE
[codegen] If rolebindings are absent in the codegen, don't include in generated manifest

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -293,9 +293,6 @@ func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.Manifes
 			bindings = &defaultBindings
 		}
 	}
-	if bindings == nil {
-		bindings = &codegen.AppManifestPropertiesRoleBindings{}
-	}
 	manifest.Roles = make(map[string]app.ManifestRole)
 	for k, v := range roles {
 		converted := app.ManifestRole{
@@ -314,11 +311,13 @@ func buildManifestData(m codegen.AppManifest, includeSchemas bool) (*app.Manifes
 		copy(converted.Routes, v.Routes)
 		manifest.Roles[k] = converted
 	}
-	manifest.RoleBindings = &app.ManifestRoleBindings{
-		Viewer:     bindings.Viewer,
-		Editor:     bindings.Editor,
-		Admin:      bindings.Admin,
-		Additional: bindings.Additional,
+	if bindings != nil {
+		manifest.RoleBindings = &app.ManifestRoleBindings{
+			Viewer:     bindings.Viewer,
+			Editor:     bindings.Editor,
+			Admin:      bindings.Admin,
+			Additional: bindings.Additional,
+		}
 	}
 
 	return &manifest, validateManifestRoles(manifest, includeSchemas)


### PR DESCRIPTION
## What Changed? Why?

[codegen] If rolebindings are absent in the codegen, don't create empty ones for generated manifest (leave them nil).

This allows there to be no diff in codegen if `roles: {}` when upgrading app-sdk versions. Otherwise, an empty set of RoleBindings is created, which is also not technically correct, as RoleBindings should be nil in the manifest due to being absent.

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
