### PR TITLE
Revert linter version in Makefile to match the actions version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ check-go-version:
 		exit 1; \
 	fi
 
-LINTER_VERSION := 2.11.4
+LINTER_VERSION := 2.5.0
 LINTER_BINARY  := $(BIN_DIR)/golangci-lint-$(LINTER_VERSION)
 
 .PHONY: lint


### PR DESCRIPTION
Revert linter version in Makefile to match the actions version, will update both in a subsequent PR.
