### PR TITLE
feat: route DynamicPatcher per-group via ClientGenerator

### DIFF
--- a/benchmark/benchmark_mocks_test.go
+++ b/benchmark/benchmark_mocks_test.go
@@ -298,7 +298,3 @@ func (m *mockClientGeneratorWithK8sClient) ClientFor(kind resource.Kind) (resour
 func (m *mockClientGeneratorWithK8sClient) GetCustomRouteClient(gv schema.GroupVersion, defaultNamespace string) (resource.CustomRouteClient, error) {
 	return nil, nil
 }
-
-func (m *mockClientGeneratorWithK8sClient) KubeConfigForGroup(string) rest.Config {
-	return rest.Config{}
-}

--- a/benchmark/benchmark_mocks_test.go
+++ b/benchmark/benchmark_mocks_test.go
@@ -298,3 +298,7 @@ func (m *mockClientGeneratorWithK8sClient) ClientFor(kind resource.Kind) (resour
 func (m *mockClientGeneratorWithK8sClient) GetCustomRouteClient(gv schema.GroupVersion, defaultNamespace string) (resource.CustomRouteClient, error) {
 	return nil, nil
 }
+
+func (m *mockClientGeneratorWithK8sClient) KubeConfigForGroup(string) rest.Config {
+	return rest.Config{}
+}

--- a/benchmark/benchmark_mocks_test.go
+++ b/benchmark/benchmark_mocks_test.go
@@ -298,3 +298,7 @@ func (m *mockClientGeneratorWithK8sClient) ClientFor(kind resource.Kind) (resour
 func (m *mockClientGeneratorWithK8sClient) GetCustomRouteClient(gv schema.GroupVersion, defaultNamespace string) (resource.CustomRouteClient, error) {
 	return nil, nil
 }
+
+func (m *mockClientGeneratorWithK8sClient) DiscoveryClient() (resource.DiscoveryClient, error) {
+	return nil, nil
+}

--- a/k8s/client_registry.go
+++ b/k8s/client_registry.go
@@ -148,6 +148,21 @@ func (c *ClientRegistry) getCustomRouteClient(gv schema.GroupVersion) (rest.Inte
 	return restClient, nil
 }
 
+// KubeConfigForGroup returns the rest.Config the registry would use for clients operating on
+// the given API group, by invoking ClientConfig.KubeConfigProvider with a synthetic Kind that
+// has only the group populated. This assumes KubeConfigProvider implementations inspect only
+// the kind's group for routing (the pattern used by DefaultClientConfig and
+// NewClientConfigWithExternalClients). Callers that only know the group (e.g. DynamicPatcher)
+// can use this to reach the correct API server in per-group routing setups.
+func (c *ClientRegistry) KubeConfigForGroup(group string) rest.Config {
+	cfg := c.cfg
+	if c.clientConfig.KubeConfigProvider != nil {
+		sch := resource.NewSimpleSchema(group, "", &resource.UntypedObject{}, &resource.UntypedList{})
+		cfg = c.clientConfig.KubeConfigProvider(resource.Kind{Schema: sch}, cfg)
+	}
+	return cfg
+}
+
 func (c *ClientRegistry) getClientFor(sch resource.Kind) (rest.Interface, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/k8s/client_registry.go
+++ b/k8s/client_registry.go
@@ -66,6 +66,7 @@ func NewClientRegistry(kubeCconfig rest.Config, clientConfig ClientConfig) *Clie
 type ClientRegistry struct {
 	clients          map[schema.GroupVersionKind]rest.Interface
 	crClients        map[schema.GroupVersion]rest.Interface
+	discoveryClient  *DiscoveryClient
 	cfg              rest.Config
 	clientConfig     ClientConfig
 	mutex            sync.Mutex
@@ -146,6 +147,19 @@ func (c *ClientRegistry) getCustomRouteClient(gv schema.GroupVersion) (rest.Inte
 	}
 	c.crClients[gv] = restClient
 	return restClient, nil
+}
+
+// DiscoveryClient returns a DiscoveryClient configured with the registry's kubeconfig and
+// KubeConfigProvider, so per-group routing (if any) is preserved. The DiscoveryClient is
+// cached on first call and reused, so its internal per-group client cache is shared across
+// callers.
+func (c *ClientRegistry) DiscoveryClient() (resource.DiscoveryClient, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.discoveryClient == nil {
+		c.discoveryClient = NewDiscoveryClient(c.cfg, c.clientConfig.KubeConfigProvider)
+	}
+	return c.discoveryClient, nil
 }
 
 func (c *ClientRegistry) getClientFor(sch resource.Kind) (rest.Interface, error) {

--- a/k8s/client_registry.go
+++ b/k8s/client_registry.go
@@ -148,21 +148,6 @@ func (c *ClientRegistry) getCustomRouteClient(gv schema.GroupVersion) (rest.Inte
 	return restClient, nil
 }
 
-// KubeConfigForGroup returns the rest.Config the registry would use for clients operating on
-// the given API group, by invoking ClientConfig.KubeConfigProvider with a synthetic Kind that
-// has only the group populated. This assumes KubeConfigProvider implementations inspect only
-// the kind's group for routing (the pattern used by DefaultClientConfig and
-// NewClientConfigWithExternalClients). Callers that only know the group (e.g. DynamicPatcher)
-// can use this to reach the correct API server in per-group routing setups.
-func (c *ClientRegistry) KubeConfigForGroup(group string) rest.Config {
-	cfg := c.cfg
-	if c.clientConfig.KubeConfigProvider != nil {
-		sch := resource.NewSimpleSchema(group, "", &resource.UntypedObject{}, &resource.UntypedList{})
-		cfg = c.clientConfig.KubeConfigProvider(resource.Kind{Schema: sch}, cfg)
-	}
-	return cfg
-}
-
 func (c *ClientRegistry) getClientFor(sch resource.Kind) (rest.Interface, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -108,11 +108,24 @@ func (d *DiscoveryClient) getClient(group string) (*discovery.DiscoveryClient, e
 	if c, ok := d.clients.Load(group); ok {
 		return c, nil
 	}
-	cfg := d.kubeConfigForGroup(group)
-	c, err := discovery.NewDiscoveryClientForConfig(&cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error creating discovery client for group %q: %w", group, err)
+	// Compute holds the shard lock for `group`, so concurrent first-time callers for the same
+	// group won't both construct a discovery client. On failure we return delete=true so the
+	// failure isn't cached and a subsequent call gets to retry.
+	var createErr error
+	c, _ := d.clients.Compute(group, func(existing *discovery.DiscoveryClient, loaded bool) (*discovery.DiscoveryClient, bool) {
+		if loaded {
+			return existing, false
+		}
+		cfg := d.kubeConfigForGroup(group)
+		newClient, err := discovery.NewDiscoveryClientForConfig(&cfg)
+		if err != nil {
+			createErr = err
+			return nil, true
+		}
+		return newClient, false
+	})
+	if createErr != nil {
+		return nil, fmt.Errorf("error creating discovery client for group %q: %w", group, createErr)
 	}
-	actual, _ := d.clients.LoadOrStore(group, c)
-	return actual, nil
+	return c, nil
 }

--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -29,8 +29,9 @@ type DiscoveryClient struct {
 }
 
 // NewDiscoveryClient returns a new DiscoveryClient. If kubeConfigProvider is non-nil, it is used
-// to resolve the rest.Config for each API group (called with a synthetic Kind whose only
-// populated field is Group, matching the pattern used by DefaultClientConfig).
+// to resolve the rest.Config for each API group (called with a synthetic Kind whose Group is the
+// only field carrying caller intent — Version/Kind/Plural are left as NewSimpleSchema defaults,
+// matching how DefaultClientConfig's KubeConfigProvider only reads kind.Group()).
 func NewDiscoveryClient(cfg rest.Config, kubeConfigProvider func(kind resource.Kind, kubeConfig rest.Config) rest.Config) *DiscoveryClient {
 	return &DiscoveryClient{
 		defaultKubeConfig:  cfg,
@@ -86,9 +87,8 @@ func (d *DiscoveryClient) PreferredVersion(apiGroup string) (*metav1.APIResource
 		result.GroupVersion = pref.GroupVersion
 		for _, res := range pref.APIResources {
 			// ServerPreferredResources returns subresources (e.g. "pods/status") alongside the
-			// main resource. They share the parent's Kind, so if we didn't skip them the map
-			// keyed by Kind would end up with the subresource entry and a plural containing "/",
-			// producing broken request URLs downstream.
+			// main resource. They share the parent's Kind but carry a "/"-containing Name, which
+			// would produce broken request URLs if a caller used them to build a GroupVersionResource.
 			if strings.Contains(res.Name, "/") {
 				continue
 			}

--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -1,0 +1,118 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/puzpuzpuz/xsync/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+var _ resource.DiscoveryClient = (*DiscoveryClient)(nil)
+
+// DiscoveryClient is a resource.DiscoveryClient backed by one or more client-go discovery clients.
+// In installations where different API groups are routed to different API servers
+// (via ClientConfig.KubeConfigProvider / NewClientConfigWithExternalClients), it keeps a separate
+// discovery client per group so each group hits its authoritative API server.
+type DiscoveryClient struct {
+	defaultKubeConfig  rest.Config
+	kubeConfigProvider func(kind resource.Kind, kubeConfig rest.Config) rest.Config
+	clients            *xsync.MapOf[string, *discovery.DiscoveryClient]
+}
+
+// NewDiscoveryClient returns a new DiscoveryClient. If kubeConfigProvider is non-nil, it is used
+// to resolve the rest.Config for each API group (called with a synthetic Kind whose only
+// populated field is Group, matching the pattern used by DefaultClientConfig).
+func NewDiscoveryClient(cfg rest.Config, kubeConfigProvider func(kind resource.Kind, kubeConfig rest.Config) rest.Config) *DiscoveryClient {
+	return &DiscoveryClient{
+		defaultKubeConfig:  cfg,
+		kubeConfigProvider: kubeConfigProvider,
+		clients:            xsync.NewMapOf[*discovery.DiscoveryClient](),
+	}
+}
+
+// APIGroupInfo returns the preferred-version resources exposed by the given API group.
+// Each entry's Group and Version fields are populated with the resource's preferred GroupVersion.
+func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, error) {
+	client, err := d.getClient(apiGroup)
+	if err != nil {
+		return nil, err
+	}
+	preferred, err := client.ServerPreferredResources()
+	var targetGroupErr error
+	if err != nil {
+		// There are errors that are "partial" errors and still return results.
+		// In those cases, we should check into the error further rather than just returning.
+		// If there are no results, return the error we got.
+		if len(preferred) == 0 {
+			var statusErr *apierrors.StatusError
+			if errors.As(err, &statusErr) {
+				return nil, statusErr
+			}
+			return nil, fmt.Errorf("error getting preferred resources from discovery client: %w", err)
+		}
+		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
+		if errors.As(err, &groupDiscoveryErr) {
+			for g, gerr := range groupDiscoveryErr.Groups {
+				logging.DefaultLogger.Warn(fmt.Sprintf("discovery failed for GroupVersion %s", g.String()), "groupversion", g, "error", gerr)
+				if g.Group == apiGroup {
+					targetGroupErr = fmt.Errorf("discovery failed for group %q: %w", apiGroup, gerr)
+				}
+			}
+		} else {
+			logging.DefaultLogger.Warn("error getting preferred resources, returned partial results", "error", err)
+		}
+	}
+	var resources []metav1.APIResource
+	for _, pref := range preferred {
+		gv, err := schema.ParseGroupVersion(pref.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		// In multi-host setups, a different API server may be authoritative for another group,
+		// so only include entries for the group we queried.
+		if gv.Group != apiGroup {
+			continue
+		}
+		for _, res := range pref.APIResources {
+			if res.Version == "" {
+				res.Version = gv.Version
+			}
+			if res.Group == "" {
+				res.Group = gv.Group
+			}
+			resources = append(resources, res)
+		}
+	}
+
+	return resources, targetGroupErr
+}
+
+func (d *DiscoveryClient) kubeConfigForGroup(group string) rest.Config {
+	cfg := d.defaultKubeConfig
+	if d.kubeConfigProvider != nil {
+		sch := resource.NewSimpleSchema(group, "", &resource.UntypedObject{}, &resource.UntypedList{})
+		cfg = d.kubeConfigProvider(resource.Kind{Schema: sch}, cfg)
+	}
+	return cfg
+}
+
+func (d *DiscoveryClient) getClient(group string) (*discovery.DiscoveryClient, error) {
+	if c, ok := d.clients.Load(group); ok {
+		return c, nil
+	}
+	cfg := d.kubeConfigForGroup(group)
+	c, err := discovery.NewDiscoveryClientForConfig(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating discovery client for group %q: %w", group, err)
+	}
+	actual, _ := d.clients.LoadOrStore(group, c)
+	return actual, nil
+}

--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -39,9 +39,10 @@ func NewDiscoveryClient(cfg rest.Config, kubeConfigProvider func(kind resource.K
 	}
 }
 
-// APIGroupInfo returns the preferred-version resources exposed by the given API group.
-// Each entry's Group and Version fields are populated with the resource's preferred GroupVersion.
-func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, error) {
+// PreferredVersion returns the APIResourceList for the preferred version of the given API group.
+// The returned list's GroupVersion is the preferred GroupVersion; each APIResource entry's
+// Group and Version fields are also populated with that same GroupVersion for caller convenience.
+func (d *DiscoveryClient) PreferredVersion(apiGroup string) (*metav1.APIResourceList, error) {
 	client, err := d.getClient(apiGroup)
 	if err != nil {
 		return nil, err
@@ -71,7 +72,7 @@ func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, e
 			logging.DefaultLogger.Warn("error getting preferred resources, returned partial results", "error", err)
 		}
 	}
-	var resources []metav1.APIResource
+	result := &metav1.APIResourceList{}
 	for _, pref := range preferred {
 		gv, err := schema.ParseGroupVersion(pref.GroupVersion)
 		if err != nil {
@@ -82,6 +83,7 @@ func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, e
 		if gv.Group != apiGroup {
 			continue
 		}
+		result.GroupVersion = pref.GroupVersion
 		for _, res := range pref.APIResources {
 			// ServerPreferredResources returns subresources (e.g. "pods/status") alongside the
 			// main resource. They share the parent's Kind, so if we didn't skip them the map
@@ -96,16 +98,16 @@ func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, e
 			if res.Group == "" {
 				res.Group = gv.Group
 			}
-			resources = append(resources, res)
+			result.APIResources = append(result.APIResources, res)
 		}
 	}
 	// Only propagate the target-group discovery failure when it left us with nothing usable.
 	// If we got partial results, let the caller consume them; otherwise common partial-discovery
 	// scenarios would permanently block the preferred-version cache from updating.
-	if len(resources) == 0 && targetGroupErr != nil {
+	if len(result.APIResources) == 0 && targetGroupErr != nil {
 		return nil, targetGroupErr
 	}
-	return resources, nil
+	return result, nil
 }
 
 func (d *DiscoveryClient) kubeConfigForGroup(group string) rest.Config {

--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/puzpuzpuz/xsync/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,6 +83,13 @@ func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, e
 			continue
 		}
 		for _, res := range pref.APIResources {
+			// ServerPreferredResources returns subresources (e.g. "pods/status") alongside the
+			// main resource. They share the parent's Kind, so if we didn't skip them the map
+			// keyed by Kind would end up with the subresource entry and a plural containing "/",
+			// producing broken request URLs downstream.
+			if strings.Contains(res.Name, "/") {
+				continue
+			}
 			if res.Version == "" {
 				res.Version = gv.Version
 			}
@@ -91,8 +99,13 @@ func (d *DiscoveryClient) APIGroupInfo(apiGroup string) ([]metav1.APIResource, e
 			resources = append(resources, res)
 		}
 	}
-
-	return resources, targetGroupErr
+	// Only propagate the target-group discovery failure when it left us with nothing usable.
+	// If we got partial results, let the caller consume them; otherwise common partial-discovery
+	// scenarios would permanently block the preferred-version cache from updating.
+	if len(resources) == 0 && targetGroupErr != nil {
+		return nil, targetGroupErr
+	}
+	return resources, nil
 }
 
 func (d *DiscoveryClient) kubeConfigForGroup(group string) rest.Config {

--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -19,8 +19,7 @@ import (
 // It obtains per-kind clients through the provided ClientGenerator, so installations routing
 // different groups to different API servers (via ClientConfig.KubeConfigProvider) are handled correctly.
 type DynamicPatcher struct {
-	clients   resource.ClientGenerator
-	discovery resource.DiscoveryClient
+	clients resource.ClientGenerator
 
 	preferred  *xsync.MapOf[string, metav1.APIResource] // keyed by schema.GroupKind.String()
 	lastUpdate *xsync.MapOf[string, time.Time]          // keyed by API group
@@ -29,24 +28,18 @@ type DynamicPatcher struct {
 	group          singleflight.Group
 }
 
-// NewDynamicPatcher returns a new DynamicPatcher. The ClientGenerator is used to build per-kind
-// clients at the preferred version (via ClientGenerator.ClientFor), and the DiscoveryClient is
-// used to look up the preferred version for each API group. Callers routing different groups to
-// different API servers should provide a DiscoveryClient that mirrors that routing (e.g. via
-// NewDiscoveryClient with a matching KubeConfigProvider).
+// NewDynamicPatcher returns a new DynamicPatcher that uses the provided ClientGenerator for
+// both API group discovery (via ClientGenerator.DiscoveryClient) and building per-kind clients
+// at the preferred version (via ClientGenerator.ClientFor).
 // cacheUpdateInterval is the interval to refresh the preferred version cache from the API server.
 // To disable the cache refresh (and only update on first request and whenever ForceRefresh() is called),
 // set this value to <= 0.
-func NewDynamicPatcher(clients resource.ClientGenerator, discovery resource.DiscoveryClient, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
+func NewDynamicPatcher(clients resource.ClientGenerator, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
 	if clients == nil {
 		return nil, errors.New("ClientGenerator cannot be nil")
 	}
-	if discovery == nil {
-		return nil, errors.New("DiscoveryClient cannot be nil")
-	}
 	return &DynamicPatcher{
 		clients:        clients,
-		discovery:      discovery,
 		preferred:      xsync.NewMapOf[metav1.APIResource](),
 		lastUpdate:     xsync.NewMapOf[time.Time](),
 		updateInterval: cacheUpdateInterval,
@@ -153,7 +146,11 @@ func (d *DynamicPatcher) getPreferred(kind schema.GroupKind) (*metav1.APIResourc
 }
 
 func (d *DynamicPatcher) updatePreferred(group string) error {
-	resources, err := d.discovery.APIGroupInfo(group)
+	client, err := d.clients.DiscoveryClient()
+	if err != nil {
+		return err
+	}
+	resources, err := client.APIGroupInfo(group)
 	if err != nil {
 		return err
 	}

--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -8,49 +8,48 @@ import (
 
 	"github.com/puzpuzpuz/xsync/v2"
 	"golang.org/x/sync/singleflight"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
 // DynamicPatcher is a client which will always patch against the current preferred version of a kind.
-// It keeps a dynamic client and discovery client per API group, so that installations routing
+// It obtains per-kind clients through the provided ClientGenerator, so installations routing
 // different groups to different API servers (via ClientConfig.KubeConfigProvider) are handled correctly.
 type DynamicPatcher struct {
-	configForGroup func(group string) rest.Config
+	clients   resource.ClientGenerator
+	discovery resource.DiscoveryClient
 
-	dynamicClients   *xsync.MapOf[string, *dynamic.DynamicClient]
-	discoveryClients *xsync.MapOf[string, *discovery.DiscoveryClient]
-	preferred        *xsync.MapOf[string, metav1.APIResource] // keyed by schema.GroupKind.String()
-	lastUpdate       *xsync.MapOf[string, time.Time]          // keyed by API group
+	preferred  *xsync.MapOf[string, metav1.APIResource] // keyed by schema.GroupKind.String()
+	lastUpdate *xsync.MapOf[string, time.Time]          // keyed by API group
 
 	updateInterval time.Duration
 	group          singleflight.Group
 }
 
-// NewDynamicPatcher returns a new DynamicPatcher that resolves the rest.Config for each API group
-// via ClientGenerator.KubeConfigForGroup, and cacheUpdateInterval as the interval to refresh its
-// preferred version cache from the API server.
+// NewDynamicPatcher returns a new DynamicPatcher. The ClientGenerator is used to build per-kind
+// clients at the preferred version (via ClientGenerator.ClientFor), and the DiscoveryClient is
+// used to look up the preferred version for each API group. Callers routing different groups to
+// different API servers should provide a DiscoveryClient that mirrors that routing (e.g. via
+// NewDiscoveryClient with a matching KubeConfigProvider).
+// cacheUpdateInterval is the interval to refresh the preferred version cache from the API server.
 // To disable the cache refresh (and only update on first request and whenever ForceRefresh() is called),
 // set this value to <= 0.
-func NewDynamicPatcher(clients resource.ClientGenerator, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
+func NewDynamicPatcher(clients resource.ClientGenerator, discovery resource.DiscoveryClient, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
 	if clients == nil {
 		return nil, errors.New("ClientGenerator cannot be nil")
 	}
+	if discovery == nil {
+		return nil, errors.New("DiscoveryClient cannot be nil")
+	}
 	return &DynamicPatcher{
-		configForGroup:   clients.KubeConfigForGroup,
-		dynamicClients:   xsync.NewMapOf[*dynamic.DynamicClient](),
-		discoveryClients: xsync.NewMapOf[*discovery.DiscoveryClient](),
-		preferred:        xsync.NewMapOf[metav1.APIResource](),
-		lastUpdate:       xsync.NewMapOf[time.Time](),
-		updateInterval:   cacheUpdateInterval,
+		clients:        clients,
+		discovery:      discovery,
+		preferred:      xsync.NewMapOf[metav1.APIResource](),
+		lastUpdate:     xsync.NewMapOf[time.Time](),
+		updateInterval: cacheUpdateInterval,
 	}, nil
 }
 
@@ -59,7 +58,7 @@ type DynamicKindPatcher struct {
 	groupKind schema.GroupKind
 }
 
-func (d *DynamicKindPatcher) Get(ctx context.Context, identifier resource.Identifier) (*resource.UnstructuredWrapper, error) {
+func (d *DynamicKindPatcher) Get(ctx context.Context, identifier resource.Identifier) (resource.Object, error) {
 	return d.patcher.Get(ctx, d.groupKind, identifier)
 }
 
@@ -67,74 +66,22 @@ func (d *DynamicKindPatcher) Patch(ctx context.Context, identifier resource.Iden
 	return d.patcher.Patch(ctx, d.groupKind, identifier, patch, options)
 }
 
-func (d *DynamicPatcher) Patch(ctx context.Context, groupKind schema.GroupKind, identifier resource.Identifier, patch resource.PatchRequest, opts resource.PatchOptions) (*resource.UnstructuredWrapper, error) {
-	preferred, err := d.getPreferred(groupKind)
+func (d *DynamicPatcher) Patch(ctx context.Context, groupKind schema.GroupKind, identifier resource.Identifier, patch resource.PatchRequest, opts resource.PatchOptions) (resource.Object, error) {
+	client, preferred, err := d.clientForPreferred(groupKind)
 	if err != nil {
 		return nil, err
 	}
-	logging.FromContext(ctx).Debug("patching with dynamic client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
-	data, err := marshalJSONPatch(patch)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal patch: %w", err)
-	}
-	client, err := d.getDynamicClient(groupKind.Group)
-	if err != nil {
-		return nil, err
-	}
-	res := client.Resource(schema.GroupVersionResource{
-		Group:    preferred.Group,
-		Version:  preferred.Version,
-		Resource: preferred.Name,
-	})
-	subresources := make([]string, 0)
-	if opts.Subresource != "" {
-		subresources = append(subresources, opts.Subresource)
-	}
-	patchOpts := metav1.PatchOptions{}
-	if opts.DryRun {
-		patchOpts.DryRun = []string{"All"}
-	}
-	if preferred.Namespaced {
-		resp, err := res.Namespace(identifier.Namespace).Patch(ctx, identifier.Name, types.JSONPatchType, data, patchOpts, subresources...)
-		if err != nil {
-			return nil, d.parseError(err)
-		}
-		return resource.NewUnstructuredWrapper(resp), nil
-	}
-	resp, err := res.Patch(ctx, identifier.Name, types.JSONPatchType, data, patchOpts, subresources...)
-	if err != nil {
-		return nil, d.parseError(err)
-	}
-	return resource.NewUnstructuredWrapper(resp), nil
+	logging.FromContext(ctx).Debug("patching with preferred-version client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
+	return client.Patch(ctx, identifier, patch, opts)
 }
 
-func (d *DynamicPatcher) Get(ctx context.Context, groupKind schema.GroupKind, identifier resource.Identifier) (*resource.UnstructuredWrapper, error) {
-	preferred, err := d.getPreferred(groupKind)
+func (d *DynamicPatcher) Get(ctx context.Context, groupKind schema.GroupKind, identifier resource.Identifier) (resource.Object, error) {
+	client, preferred, err := d.clientForPreferred(groupKind)
 	if err != nil {
 		return nil, err
 	}
-	logging.FromContext(ctx).Debug("getting with dynamic client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
-	client, err := d.getDynamicClient(groupKind.Group)
-	if err != nil {
-		return nil, err
-	}
-	res := client.Resource(schema.GroupVersionResource{
-		Group:    preferred.Group,
-		Version:  preferred.Version,
-		Resource: preferred.Name,
-	})
-	if preferred.Namespaced {
-		resp, err := res.Namespace(identifier.Namespace).Get(ctx, identifier.Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, d.parseError(err)
-		}
-		return resource.NewUnstructuredWrapper(resp), nil
-	}
-	resp, err := res.Get(ctx, identifier.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, d.parseError(err)
-	}
-	return resource.NewUnstructuredWrapper(resp), nil
+	logging.FromContext(ctx).Debug("getting with preferred-version client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
+	return client.Get(ctx, identifier)
 }
 
 // ForKind returns a DynamicKindPatcher for the provided group and kind, which implements the Patch method from resource.Client.
@@ -147,10 +94,10 @@ func (d *DynamicPatcher) ForKind(groupKind schema.GroupKind) *DynamicKindPatcher
 }
 
 // ForceRefresh forces an update of the preferred version cache for every API group
-// for which a discovery client has already been created.
+// that has already been queried.
 func (d *DynamicPatcher) ForceRefresh() error {
 	var rangeErr error
-	d.discoveryClients.Range(func(group string, _ *discovery.DiscoveryClient) bool {
+	d.lastUpdate.Range(func(group string, _ time.Time) bool {
 		if err := d.updatePreferred(group); err != nil {
 			rangeErr = err
 			return false
@@ -160,10 +107,35 @@ func (d *DynamicPatcher) ForceRefresh() error {
 	return rangeErr
 }
 
+func (d *DynamicPatcher) clientForPreferred(groupKind schema.GroupKind) (resource.Client, *metav1.APIResource, error) {
+	preferred, err := d.getPreferred(groupKind)
+	if err != nil {
+		return nil, nil, err
+	}
+	scope := resource.NamespacedScope
+	if !preferred.Namespaced {
+		scope = resource.ClusterScope
+	}
+	sch := resource.NewSimpleSchema(groupKind.Group, preferred.Version, &resource.UntypedObject{}, &resource.UntypedList{},
+		resource.WithKind(groupKind.Kind),
+		resource.WithPlural(preferred.Name),
+		resource.WithScope(scope),
+	)
+	kind := resource.Kind{
+		Schema: sch,
+		Codecs: map[resource.KindEncoding]resource.Codec{resource.KindEncodingJSON: resource.NewJSONCodec()},
+	}
+	client, err := d.clients.ClientFor(kind)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, preferred, nil
+}
+
 func (d *DynamicPatcher) getPreferred(kind schema.GroupKind) (*metav1.APIResource, error) {
 	_, err, _ := d.group.Do("check-cache-update:"+kind.Group, func() (any, error) {
 		last, _ := d.lastUpdate.Load(kind.Group)
-		if last.IsZero() || (d.updateInterval >= 0 && last.Before(now().Add(-d.updateInterval))) {
+		if last.IsZero() || (d.updateInterval > 0 && last.Before(now().Add(-d.updateInterval))) {
 			if err := d.updatePreferred(kind.Group); err != nil {
 				return nil, err
 			}
@@ -181,86 +153,13 @@ func (d *DynamicPatcher) getPreferred(kind schema.GroupKind) (*metav1.APIResourc
 }
 
 func (d *DynamicPatcher) updatePreferred(group string) error {
-	disc, err := d.getDiscoveryClient(group)
+	resources, err := d.discovery.APIGroupInfo(group)
 	if err != nil {
 		return err
 	}
-	preferred, err := disc.ServerPreferredResources()
-	if err != nil {
-		// There are errors that are "partial" errors and still return results.
-		// In those cases, we should check into the error further rather than just returning.
-		// If there are no results, return the error we got
-		if len(preferred) == 0 {
-			var statusErr *apierrors.StatusError
-			if errors.As(err, &statusErr) {
-				return statusErr
-			}
-			return fmt.Errorf("error getting preferred resources from discovery client: %w", err)
-		}
-		if cast, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
-			// Failed discovery for a number of groups. Log the failed groups
-			for g, gerr := range cast.Groups {
-				logging.DefaultLogger.Warn(fmt.Sprintf("discovery failed for GroupVersion %s", g.String()), "groupversion", g, "error", gerr)
-			}
-		} else {
-			// just log the error
-			logging.DefaultLogger.Warn("error getting preferred resources, returned partial results", "error", err)
-		}
-	}
-	for _, pref := range preferred {
-		gv, err := schema.ParseGroupVersion(pref.GroupVersion)
-		if err != nil {
-			return err
-		}
-		// Only cache entries for the group we queried. In multi-host setups, a different
-		// API server may be authoritative for another group.
-		if gv.Group != group {
-			continue
-		}
-		for _, res := range pref.APIResources {
-			if res.Version == "" {
-				res.Version = gv.Version
-			}
-			if res.Group == "" {
-				res.Group = gv.Group
-			}
-			d.preferred.Store(schema.GroupKind{Group: gv.Group, Kind: res.Kind}.String(), res)
-		}
+	for _, res := range resources {
+		d.preferred.Store(schema.GroupKind{Group: group, Kind: res.Kind}.String(), res)
 	}
 	d.lastUpdate.Store(group, now())
 	return nil
-}
-
-func (d *DynamicPatcher) getDynamicClient(group string) (*dynamic.DynamicClient, error) {
-	if client, ok := d.dynamicClients.Load(group); ok {
-		return client, nil
-	}
-	cfg := d.configForGroup(group)
-	client, err := dynamic.NewForConfig(&cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error creating dynamic client for group %q: %w", group, err)
-	}
-	actual, _ := d.dynamicClients.LoadOrStore(group, client)
-	return actual, nil
-}
-
-func (d *DynamicPatcher) getDiscoveryClient(group string) (*discovery.DiscoveryClient, error) {
-	if disc, ok := d.discoveryClients.Load(group); ok {
-		return disc, nil
-	}
-	cfg := d.configForGroup(group)
-	disc, err := discovery.NewDiscoveryClientForConfig(&cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error creating discovery client for group %q: %w", group, err)
-	}
-	actual, _ := d.discoveryClients.LoadOrStore(group, disc)
-	return actual, nil
-}
-
-func (*DynamicPatcher) parseError(err error) error {
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) {
-		return NewServerResponseError(statusErr, statusErr.Status().Code)
-	}
-	return err
 }

--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
+	"github.com/puzpuzpuz/xsync/v2"
 	"golang.org/x/sync/singleflight"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,34 +21,36 @@ import (
 )
 
 // DynamicPatcher is a client which will always patch against the current preferred version of a kind.
+// It keeps a dynamic client and discovery client per API group, so that installations routing
+// different groups to different API servers (via ClientConfig.KubeConfigProvider) are handled correctly.
 type DynamicPatcher struct {
-	client         *dynamic.DynamicClient
-	discovery      *discovery.DiscoveryClient
-	preferred      map[string]metav1.APIResource
-	mux            sync.RWMutex
-	lastUpdate     time.Time
+	configForGroup func(group string) rest.Config
+
+	dynamicClients   *xsync.MapOf[string, *dynamic.DynamicClient]
+	discoveryClients *xsync.MapOf[string, *discovery.DiscoveryClient]
+	preferred        *xsync.MapOf[string, metav1.APIResource] // keyed by schema.GroupKind.String()
+	lastUpdate       *xsync.MapOf[string, time.Time]          // keyed by API group
+
 	updateInterval time.Duration
 	group          singleflight.Group
 }
 
-// NewDynamicPatcher returns a new DynamicPatcher using the provided rest.Config for its internal client(s),
-// and cacheUpdateInterval as the interval to refresh its preferred version cache from the API server.
+// NewDynamicPatcher returns a new DynamicPatcher that resolves the rest.Config for each API group
+// via ClientGenerator.KubeConfigForGroup, and cacheUpdateInterval as the interval to refresh its
+// preferred version cache from the API server.
 // To disable the cache refresh (and only update on first request and whenever ForceRefresh() is called),
 // set this value to <= 0.
-func NewDynamicPatcher(cfg *rest.Config, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
-	client, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error creating dynamic client: %w", err)
-	}
-	disc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("error creating discovery client: %w", err)
+func NewDynamicPatcher(clients resource.ClientGenerator, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
+	if clients == nil {
+		return nil, errors.New("ClientGenerator cannot be nil")
 	}
 	return &DynamicPatcher{
-		client:         client,
-		discovery:      disc,
-		preferred:      make(map[string]metav1.APIResource),
-		updateInterval: cacheUpdateInterval,
+		configForGroup:   clients.KubeConfigForGroup,
+		dynamicClients:   xsync.NewMapOf[*dynamic.DynamicClient](),
+		discoveryClients: xsync.NewMapOf[*discovery.DiscoveryClient](),
+		preferred:        xsync.NewMapOf[metav1.APIResource](),
+		lastUpdate:       xsync.NewMapOf[time.Time](),
+		updateInterval:   cacheUpdateInterval,
 	}, nil
 }
 
@@ -75,7 +77,11 @@ func (d *DynamicPatcher) Patch(ctx context.Context, groupKind schema.GroupKind, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal patch: %w", err)
 	}
-	res := d.client.Resource(schema.GroupVersionResource{
+	client, err := d.getDynamicClient(groupKind.Group)
+	if err != nil {
+		return nil, err
+	}
+	res := client.Resource(schema.GroupVersionResource{
 		Group:    preferred.Group,
 		Version:  preferred.Version,
 		Resource: preferred.Name,
@@ -107,8 +113,12 @@ func (d *DynamicPatcher) Get(ctx context.Context, groupKind schema.GroupKind, id
 	if err != nil {
 		return nil, err
 	}
-	logging.FromContext(ctx).Debug("patching with dynamic client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
-	res := d.client.Resource(schema.GroupVersionResource{
+	logging.FromContext(ctx).Debug("getting with dynamic client", "group", groupKind.Group, "version", preferred.Version, "kind", groupKind.Kind, "plural", preferred.Name)
+	client, err := d.getDynamicClient(groupKind.Group)
+	if err != nil {
+		return nil, err
+	}
+	res := client.Resource(schema.GroupVersionResource{
 		Group:    preferred.Group,
 		Version:  preferred.Version,
 		Resource: preferred.Name,
@@ -136,15 +146,25 @@ func (d *DynamicPatcher) ForKind(groupKind schema.GroupKind) *DynamicKindPatcher
 	}
 }
 
-// ForceRefresh forces an update of the DiscoveryClient's cache of preferred versions for kinds
+// ForceRefresh forces an update of the preferred version cache for every API group
+// for which a discovery client has already been created.
 func (d *DynamicPatcher) ForceRefresh() error {
-	return d.updatePreferred()
+	var rangeErr error
+	d.discoveryClients.Range(func(group string, _ *discovery.DiscoveryClient) bool {
+		if err := d.updatePreferred(group); err != nil {
+			rangeErr = err
+			return false
+		}
+		return true
+	})
+	return rangeErr
 }
 
 func (d *DynamicPatcher) getPreferred(kind schema.GroupKind) (*metav1.APIResource, error) {
-	_, err, _ := d.group.Do("check-cache-update", func() (any, error) {
-		if d.preferred == nil || (d.updateInterval >= 0 && d.lastUpdate.Before(now().Add(-d.updateInterval))) {
-			if err := d.updatePreferred(); err != nil {
+	_, err, _ := d.group.Do("check-cache-update:"+kind.Group, func() (any, error) {
+		last, _ := d.lastUpdate.Load(kind.Group)
+		if last.IsZero() || (d.updateInterval >= 0 && last.Before(now().Add(-d.updateInterval))) {
+			if err := d.updatePreferred(kind.Group); err != nil {
 				return nil, err
 			}
 		}
@@ -153,20 +173,19 @@ func (d *DynamicPatcher) getPreferred(kind schema.GroupKind) (*metav1.APIResourc
 	if err != nil {
 		return nil, err
 	}
-	d.mux.RLock()
-	defer d.mux.RUnlock()
-
-	preferred, ok := d.preferred[kind.String()]
+	pref, ok := d.preferred.Load(kind.String())
 	if !ok {
 		return nil, fmt.Errorf("preferred resource not found for kind '%s'", kind)
 	}
-	return &preferred, nil
+	return &pref, nil
 }
 
-func (d *DynamicPatcher) updatePreferred() error {
-	d.mux.Lock()
-	defer d.mux.Unlock()
-	preferred, err := d.discovery.ServerPreferredResources()
+func (d *DynamicPatcher) updatePreferred(group string) error {
+	disc, err := d.getDiscoveryClient(group)
+	if err != nil {
+		return err
+	}
+	preferred, err := disc.ServerPreferredResources()
 	if err != nil {
 		// There are errors that are "partial" errors and still return results.
 		// In those cases, we should check into the error further rather than just returning.
@@ -180,8 +199,8 @@ func (d *DynamicPatcher) updatePreferred() error {
 		}
 		if cast, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
 			// Failed discovery for a number of groups. Log the failed groups
-			for group, gerr := range cast.Groups {
-				logging.DefaultLogger.Warn(fmt.Sprintf("discovery failed for GroupVersion %s", group.String()), "groupversion", group, "error", gerr)
+			for g, gerr := range cast.Groups {
+				logging.DefaultLogger.Warn(fmt.Sprintf("discovery failed for GroupVersion %s", g.String()), "groupversion", g, "error", gerr)
 			}
 		} else {
 			// just log the error
@@ -193,6 +212,11 @@ func (d *DynamicPatcher) updatePreferred() error {
 		if err != nil {
 			return err
 		}
+		// Only cache entries for the group we queried. In multi-host setups, a different
+		// API server may be authoritative for another group.
+		if gv.Group != group {
+			continue
+		}
 		for _, res := range pref.APIResources {
 			if res.Version == "" {
 				res.Version = gv.Version
@@ -200,14 +224,37 @@ func (d *DynamicPatcher) updatePreferred() error {
 			if res.Group == "" {
 				res.Group = gv.Group
 			}
-			d.preferred[schema.GroupKind{
-				Group: gv.Group,
-				Kind:  res.Kind,
-			}.String()] = res
+			d.preferred.Store(schema.GroupKind{Group: gv.Group, Kind: res.Kind}.String(), res)
 		}
 	}
-	d.lastUpdate = now()
+	d.lastUpdate.Store(group, now())
 	return nil
+}
+
+func (d *DynamicPatcher) getDynamicClient(group string) (*dynamic.DynamicClient, error) {
+	if client, ok := d.dynamicClients.Load(group); ok {
+		return client, nil
+	}
+	cfg := d.configForGroup(group)
+	client, err := dynamic.NewForConfig(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating dynamic client for group %q: %w", group, err)
+	}
+	actual, _ := d.dynamicClients.LoadOrStore(group, client)
+	return actual, nil
+}
+
+func (d *DynamicPatcher) getDiscoveryClient(group string) (*discovery.DiscoveryClient, error) {
+	if disc, ok := d.discoveryClients.Load(group); ok {
+		return disc, nil
+	}
+	cfg := d.configForGroup(group)
+	disc, err := discovery.NewDiscoveryClientForConfig(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating discovery client for group %q: %w", group, err)
+	}
+	actual, _ := d.discoveryClients.LoadOrStore(group, disc)
+	return actual, nil
 }
 
 func (*DynamicPatcher) parseError(err error) error {

--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -15,6 +15,12 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
+// dynamicPatcherCodecs is shared across all synthesized Kinds inside DynamicPatcher — the
+// JSONCodec is stateless, so reusing one map instance avoids a per-request allocation.
+var dynamicPatcherCodecs = map[resource.KindEncoding]resource.Codec{
+	resource.KindEncodingJSON: resource.NewJSONCodec(),
+}
+
 // DynamicPatcher is a client which will always patch against the current preferred version of a kind.
 // It obtains per-kind clients through the provided ClientGenerator, so installations routing
 // different groups to different API servers (via ClientConfig.KubeConfigProvider) are handled correctly.
@@ -23,6 +29,10 @@ type DynamicPatcher struct {
 
 	preferred  *xsync.MapOf[string, metav1.APIResource] // keyed by schema.GroupKind.String()
 	lastUpdate *xsync.MapOf[string, time.Time]          // keyed by API group
+	// kindCache memoizes the synthesized Kind per (groupKind, preferred version) so hot-path
+	// Get/Patch calls don't allocate a new Schema + codec map each invocation. Keyed by
+	// "groupKind.String()/version".
+	kindCache *xsync.MapOf[string, resource.Kind]
 
 	updateInterval time.Duration
 	group          singleflight.Group
@@ -36,12 +46,13 @@ type DynamicPatcher struct {
 // set this value to <= 0.
 func NewDynamicPatcher(clients resource.ClientGenerator, cacheUpdateInterval time.Duration) (*DynamicPatcher, error) {
 	if clients == nil {
-		return nil, errors.New("ClientGenerator cannot be nil")
+		return nil, errors.New("client generator cannot be nil")
 	}
 	return &DynamicPatcher{
 		clients:        clients,
 		preferred:      xsync.NewMapOf[metav1.APIResource](),
 		lastUpdate:     xsync.NewMapOf[time.Time](),
+		kindCache:      xsync.NewMapOf[resource.Kind](),
 		updateInterval: cacheUpdateInterval,
 	}, nil
 }
@@ -105,19 +116,19 @@ func (d *DynamicPatcher) clientForPreferred(groupKind schema.GroupKind) (resourc
 	if err != nil {
 		return nil, nil, err
 	}
-	scope := resource.NamespacedScope
-	if !preferred.Namespaced {
-		scope = resource.ClusterScope
-	}
-	sch := resource.NewSimpleSchema(groupKind.Group, preferred.Version, &resource.UntypedObject{}, &resource.UntypedList{},
-		resource.WithKind(groupKind.Kind),
-		resource.WithPlural(preferred.Name),
-		resource.WithScope(scope),
-	)
-	kind := resource.Kind{
-		Schema: sch,
-		Codecs: map[resource.KindEncoding]resource.Codec{resource.KindEncodingJSON: resource.NewJSONCodec()},
-	}
+	cacheKey := groupKind.String() + "/" + preferred.Version
+	kind, _ := d.kindCache.LoadOrCompute(cacheKey, func() resource.Kind {
+		scope := resource.NamespacedScope
+		if !preferred.Namespaced {
+			scope = resource.ClusterScope
+		}
+		sch := resource.NewSimpleSchema(groupKind.Group, preferred.Version, &resource.UntypedObject{}, &resource.UntypedList{},
+			resource.WithKind(groupKind.Kind),
+			resource.WithPlural(preferred.Name),
+			resource.WithScope(scope),
+		)
+		return resource.Kind{Schema: sch, Codecs: dynamicPatcherCodecs}
+	})
 	client, err := d.clients.ClientFor(kind)
 	if err != nil {
 		return nil, nil, err

--- a/k8s/dynamic.go
+++ b/k8s/dynamic.go
@@ -161,11 +161,11 @@ func (d *DynamicPatcher) updatePreferred(group string) error {
 	if err != nil {
 		return err
 	}
-	resources, err := client.APIGroupInfo(group)
+	list, err := client.PreferredVersion(group)
 	if err != nil {
 		return err
 	}
-	for _, res := range resources {
+	for _, res := range list.APIResources {
 		d.preferred.Store(schema.GroupKind{Group: group, Kind: res.Kind}.String(), res)
 	}
 	d.lastUpdate.Store(group, now())

--- a/k8s/dynamic_test.go
+++ b/k8s/dynamic_test.go
@@ -191,6 +191,98 @@ func TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup(t *testing.T) {
 	require.Equal(t, wantVersion, resources[0].Version)
 }
 
+// TestDiscoveryClient_APIGroupInfo_SkipsSubresources ensures subresource entries
+// (e.g. "pods/status") don't get folded into the result set, since they share the parent's
+// Kind and would otherwise overwrite the main resource with a plural containing "/".
+func TestDiscoveryClient_APIGroupInfo_SkipsSubresources(t *testing.T) {
+	const group, version = "alpha.example.com", "v1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apis":
+			_ = json.NewEncoder(w).Encode(metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{{
+					Name:             group,
+					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: group + "/" + version, Version: version},
+					Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: group + "/" + version, Version: version}},
+				}},
+			})
+		case "/apis/" + group + "/" + version:
+			_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: group + "/" + version,
+				APIResources: []metav1.APIResource{
+					{Name: "widgets", Kind: "Widget", Namespaced: true, Verbs: metav1.Verbs{"get"}},
+					{Name: "widgets/status", Kind: "Widget", Namespaced: true, Verbs: metav1.Verbs{"get"}},
+					{Name: "widgets/scale", Kind: "Scale", Namespaced: true, Verbs: metav1.Verbs{"get"}},
+				},
+			})
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
+	resources, err := dc.APIGroupInfo(group)
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "subresources must be filtered out")
+	require.Equal(t, "widgets", resources[0].Name)
+	require.Equal(t, "Widget", resources[0].Kind)
+}
+
+// TestDiscoveryClient_APIGroupInfo_PartialErrorWithResults verifies that when
+// ServerPreferredResources reports an ErrGroupDiscoveryFailed but still produced usable
+// resources for the requested group, APIGroupInfo returns the resources with no error
+// (so DynamicPatcher.updatePreferred can proceed on a partial failure).
+func TestDiscoveryClient_APIGroupInfo_PartialErrorWithResults(t *testing.T) {
+	const (
+		wantGroup, wantVersion = "alpha.example.com", "v1"
+		brokenGroup            = "broken.example.com"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apis":
+			// Advertise both groups so client-go asks for each version below.
+			_ = json.NewEncoder(w).Encode(metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{
+					{
+						Name:             wantGroup,
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: wantGroup + "/" + wantVersion, Version: wantVersion},
+						Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: wantGroup + "/" + wantVersion, Version: wantVersion}},
+					},
+					{
+						Name:             brokenGroup,
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: brokenGroup + "/v1", Version: "v1"},
+						Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: brokenGroup + "/v1", Version: "v1"}},
+					},
+				},
+			})
+		case "/apis/" + wantGroup + "/" + wantVersion:
+			_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: wantGroup + "/" + wantVersion,
+				APIResources: []metav1.APIResource{{Name: "widgets", Kind: "Widget", Namespaced: true, Verbs: metav1.Verbs{"get"}}},
+			})
+		case "/apis/" + brokenGroup + "/v1":
+			// Trigger an ErrGroupDiscoveryFailed entry for a non-target group.
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
+	resources, err := dc.APIGroupInfo(wantGroup)
+	require.NoError(t, err, "partial discovery failure for an unrelated group must not fail the target lookup")
+	require.Len(t, resources, 1)
+	require.Equal(t, "Widget", resources[0].Kind)
+}
+
 // TestDynamicPatcher_ForceRefresh verifies that ForceRefresh only refreshes groups that
 // have already been queried, and re-hits the apiserver for each of them.
 func TestDynamicPatcher_ForceRefresh(t *testing.T) {

--- a/k8s/dynamic_test.go
+++ b/k8s/dynamic_test.go
@@ -137,10 +137,10 @@ func TestDynamicPatcher_PerGroupDiscoveryRouting(t *testing.T) {
 	require.Equal(t, pluralB, prefB.Name)
 }
 
-// TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup exercises APIGroupInfo directly
+// TestDiscoveryClient_PreferredVersion_FiltersToRequestedGroup exercises PreferredVersion directly
 // against a server that advertises multiple groups. We only asked about one, so the
-// returned slice should only contain entries for that group.
-func TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup(t *testing.T) {
+// returned list should only contain entries for that group.
+func TestDiscoveryClient_PreferredVersion_FiltersToRequestedGroup(t *testing.T) {
 	const (
 		wantGroup, wantVersion = "alpha.example.com", "v1"
 		otherGroup             = "beta.example.com"
@@ -183,18 +183,19 @@ func TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
-	resources, err := dc.APIGroupInfo(wantGroup)
+	list, err := dc.PreferredVersion(wantGroup)
 	require.NoError(t, err)
-	require.Len(t, resources, 1)
-	require.Equal(t, "Widget", resources[0].Kind)
-	require.Equal(t, wantGroup, resources[0].Group)
-	require.Equal(t, wantVersion, resources[0].Version)
+	require.Equal(t, wantGroup+"/"+wantVersion, list.GroupVersion)
+	require.Len(t, list.APIResources, 1)
+	require.Equal(t, "Widget", list.APIResources[0].Kind)
+	require.Equal(t, wantGroup, list.APIResources[0].Group)
+	require.Equal(t, wantVersion, list.APIResources[0].Version)
 }
 
-// TestDiscoveryClient_APIGroupInfo_SkipsSubresources ensures subresource entries
+// TestDiscoveryClient_PreferredVersion_SkipsSubresources ensures subresource entries
 // (e.g. "pods/status") don't get folded into the result set, since they share the parent's
 // Kind and would otherwise overwrite the main resource with a plural containing "/".
-func TestDiscoveryClient_APIGroupInfo_SkipsSubresources(t *testing.T) {
+func TestDiscoveryClient_PreferredVersion_SkipsSubresources(t *testing.T) {
 	const group, version = "alpha.example.com", "v1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -225,18 +226,18 @@ func TestDiscoveryClient_APIGroupInfo_SkipsSubresources(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
-	resources, err := dc.APIGroupInfo(group)
+	list, err := dc.PreferredVersion(group)
 	require.NoError(t, err)
-	require.Len(t, resources, 1, "subresources must be filtered out")
-	require.Equal(t, "widgets", resources[0].Name)
-	require.Equal(t, "Widget", resources[0].Kind)
+	require.Len(t, list.APIResources, 1, "subresources must be filtered out")
+	require.Equal(t, "widgets", list.APIResources[0].Name)
+	require.Equal(t, "Widget", list.APIResources[0].Kind)
 }
 
-// TestDiscoveryClient_APIGroupInfo_PartialErrorWithResults verifies that when
+// TestDiscoveryClient_PreferredVersion_PartialErrorWithResults verifies that when
 // ServerPreferredResources reports an ErrGroupDiscoveryFailed but still produced usable
-// resources for the requested group, APIGroupInfo returns the resources with no error
+// resources for the requested group, PreferredVersion returns the resources with no error
 // (so DynamicPatcher.updatePreferred can proceed on a partial failure).
-func TestDiscoveryClient_APIGroupInfo_PartialErrorWithResults(t *testing.T) {
+func TestDiscoveryClient_PreferredVersion_PartialErrorWithResults(t *testing.T) {
 	const (
 		wantGroup, wantVersion = "alpha.example.com", "v1"
 		brokenGroup            = "broken.example.com"
@@ -277,10 +278,10 @@ func TestDiscoveryClient_APIGroupInfo_PartialErrorWithResults(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
-	resources, err := dc.APIGroupInfo(wantGroup)
+	list, err := dc.PreferredVersion(wantGroup)
 	require.NoError(t, err, "partial discovery failure for an unrelated group must not fail the target lookup")
-	require.Len(t, resources, 1)
-	require.Equal(t, "Widget", resources[0].Kind)
+	require.Len(t, list.APIResources, 1)
+	require.Equal(t, "Widget", list.APIResources[0].Kind)
 }
 
 // TestDynamicPatcher_ForceRefresh verifies that ForceRefresh only refreshes groups that

--- a/k8s/dynamic_test.go
+++ b/k8s/dynamic_test.go
@@ -1,0 +1,221 @@
+package k8s
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// discoveryTestServer is a stub apiserver that knows a single (group, version) and records hit paths.
+// Any path it doesn't explicitly handle returns a 200 with empty JSON so the discovery client's
+// partial-failure path doesn't blow up during legacy `/api` probing.
+type discoveryTestServer struct {
+	group   string
+	version string
+	kind    string
+	plural  string
+
+	mu   sync.Mutex
+	hits map[string]int
+
+	srv *httptest.Server
+}
+
+func newDiscoveryTestServer(t *testing.T, group, version, kind, plural string) *discoveryTestServer {
+	t.Helper()
+	ds := &discoveryTestServer{
+		group:   group,
+		version: version,
+		kind:    kind,
+		plural:  plural,
+		hits:    map[string]int{},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ds.mu.Lock()
+		ds.hits[r.URL.Path]++
+		ds.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apis":
+			_ = json.NewEncoder(w).Encode(metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{{
+					Name: ds.group,
+					PreferredVersion: metav1.GroupVersionForDiscovery{
+						GroupVersion: ds.group + "/" + ds.version,
+						Version:      ds.version,
+					},
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: ds.group + "/" + ds.version,
+						Version:      ds.version,
+					}},
+				}},
+			})
+		case "/apis/" + ds.group + "/" + ds.version:
+			_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: ds.group + "/" + ds.version,
+				APIResources: []metav1.APIResource{{
+					Name:       ds.plural,
+					Kind:       ds.kind,
+					Namespaced: true,
+					Verbs:      metav1.Verbs{"get", "list", "patch"},
+				}},
+			})
+		default:
+			// 200 with empty doc to keep discovery's legacy probes quiet.
+			_, _ = w.Write([]byte(`{}`))
+		}
+	})
+
+	ds.srv = httptest.NewServer(mux)
+	t.Cleanup(ds.srv.Close)
+	return ds
+}
+
+func (d *discoveryTestServer) hitCount(path string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.hits[path]
+}
+
+// TestDynamicPatcher_PerGroupDiscoveryRouting proves that when a ClientRegistry is configured with
+// per-group external clients (NewClientConfigWithExternalClients), DynamicPatcher's discovery lookups
+// for each group land on the correct apiserver — i.e. the ClientGenerator's KubeConfigProvider is
+// threaded all the way through to the DiscoveryClient.
+func TestDynamicPatcher_PerGroupDiscoveryRouting(t *testing.T) {
+	const (
+		groupA, versionA, kindA, pluralA = "alpha.example.com", "v1", "Widget", "widgets"
+		groupB, versionB, kindB, pluralB = "beta.example.com", "v2", "Gadget", "gadgets"
+	)
+
+	srvA := newDiscoveryTestServer(t, groupA, versionA, kindA, pluralA)
+	srvB := newDiscoveryTestServer(t, groupB, versionB, kindB, pluralB)
+
+	cfg := NewClientConfigWithExternalClients(map[string]*RemoteRestConfig{
+		groupA: {Host: srvA.srv.URL},
+		groupB: {Host: srvB.srv.URL},
+	})
+	// Base kubeconfig points at a host that MUST NOT be reached; if routing is broken we'll see
+	// the connection failure rather than silently hitting one of the servers.
+	registry := NewClientRegistry(rest.Config{Host: "http://should-not-be-called.invalid"}, cfg)
+
+	patcher, err := NewDynamicPatcher(registry, 0)
+	require.NoError(t, err)
+
+	// Drive a discovery refresh for each group through the real code path.
+	require.NoError(t, patcher.updatePreferred(groupA))
+	require.NoError(t, patcher.updatePreferred(groupB))
+
+	// Server A saw groupA's discovery probe, not groupB's.
+	require.Positive(t, srvA.hitCount("/apis/"+groupA+"/"+versionA), "srvA should have served groupA discovery")
+	require.Zero(t, srvA.hitCount("/apis/"+groupB+"/"+versionB), "srvA must not serve groupB discovery")
+
+	// And vice versa.
+	require.Positive(t, srvB.hitCount("/apis/"+groupB+"/"+versionB), "srvB should have served groupB discovery")
+	require.Zero(t, srvB.hitCount("/apis/"+groupA+"/"+versionA), "srvB must not serve groupA discovery")
+
+	// Cache ended up with the correct preferred version per group.
+	prefA, err := patcher.getPreferred(schema.GroupKind{Group: groupA, Kind: kindA})
+	require.NoError(t, err)
+	require.Equal(t, versionA, prefA.Version)
+	require.Equal(t, pluralA, prefA.Name)
+
+	prefB, err := patcher.getPreferred(schema.GroupKind{Group: groupB, Kind: kindB})
+	require.NoError(t, err)
+	require.Equal(t, versionB, prefB.Version)
+	require.Equal(t, pluralB, prefB.Name)
+}
+
+// TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup exercises APIGroupInfo directly
+// against a server that advertises multiple groups. We only asked about one, so the
+// returned slice should only contain entries for that group.
+func TestDiscoveryClient_APIGroupInfo_FiltersToRequestedGroup(t *testing.T) {
+	const (
+		wantGroup, wantVersion = "alpha.example.com", "v1"
+		otherGroup             = "beta.example.com"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apis":
+			_ = json.NewEncoder(w).Encode(metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{
+					{
+						Name:             wantGroup,
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: wantGroup + "/" + wantVersion, Version: wantVersion},
+						Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: wantGroup + "/" + wantVersion, Version: wantVersion}},
+					},
+					{
+						Name:             otherGroup,
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: otherGroup + "/v1", Version: "v1"},
+						Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: otherGroup + "/v1", Version: "v1"}},
+					},
+				},
+			})
+		case "/apis/" + wantGroup + "/" + wantVersion:
+			_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: wantGroup + "/" + wantVersion,
+				APIResources: []metav1.APIResource{{Name: "widgets", Kind: "Widget", Namespaced: true, Verbs: metav1.Verbs{"get"}}},
+			})
+		case "/apis/" + otherGroup + "/v1":
+			_ = json.NewEncoder(w).Encode(metav1.APIResourceList{
+				TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+				GroupVersion: otherGroup + "/v1",
+				APIResources: []metav1.APIResource{{Name: "gadgets", Kind: "Gadget", Namespaced: true, Verbs: metav1.Verbs{"get"}}},
+			})
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dc := NewDiscoveryClient(rest.Config{Host: server.URL}, nil)
+	resources, err := dc.APIGroupInfo(wantGroup)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.Equal(t, "Widget", resources[0].Kind)
+	require.Equal(t, wantGroup, resources[0].Group)
+	require.Equal(t, wantVersion, resources[0].Version)
+}
+
+// TestDynamicPatcher_ForceRefresh verifies that ForceRefresh only refreshes groups that
+// have already been queried, and re-hits the apiserver for each of them.
+func TestDynamicPatcher_ForceRefresh(t *testing.T) {
+	const group, version, kind, plural = "alpha.example.com", "v1", "Widget", "widgets"
+	srv := newDiscoveryTestServer(t, group, version, kind, plural)
+
+	cfg := NewClientConfigWithExternalClients(map[string]*RemoteRestConfig{
+		group: {Host: srv.srv.URL},
+	})
+	registry := NewClientRegistry(rest.Config{Host: "http://should-not-be-called.invalid"}, cfg)
+
+	patcher, err := NewDynamicPatcher(registry, 0)
+	require.NoError(t, err)
+
+	// No groups queried yet — ForceRefresh must be a no-op (documented behavior).
+	require.NoError(t, patcher.ForceRefresh())
+	require.Zero(t, srv.hitCount("/apis/"+group+"/"+version))
+
+	// Prime the cache for this group.
+	_, err = patcher.getPreferred(schema.GroupKind{Group: group, Kind: kind})
+	require.NoError(t, err)
+	firstHits := srv.hitCount("/apis/" + group + "/" + version)
+	require.Positive(t, firstHits)
+
+	// Now ForceRefresh should re-hit the apiserver for this group.
+	require.NoError(t, patcher.ForceRefresh())
+	require.Greater(t, srv.hitCount("/apis/"+group+"/"+version), firstHits, "ForceRefresh should re-hit discovery")
+}

--- a/resource/client.go
+++ b/resource/client.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"net/url"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 )
 
 const NamespaceAll = ""
@@ -281,9 +281,11 @@ type ClientGenerator interface {
 	// GetCustomRouteClient returns a Client for the provided GroupVersion. This returned Client is not guaranteed to be unique,
 	// and can be shared by other ClientForGV calls.
 	GetCustomRouteClient(schema.GroupVersion, string) (CustomRouteClient, error)
-	// KubeConfigForGroup returns the rest.Config to use for clients that operate on the given API group.
-	// Implementations should apply any per-group routing configuration (such as a KubeConfigProvider),
-	// so callers that only know the group (e.g. DynamicPatcher) can still reach the correct API server
-	// in multi-host setups.
-	KubeConfigForGroup(group string) rest.Config
+}
+
+// DiscoveryClient inspects the API groups and resources exposed by the underlying storage system.
+type DiscoveryClient interface {
+	// APIGroupInfo returns the preferred-version resources exposed by the given API group.
+	// Each entry's Group and Version fields are populated with the resource's preferred GroupVersion.
+	APIGroupInfo(apiGroup string) ([]metav1.APIResource, error)
 }

--- a/resource/client.go
+++ b/resource/client.go
@@ -287,9 +287,10 @@ type ClientGenerator interface {
 	DiscoveryClient() (DiscoveryClient, error)
 }
 
-// DiscoveryClient inspects the API groups and resources exposed by the underlying storage system.
+// DiscoveryClient inspects the API groups and resources exposed by the underlying API server.
 type DiscoveryClient interface {
-	// APIGroupInfo returns the preferred-version resources exposed by the given API group.
-	// Each entry's Group and Version fields are populated with the resource's preferred GroupVersion.
-	APIGroupInfo(apiGroup string) ([]metav1.APIResource, error)
+	// PreferredVersion returns the APIResourceList for the preferred version of the given API group.
+	// The returned list's GroupVersion is the preferred GroupVersion; each APIResource entry's
+	// Group and Version fields are also populated with that same GroupVersion for caller convenience.
+	PreferredVersion(apiGroup string) (*metav1.APIResourceList, error)
 }

--- a/resource/client.go
+++ b/resource/client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 )
 
 const NamespaceAll = ""
@@ -280,4 +281,9 @@ type ClientGenerator interface {
 	// GetCustomRouteClient returns a Client for the provided GroupVersion. This returned Client is not guaranteed to be unique,
 	// and can be shared by other ClientForGV calls.
 	GetCustomRouteClient(schema.GroupVersion, string) (CustomRouteClient, error)
+	// KubeConfigForGroup returns the rest.Config to use for clients that operate on the given API group.
+	// Implementations should apply any per-group routing configuration (such as a KubeConfigProvider),
+	// so callers that only know the group (e.g. DynamicPatcher) can still reach the correct API server
+	// in multi-host setups.
+	KubeConfigForGroup(group string) rest.Config
 }

--- a/resource/client.go
+++ b/resource/client.go
@@ -281,6 +281,10 @@ type ClientGenerator interface {
 	// GetCustomRouteClient returns a Client for the provided GroupVersion. This returned Client is not guaranteed to be unique,
 	// and can be shared by other ClientForGV calls.
 	GetCustomRouteClient(schema.GroupVersion, string) (CustomRouteClient, error)
+	// DiscoveryClient returns a DiscoveryClient that can be used to inspect API groups exposed by the
+	// underlying storage system. Implementations may keep per-group clients internally to handle
+	// setups where different groups are routed to different hosts.
+	DiscoveryClient() (DiscoveryClient, error)
 }
 
 // DiscoveryClient inspects the API groups and resources exposed by the underlying storage system.

--- a/resource/client.go
+++ b/resource/client.go
@@ -282,7 +282,7 @@ type ClientGenerator interface {
 	// and can be shared by other ClientForGV calls.
 	GetCustomRouteClient(schema.GroupVersion, string) (CustomRouteClient, error)
 	// DiscoveryClient returns a DiscoveryClient that can be used to inspect API groups exposed by the
-	// underlying storage system. Implementations may keep per-group clients internally to handle
+	// underlying API server. Implementations may keep per-group clients internally to handle
 	// setups where different groups are routed to different hosts.
 	DiscoveryClient() (DiscoveryClient, error)
 }

--- a/resource/store_test.go
+++ b/resource/store_test.go
@@ -951,6 +951,10 @@ func (g *mockClientGenerator) GetCustomRouteClient(s schema.GroupVersion, defaul
 	return nil, nil
 }
 
+func (g *mockClientGenerator) DiscoveryClient() (DiscoveryClient, error) {
+	return nil, nil
+}
+
 type mockClient struct {
 	GetFunc                func(ctx context.Context, identifier Identifier) (Object, error)
 	GetIntoFunc            func(ctx context.Context, identifier Identifier, into Object) error

--- a/resource/store_test.go
+++ b/resource/store_test.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 )
 
 type TestGroup struct {
@@ -950,10 +949,6 @@ func (g *mockClientGenerator) GetCustomRouteClient(s schema.GroupVersion, defaul
 		return g.GetClientFunc(s, defaultNamespace)
 	}
 	return nil, nil
-}
-
-func (g *mockClientGenerator) KubeConfigForGroup(string) rest.Config {
-	return rest.Config{}
 }
 
 type mockClient struct {

--- a/resource/store_test.go
+++ b/resource/store_test.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 )
 
 type TestGroup struct {
@@ -949,6 +950,10 @@ func (g *mockClientGenerator) GetCustomRouteClient(s schema.GroupVersion, defaul
 		return g.GetClientFunc(s, defaultNamespace)
 	}
 	return nil, nil
+}
+
+func (g *mockClientGenerator) KubeConfigForGroup(string) rest.Config {
+	return rest.Config{}
 }
 
 type mockClient struct {

--- a/simple/app.go
+++ b/simple/app.go
@@ -332,8 +332,7 @@ func NewApp(config AppConfig) (*App, error) {
 	if discoveryRefresh == 0 {
 		discoveryRefresh = time.Minute * 10
 	}
-	discovery := k8s.NewDiscoveryClient(config.KubeConfig, k8s.DefaultClientConfig().KubeConfigProvider)
-	p, err := k8s.NewDynamicPatcher(clients, discovery, discoveryRefresh)
+	p, err := k8s.NewDynamicPatcher(clients, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/simple/app.go
+++ b/simple/app.go
@@ -332,7 +332,8 @@ func NewApp(config AppConfig) (*App, error) {
 	if discoveryRefresh == 0 {
 		discoveryRefresh = time.Minute * 10
 	}
-	p, err := k8s.NewDynamicPatcher(clients, discoveryRefresh)
+	discovery := k8s.NewDiscoveryClient(config.KubeConfig, k8s.DefaultClientConfig().KubeConfigProvider)
+	p, err := k8s.NewDynamicPatcher(clients, discovery, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/simple/app.go
+++ b/simple/app.go
@@ -332,7 +332,7 @@ func NewApp(config AppConfig) (*App, error) {
 	if discoveryRefresh == 0 {
 		discoveryRefresh = time.Minute * 10
 	}
-	p, err := k8s.NewDynamicPatcher(&config.KubeConfig, discoveryRefresh)
+	p, err := k8s.NewDynamicPatcher(clients, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -106,7 +106,7 @@ func NewOperator(cfg OperatorConfig) (*Operator, error) {
 		discoveryRefresh = time.Minute * 10
 	}
 
-	patcher, err := k8s.NewDynamicPatcher(&cfg.KubeConfig, discoveryRefresh)
+	patcher, err := k8s.NewDynamicPatcher(cg, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -106,7 +106,8 @@ func NewOperator(cfg OperatorConfig) (*Operator, error) {
 		discoveryRefresh = time.Minute * 10
 	}
 
-	patcher, err := k8s.NewDynamicPatcher(cg, discoveryRefresh)
+	discovery := k8s.NewDiscoveryClient(cfg.KubeConfig, nil)
+	patcher, err := k8s.NewDynamicPatcher(cg, discovery, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/simple/operator.go
+++ b/simple/operator.go
@@ -106,8 +106,7 @@ func NewOperator(cfg OperatorConfig) (*Operator, error) {
 		discoveryRefresh = time.Minute * 10
 	}
 
-	discovery := k8s.NewDiscoveryClient(cfg.KubeConfig, nil)
-	patcher, err := k8s.NewDynamicPatcher(cg, discovery, discoveryRefresh)
+	patcher, err := k8s.NewDynamicPatcher(cg, discoveryRefresh)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What Changed? Why?

`DynamicPatcher` used one `rest.Config` for all groups, so finalizer patches hit the wrong apiserver when `KubeConfigProvider` routes groups to different hosts. It also stored subresource entries over parent entries in its preferred-version cache, producing broken request URLs.

Motivating error seen in a multi-apiserver deployment of the example todo app:

```
{"level":"ERROR","msg":"error adding in-progress finalizer","component":"OpinionatedWatcher","kind":"Todo","namespace":"default","name":"todo-l75hd","error":"preferred resource not found for kind 'Todo.exampletodoapp.ext.grafana.app'"}
```

Discovery was hitting the local apiserver, which doesn't know about `exampletodoapp.ext.grafana.app` — that group lives on a different host. The cache never populated for it, so every finalizer patch failed with "preferred resource not found".

Key changes:

- **Per-group routing.** `DynamicPatcher` now takes a `ClientGenerator`; discovery goes through `ClientGenerator.DiscoveryClient()` and patch/get through `ClientFor` at the preferred version. Per-group `KubeConfigProvider` routing is preserved end-to-end.
- **Subresource filter.** `APIGroupInfo` skips entries whose `Name` contains `/` (`pods/status`, `deployments/scale`, etc.) so they don't overwrite the parent resource in the cache.
- **Scoped cache state.** `preferred` and `lastUpdate` are keyed per group; one group's discovery failure no longer poisons the whole cache. Target-group failures with no usable results surface a real error instead of the downstream "preferred resource not found".
- **`updateInterval` fix.** `>= 0` → `> 0`, so `interval == 0` actually disables refresh as the docstring claims.

### How was it tested?

Unit tests added in `k8s/dynamic_test.go` (per-group routing, subresource filter, partial-error handling, `ForceRefresh`). End-to-end verified by running the example operator (https://github.com/grafana/app-sdk-example-todo-app) against a local k3d cluster with managed kinds routed to different apiservers — the error above no longer reproduces.

### Where did you document your changes?

Godoc on the new/changed types and constructors.

### Notes to Reviewers

Breaking changes:

- `resource.ClientGenerator` gains `DiscoveryClient() (DiscoveryClient, error)` — out-of-tree implementations must add it.
- `NewDynamicPatcher(*rest.Config, interval)` → `NewDynamicPatcher(ClientGenerator, interval)`.
- `DynamicPatcher.Get`/`Patch` + `DynamicKindPatcher.Get`/`Patch` return `resource.Object` (concrete type `*resource.UntypedObject`) instead of `*resource.UnstructuredWrapper`.
- `DynamicPatcher.ForceRefresh()` only refreshes groups already queried; no-op on a fresh patcher.

---
PR description was generated by Claude Code.