### PR TITLE
chore(codegen): populate config.cue.tmpl with all defaults

### DIFF
--- a/cmd/grafana-app-sdk/templates/config.cue.tmpl
+++ b/cmd/grafana-app-sdk/templates/config.cue.tmpl
@@ -4,8 +4,10 @@ package kinds
 // You can modify this as you see fit. These are the defaults:
 config: {
 	definitions: {
+		genManifest:     true
+		genCRDs:         true
 		manifestSchemas: true
-		manifestVersion: "v1alpha1"
+		manifestVersion: "v1alpha2"
 		path:            "definitions"
 		encoding:        "json"
 	}
@@ -15,9 +17,13 @@ config: {
 	}
 
 	codegen: {
+		goModule:                       ""
+		goModGenPath:                   ""
 		goGenPath:                      "pkg/generated/"
 		tsGenPath:                      "plugin/src/generated/"
 		enableK8sPostProcessing:        false
 		enableOperatorStatusGeneration: true
 	}
+
+	manifestSelectors: ["manifest"]
 }


### PR DESCRIPTION
## What Changed? Why?

The generated `config.cue` template was missing several fields defined in `codegen/cuekind/def.cue`:
- `definitions.genManifest`, `definitions.genCRDs`
- `codegen.goModule`, `codegen.goModGenPath`
- `manifestSelectors`

Also fixes `manifestVersion` default from `v1alpha1` → `v1alpha2` to match the actual default in `def.cue`.

Inspired by https://github.com/grafana/deployment_tools/pull/573288.

### How was it tested?

Manual inspection against `codegen/cuekind/def.cue`.

### Where did you document your changes?

N/A.

### Notes to Reviewers

---
_Description generated by Claude Code._