### PR TITLE
[codegen] Run format.Source on all generated Go files

### DIFF
--- a/codegen/jennies/backendplugin.go
+++ b/codegen/jennies/backendplugin.go
@@ -2,6 +2,7 @@ package jennies
 
 import (
 	"bytes"
+	"go/format"
 	"strings"
 
 	"github.com/grafana/codejen"
@@ -46,7 +47,11 @@ func (m *backendPluginMainGenerator) Generate(decls ...codegen.Kind) (*codejen.F
 	if err != nil {
 		return nil, err
 	}
-	return codejen.NewFile("../plugin/pkg/main.go", b.Bytes(), m), nil
+	formatted, err := format.Source(b.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return codejen.NewFile("../plugin/pkg/main.go", formatted, m), nil
 }
 
 func (*backendPluginMainGenerator) JennyName() string {

--- a/codegen/jennies/gotypes.go
+++ b/codegen/jennies/gotypes.go
@@ -3,6 +3,7 @@ package jennies
 import (
 	"context"
 	"fmt"
+	"go/format"
 	"path"
 	"strings"
 
@@ -138,8 +139,13 @@ func (g *GoTypes) generateFiles(kind codegen.Kind, version *codegen.KindVersion,
 		return nil, fmt.Errorf("expected one file to be generated, got %d", len(files))
 	}
 
+	formatted, err := format.Source(files[0].Data)
+	if err != nil {
+		return nil, err
+	}
+
 	return codejen.Files{codejen.File{
-		Data:         files[0].Data,
+		Data:         formatted,
 		RelativePath: fmt.Sprintf(path.Join(pathPrefix, "%s_gen.go"), strings.ToLower(machineName)),
 		From:         []codejen.NamedJenny{g},
 	}}, nil
@@ -270,7 +276,12 @@ func GoTypesFromCUE(v cue.Value, cfg CUEGoConfig, maxNamingDepth int, namerFunc 
 		return nil, fmt.Errorf("expected one file to be generated, got %d", len(files))
 	}
 
-	return files[0].Data, nil
+	formatted, err := format.Source(files[0].Data)
+	if err != nil {
+		return nil, err
+	}
+
+	return formatted, nil
 }
 
 // SanitizeLabelString strips characters from a string that are not allowed for

--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -146,7 +146,7 @@ VendorExtensible: spec.VendorExtensible{
     },
 },{{ end }}{{ end }}
 
-{{- if .ManifestData.Versions }}
+{{- if .HasVersionSchemas }}
 var ({{ range .ManifestData.Versions }}{{$v:=.}}{{ range .Kinds }}{{ if .Schema }}
     rawSchema{{.Kind}}{{$.ToPackageName $v.Name}} = []byte({{$.ToJSONBacktickString .Schema}})
     versionSchema{{.Kind}}{{$.ToPackageName $v.Name}} app.VersionSchema

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -514,6 +514,19 @@ func (ManifestGoFileMetadata) StripLeadingSlash(path string) string {
 	return path
 }
 
+// HasVersionSchemas returns true if any kind in any version has a non-nil schema.
+// Used by the manifest Go template to avoid emitting an empty var () block.
+func (m ManifestGoFileMetadata) HasVersionSchemas() bool {
+	for _, v := range m.ManifestData.Versions {
+		for _, k := range v.Kinds {
+			if k.Schema != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func WriteManifestGoFile(metadata ManifestGoFileMetadata, out io.Writer) error {
 	return templateManifestGoFile.Execute(out, metadata)
 }


### PR DESCRIPTION
## What Changed? Why?

Ensure every jenny that produces Go files runs go/format.Source before returning the file, so output is always properly `gofmt`'d:

- backendplugin.go: apply format.Source to template output
- gotypes.go: apply format.Source to cog pipeline output (both depth=0 and depth>0 paths via GoTypesFromCUE)

Also fix the manifest Go template emitting an empty var () block when IncludeSchemas is false. format.Source accepts this as valid syntax, so the real fix is in the template: guard the var block with HasVersionSchemas() instead of just checking if any versions exist.

Authored by claude code.

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
