### PR TITLE
chore: typo sweep — `recieved` → `received`, `commited` → `committed`

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -144,7 +144,7 @@ $ grafana-app-sdk project local generate
 ```
 
 This generates the kube manifests and k3d config file based on your `local/config.yaml`. The generated manifests and config are placed in `local/generated`.
-_Generally, this directory should not be commited to source control_, as the k3d config requires an absolute path for your mounted volumes, which is user-specific. Additionally, local deployments should be re-generating the kubernetes manifests every time.
+_Generally, this directory should not be committed to source control_, as the k3d config requires an absolute path for your mounted volumes, which is user-specific. Additionally, local deployments should be re-generating the kubernetes manifests every time.
 
 ```
 $ sh local/scripts/cluster.sh create "local/generated/k3d-config.json"

--- a/operator/concurrentwatcher_test.go
+++ b/operator/concurrentwatcher_test.go
@@ -314,7 +314,7 @@ func TestConcurrentWatcher(t *testing.T) {
 		assert.Equal(t, int64(2), mock.updateAttempts.Load())
 		assert.Equal(t, int64(1), mock.deleteAttempts.Load())
 		assert.Equal(t, int64(0), errCount.Load())
-		// Events recieved should be in the same order of events triggered always.
+		// Events received should be in the same order of events triggered always.
 		assert.Equal(t, []string{"add", "update", "update", "delete"}, events)
 	})
 


### PR DESCRIPTION
Two single-character typo fixes caught by a repo-wide sweep:

- \`operator/concurrentwatcher_test.go:317\` — inline comment: \`recieved\` → \`received\`
- \`docs/local-development.md:147\` — prose: \`commited\` → \`committed\`

No functional change. \`go test -count=1 -run TestConcurrentWatcher ./operator/...\` still passes locally.