### PR TITLE
Allow adding collectors to OpinionatedWatcher and OpinionatedReconciler

### DIFF
--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -393,6 +393,13 @@ func (*OpinionatedWatcher) Delete(context.Context, resource.Object) error {
 	return nil
 }
 
+// RegisterMetricsCollectors registers additional prometheus collectors for the OpinionatedWatcher,
+// in addition to those provided by any wrapped ResourceWatcher via Wrap().
+// These additional prometheus collectors are exposed as a part of the list returned by PrometheusCollectors().
+func (o *OpinionatedWatcher) RegisterMetricsCollectors(collectors ...prometheus.Collector) {
+	o.collectors = append(o.collectors, collectors...)
+}
+
 func (o *OpinionatedWatcher) PrometheusCollectors() []prometheus.Collector {
 	return o.collectors
 }

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,6 +104,77 @@ func TestOpinionatedWatcher_Wrap(t *testing.T) {
 		assert.NotNil(t, w.UpdateFunc)
 		assert.NotNil(t, w.DeleteFunc)
 		assert.NotNil(t, w.SyncFunc)
+	})
+}
+
+type metricsSimpleWatcher struct {
+	SimpleWatcher
+	collectors []prometheus.Collector
+}
+
+func (m *metricsSimpleWatcher) PrometheusCollectors() []prometheus.Collector {
+	return m.collectors
+}
+
+func TestOpinionatedWatcher_RegisterMetricsCollectors(t *testing.T) {
+	t.Run("register collectors directly", func(t *testing.T) {
+		w, err := NewOpinionatedWatcher(resource.NewSimpleSchema("", "", &resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{}), &mockPatchClient{}, OpinionatedWatcherConfig{})
+		require.NoError(t, err)
+
+		c1 := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter_1", Help: "test"})
+		c2 := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_gauge_1", Help: "test"})
+
+		w.RegisterMetricsCollectors(c1, c2)
+
+		collectors := w.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, c1)
+		assert.Contains(t, collectors, c2)
+	})
+
+	t.Run("additive calls", func(t *testing.T) {
+		w, err := NewOpinionatedWatcher(resource.NewSimpleSchema("", "", &resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{}), &mockPatchClient{}, OpinionatedWatcherConfig{})
+		require.NoError(t, err)
+
+		c1 := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter_2", Help: "test"})
+		c2 := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_gauge_2", Help: "test"})
+
+		w.RegisterMetricsCollectors(c1)
+		w.RegisterMetricsCollectors(c2)
+
+		collectors := w.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, c1)
+		assert.Contains(t, collectors, c2)
+	})
+
+	t.Run("combined with Wrap", func(t *testing.T) {
+		w, err := NewOpinionatedWatcher(resource.NewSimpleSchema("", "", &resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{}), &mockPatchClient{}, OpinionatedWatcherConfig{})
+		require.NoError(t, err)
+
+		wrapperCollector := prometheus.NewCounter(prometheus.CounterOpts{Name: "wrapper_counter", Help: "test"})
+		watcher := &metricsSimpleWatcher{
+			collectors: []prometheus.Collector{wrapperCollector},
+		}
+		w.Wrap(watcher, false)
+
+		directCollector := prometheus.NewGauge(prometheus.GaugeOpts{Name: "direct_gauge", Help: "test"})
+		w.RegisterMetricsCollectors(directCollector)
+
+		collectors := w.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, wrapperCollector)
+		assert.Contains(t, collectors, directCollector)
+	})
+
+	t.Run("no-op with no arguments", func(t *testing.T) {
+		w, err := NewOpinionatedWatcher(resource.NewSimpleSchema("", "", &resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{}), &mockPatchClient{}, OpinionatedWatcherConfig{})
+		require.NoError(t, err)
+
+		w.RegisterMetricsCollectors()
+
+		collectors := w.PrometheusCollectors()
+		assert.Empty(t, collectors)
 	})
 }
 

--- a/operator/reconciler.go
+++ b/operator/reconciler.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/metrics"
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
@@ -137,6 +139,7 @@ func NewOpinionatedReconciler(client PatchClient, finalizer string) (*Opinionate
 	return &OpinionatedReconciler{
 		finalizer:        finalizer,
 		finalizerUpdater: newFinalizerUpdater(client),
+		collectors:       make([]prometheus.Collector, 0),
 	}, nil
 }
 
@@ -147,6 +150,7 @@ type OpinionatedReconciler struct {
 	Reconciler       Reconciler
 	finalizer        string
 	finalizerUpdater FinalizerUpdater
+	collectors       []prometheus.Collector
 }
 
 const (
@@ -284,6 +288,21 @@ func (o *OpinionatedReconciler) wrappedReconcile(ctx context.Context, request Re
 // Wrap wraps the provided Reconciler's Reconcile function with this OpinionatedReconciler
 func (o *OpinionatedReconciler) Wrap(reconciler Reconciler) {
 	o.Reconciler = reconciler
+
+	if cast, ok := reconciler.(metrics.Provider); ok {
+		o.collectors = append(o.collectors, cast.PrometheusCollectors()...)
+	}
+}
+
+// RegisterMetricsCollectors registers additional prometheus collectors for the OpinionatedReconciler,
+// in addition to those provided by any wrapped Reconciler via Wrap().
+// These additional prometheus collectors are exposed as a part of the list returned by PrometheusCollectors().
+func (o *OpinionatedReconciler) RegisterMetricsCollectors(collectors ...prometheus.Collector) {
+	o.collectors = append(o.collectors, collectors...)
+}
+
+func (o *OpinionatedReconciler) PrometheusCollectors() []prometheus.Collector {
+	return o.collectors
 }
 
 // Compile-time interface compliance check

--- a/operator/reconciler_test.go
+++ b/operator/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -560,6 +561,77 @@ func TestOpinionatedReconciler_Wrap(t *testing.T) {
 	res, err := op.Reconciler.Reconcile(ctx, rreq)
 	assert.Nil(t, err)
 	assert.Equal(t, rr, res)
+}
+
+type metricsSimpleReconciler struct {
+	SimpleReconciler
+	collectors []prometheus.Collector
+}
+
+func (m *metricsSimpleReconciler) PrometheusCollectors() []prometheus.Collector {
+	return m.collectors
+}
+
+func TestOpinionatedReconciler_RegisterMetricsCollectors(t *testing.T) {
+	t.Run("register collectors directly", func(t *testing.T) {
+		op, err := NewOpinionatedReconciler(&mockPatchClient{}, "finalizer")
+		require.NoError(t, err)
+
+		c1 := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_reconciler_counter_1", Help: "test"})
+		c2 := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_reconciler_gauge_1", Help: "test"})
+
+		op.RegisterMetricsCollectors(c1, c2)
+
+		collectors := op.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, c1)
+		assert.Contains(t, collectors, c2)
+	})
+
+	t.Run("additive calls", func(t *testing.T) {
+		op, err := NewOpinionatedReconciler(&mockPatchClient{}, "finalizer")
+		require.NoError(t, err)
+
+		c1 := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_reconciler_counter_2", Help: "test"})
+		c2 := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_reconciler_gauge_2", Help: "test"})
+
+		op.RegisterMetricsCollectors(c1)
+		op.RegisterMetricsCollectors(c2)
+
+		collectors := op.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, c1)
+		assert.Contains(t, collectors, c2)
+	})
+
+	t.Run("combined with Wrap", func(t *testing.T) {
+		op, err := NewOpinionatedReconciler(&mockPatchClient{}, "finalizer")
+		require.NoError(t, err)
+
+		wrapperCollector := prometheus.NewCounter(prometheus.CounterOpts{Name: "wrapper_reconciler_counter", Help: "test"})
+		reconciler := &metricsSimpleReconciler{
+			collectors: []prometheus.Collector{wrapperCollector},
+		}
+		op.Wrap(reconciler)
+
+		directCollector := prometheus.NewGauge(prometheus.GaugeOpts{Name: "direct_reconciler_gauge", Help: "test"})
+		op.RegisterMetricsCollectors(directCollector)
+
+		collectors := op.PrometheusCollectors()
+		assert.Len(t, collectors, 2)
+		assert.Contains(t, collectors, wrapperCollector)
+		assert.Contains(t, collectors, directCollector)
+	})
+
+	t.Run("no-op with no arguments", func(t *testing.T) {
+		op, err := NewOpinionatedReconciler(&mockPatchClient{}, "finalizer")
+		require.NoError(t, err)
+
+		op.RegisterMetricsCollectors()
+
+		collectors := op.PrometheusCollectors()
+		assert.Empty(t, collectors)
+	})
 }
 
 func TestTypedReconciler_Reconcile(t *testing.T) {


### PR DESCRIPTION
## What Changed? Why?

Addresses Issue #1271

Both `OpinionatedWatcher` and `OpinionatedReconciler` now support direct registration of Prometheus collectors without requiring users to implement the full `ResourceWatcher`/`Reconciler` interface. This adds a `RegisterMetricsCollectors()` method to both types, following the established pattern in `simple.App.RegisterMetricsCollectors`.

### How was it tested?

All new functionality is covered by comprehensive tests:
- Direct collector registration
- Additive calls (multiple registrations)
- Combination with existing `Wrap()` functionality
- No-op with no arguments

All existing tests continue to pass.

### Where did you document your changes?

Documentation is in code comments for the new public methods.

### Notes to Reviewers

This is a minimal, non-breaking change that adds optional functionality. The `collectors` field is internal to both types, and the new methods follow existing patterns in the codebase.

Authored by claude code