### PR TITLE
[codegen] Generated Copy Code

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -127,7 +127,10 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 	}
 
 	// Resource
-	resourceFiles, err := generatorForManifest.Generate(cuekind.ResourceGenerator(goModule, goModGenPath, cfg.GroupKinds()), cfg.ManifestSelectors...)
+	resourceFiles, err := generatorForManifest.Generate(cuekind.ResourceGenerator(goModule, goModGenPath, cuekind.ResourceGeneratorConfig{
+		GroupKinds:       cfg.GroupKinds(),
+		GenerateCopyCode: cfg.Codegen.EnableGeneratedCopyCode,
+	}), cfg.ManifestSelectors...)
 	if err != nil {
 		return nil, err
 	}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -34,6 +34,7 @@ type CodegenConfig struct {
 	TsGenPath                      string
 	EnableK8sPostProcessing        bool
 	EnableOperatorStatusGeneration bool
+	EnableGeneratedCopyCode        bool
 }
 
 type Config struct {

--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -66,6 +66,8 @@ _kubeObjectMetadata: {
 	enableK8sPostProcessing: bool | *false
 	// Generate operator state code.
 	enableOperatorStatusGeneration: bool | *true
+	// Generate `CopyInto` methods on go struct types, and avoid using `resource.CopyObjectInto` and reflection for copies
+	enableGeneratedCopyCode: bool | *false
 }
 
 Config: {

--- a/codegen/cuekind/generators.go
+++ b/codegen/cuekind/generators.go
@@ -21,42 +21,60 @@ func CRDGenerator(outputEncoder jennies.CRDOutputEncoder, outputExtension string
 	return g
 }
 
+type ResourceGeneratorConfig struct {
+	// GroupKinds dictates whether kinds are packaged together by group,
+	// or split into separate packages for each kind.
+	// When true, kinds are packaged together based on group.
+	GroupKinds bool
+	// GenerateCopyCode dictates whether CopyInto methods will be generated
+	// for each go struct. This governs the logic of DeepCopy/DeepCopyInto
+	// for the subresource and object types. If false, reflection is used
+	// to handle deep copying (see resource.CopyObjectInto).
+	GenerateCopyCode bool
+}
+
 // ResourceGenerator returns a collection of jennies which generate backend resource code from kinds.
 // The `versioned` parameter governs whether to generate all versions where codegen.backend == true,
 // or just generate code for the current version.
 // If `groupKinds` is true, kinds within the same group will exist in the same package.
 // When combined with `versioned`, each version package will contain all kinds in the group
 // which have a schema for that version.
-func ResourceGenerator(projectRepo, generatedAPIPath string, groupKinds bool) *codejen.JennyList[codegen.AppManifest] {
+func ResourceGenerator(projectRepo, generatedAPIPath string, cfg ResourceGeneratorConfig) *codejen.JennyList[codegen.AppManifest] {
+	copyFunc := ""
+	if cfg.GenerateCopyCode {
+		copyFunc = "CopyInto"
+	}
 	g := codejen.JennyListWithNamer[codegen.AppManifest](namerFuncManifest)
 	g.Append(
 		&jennies.GoTypes{
 			Depth:                1,
 			AddKubernetesCodegen: true,
-			GroupByKind:          !groupKinds,
+			GroupByKind:          !cfg.GroupKinds,
 			AnyAsInterface:       true,                 // This is for compatibility with kube openAPI generator, which has issues with map[string]any
 			ExcludeFields:        []string{"metadata"}, // We don't want an object generated for the metadata, as we use the k8s metadata objects
 			OpenAPINamer: func(info jennies.OpenAPINamerInfo) string {
-				path := filepath.Join(projectRepo, generatedAPIPath, jennies.GetGeneratedGoTypePath(!groupKinds, info.ShortGroup, info.Version, strings.ToLower(info.Kind)), info.TypeName)
+				path := filepath.Join(projectRepo, generatedAPIPath, jennies.GetGeneratedGoTypePath(!cfg.GroupKinds, info.ShortGroup, info.Version, strings.ToLower(info.Kind)), info.TypeName)
 				return apiserver.ToOpenAPIName(path)
 			},
+			GenerateCopyCode: cfg.GenerateCopyCode,
 		},
 		&jennies.ResourceObjectGenerator{
-			SubresourceTypesArePrefixed: groupKinds,
-			GroupByKind:                 !groupKinds,
+			SubresourceTypesArePrefixed: cfg.GroupKinds,
+			GroupByKind:                 !cfg.GroupKinds,
 			OpenAPINamer: func(info jennies.OpenAPINamerInfo) string {
-				path := filepath.Join(projectRepo, generatedAPIPath, jennies.GetGeneratedGoTypePath(!groupKinds, info.ShortGroup, info.Version, strings.ToLower(info.Kind)), info.TypeName)
+				path := filepath.Join(projectRepo, generatedAPIPath, jennies.GetGeneratedGoTypePath(!cfg.GroupKinds, info.ShortGroup, info.Version, strings.ToLower(info.Kind)), info.TypeName)
 				return apiserver.ToOpenAPIName(path)
 			},
+			GoTypeCopyIntoFunction: copyFunc,
 		},
 		&jennies.SchemaGenerator{
-			GroupByKind: !groupKinds,
+			GroupByKind: !cfg.GroupKinds,
 		},
 		&jennies.CodecGenerator{
-			GroupByKind: !groupKinds,
+			GroupByKind: !cfg.GroupKinds,
 		},
 		&jennies.Constants{
-			GroupByKind: !groupKinds,
+			GroupByKind: !cfg.GroupKinds,
 		},
 	)
 	return g

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -58,7 +58,10 @@ func TestResourceGenerator(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("group by kind", func(t *testing.T) {
-		files, err := ResourceGenerator("codegen-tests", "pkg/generated", false).Generate(kinds...)
+		files, err := ResourceGenerator("codegen-tests", "pkg/generated", ResourceGeneratorConfig{
+			GroupKinds:       false,
+			GenerateCopyCode: true,
+		}).Generate(kinds...)
 		require.NoError(t, err)
 		// Check number of files generated
 		// 12 (7 -> object, spec, status, schema, codec, constants) * 2 versions
@@ -68,7 +71,10 @@ func TestResourceGenerator(t *testing.T) {
 	})
 
 	t.Run("group by group", func(t *testing.T) {
-		files, err := ResourceGenerator("codegen-tests", "pkg/generated", true).Generate(kinds...)
+		files, err := ResourceGenerator("codegen-tests", "pkg/generated", ResourceGeneratorConfig{
+			GroupKinds:       true,
+			GenerateCopyCode: true,
+		}).Generate(kinds...)
 		require.NoError(t, err)
 		// Check number of files generated
 		// 12 (7 -> object, spec, status, schema, codec, constants) * 2 versions
@@ -78,7 +84,10 @@ func TestResourceGenerator(t *testing.T) {
 	})
 
 	t.Run("group by group, multiple kinds", func(t *testing.T) {
-		files, err := ResourceGenerator("codegen-tests", "pkg/generated", true).Generate(sameGroupKinds...)
+		files, err := ResourceGenerator("codegen-tests", "pkg/generated", ResourceGeneratorConfig{
+			GroupKinds:       true,
+			GenerateCopyCode: true,
+		}).Generate(sameGroupKinds...)
 		require.NoError(t, err)
 		// Check number of files generated
 		assert.Len(t, files, 23, "should be 23 files generated, got %d", len(files))

--- a/codegen/cuekind/testing/config.cue
+++ b/codegen/cuekind/testing/config.cue
@@ -12,6 +12,7 @@ configJson: {
 		goModule:     "codegen-tests"
 		goModGenPath: "pkg/generated"
 		tsGenPath:    "codegen/testing/golden_generated/typescript/versioned"
+		enableGeneratedCopyCode: true
 	}
 	kinds: {
 		grouping: "group"
@@ -31,6 +32,7 @@ configYaml: {
 		goModule:     "codegen-tests"
 		goModGenPath: "pkg/generated"
 		tsGenPath:    "codegen/testing/golden_generated/typescript/versioned"
+		enableGeneratedCopyCode: true
 	}
 	kinds: {
 		grouping: "group"
@@ -51,6 +53,7 @@ configKind: {
 		goModule:     "codegen-tests"
 		goModGenPath: "pkg/generated"
 		tsGenPath:    "codegen/testing/golden_generated/typescript/versioned"
+		enableGeneratedCopyCode: true
 	}
 	kinds: {
 		grouping: "kind"
@@ -68,6 +71,7 @@ configIntegrationGen1: {
 		goGenPath: "pkg/gen1"
 		tsGenPath: "ts/gen1"
 		goModGenPath: "pkg/generated"
+		enableGeneratedCopyCode: true
 	}
 	kinds: {
 		grouping: "kind"
@@ -85,6 +89,7 @@ configIntegrationGen2: {
 		goGenPath: "pkg/gen2"
 		tsGenPath: "ts/gen2"
 		goModGenPath: "pkg/generated"
+		enableGeneratedCopyCode: true
 	}
 	kinds: {
 		grouping: "group"
@@ -95,4 +100,5 @@ configIntegrationGen2: {
 configIntegrationGen3: {
 	manifestSelectors: ["integrationManifest"]
 	kinds: grouping: "group"
+	codegen: enableGeneratedCopyCode: true
 }

--- a/codegen/jennies/gotypes.go
+++ b/codegen/jennies/gotypes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/format"
 	"path"
+	"reflect"
 	"strings"
 
 	"cuelang.org/go/cue"
@@ -71,6 +72,10 @@ type GoTypes struct {
 	// If nil, types will not implement OpenAPIModelNamer, which will cause problems with
 	// apiservers if using the default apiserver.AppInstaller.
 	OpenAPINamer func(OpenAPINamerInfo) string
+
+	// GenerateCopyCode dictates whether a `CopyInto` receiver method will be generated for each struct type.
+	// The `CopyInto` method copies the type into a pointer to an instance of the same type.
+	GenerateCopyCode bool
 }
 
 type OpenAPINamerInfo struct {
@@ -199,6 +204,7 @@ func (g *GoTypes) generateFilesAtDepth(v cue.Value, schemaPath cue.Path, currDep
 			NamePrefix:                     cfg.NamePrefix,
 			AddKubernetesOpenAPIGenComment: g.AddKubernetesCodegen && (len(fieldName) != 1 || fieldName[0] != "metadata"),
 			AnyAsInterface:                 g.AnyAsInterface,
+			GenerateCopyCode:               g.GenerateCopyCode,
 		}, len(v.Path().Selectors())-(g.Depth-g.NamingDepth), namerFunc)
 		if err != nil {
 			return nil, fmt.Errorf("error converting schema path %s.%s to go type: %w", schemaPath.String(), fieldName, err)
@@ -236,6 +242,9 @@ type CUEGoConfig struct {
 
 	// NamePrefix prefixes all generated types with the provided NamePrefix
 	NamePrefix string
+
+	// GenerateCopyCode dictates whether struct go types will have a CopyInto receiver method generated for them
+	GenerateCopyCode bool
 }
 
 func GoTypesFromCUE(v cue.Value, cfg CUEGoConfig, maxNamingDepth int, namerFunc func(string) string) ([]byte, error) {
@@ -277,6 +286,26 @@ func GoTypesFromCUE(v cue.Value, cfg CUEGoConfig, maxNamingDepth int, namerFunc 
 			CustomTemplatesFS: templates.GetCogTemplates(),
 			CustomTemplatesFuncs: map[string]any{
 				"namerFunc": namerFunc,
+				"arr": func(items ...any) []any {
+					return items
+				},
+				"concat": func(items ...string) string {
+					return strings.Join(items, "")
+				},
+				"noPtr": func(item any) any {
+					// reflect.ValueOf(item) is non-addressable, so allocate an addressable copy.
+					src := reflect.ValueOf(item)
+					v := reflect.New(src.Type()).Elem()
+					v.Set(src)
+					v.FieldByName("Nullable").SetBool(false)
+					return v.Interface()
+				},
+				"generateCopyCode": func() bool {
+					return cfg.GenerateCopyCode
+				},
+				"copyFunctionName": func() string {
+					return "CopyInto"
+				},
 			},
 		})
 

--- a/codegen/jennies/gotypes.go
+++ b/codegen/jennies/gotypes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/format"
 	"path"
-	"reflect"
 	"strings"
 
 	"cuelang.org/go/cue"
@@ -292,19 +291,17 @@ func GoTypesFromCUE(v cue.Value, cfg CUEGoConfig, maxNamingDepth int, namerFunc 
 				"concat": func(items ...string) string {
 					return strings.Join(items, "")
 				},
-				"noPtr": func(item any) any {
-					// reflect.ValueOf(item) is non-addressable, so allocate an addressable copy.
-					src := reflect.ValueOf(item)
-					v := reflect.New(src.Type()).Elem()
-					v.Set(src)
-					v.FieldByName("Nullable").SetBool(false)
-					return v.Interface()
+				"dePointer": func(s string) string {
+					if len(s) > 1 && s[0] == '*' {
+						return s[1:]
+					}
+					return s
 				},
 				"generateCopyCode": func() bool {
 					return cfg.GenerateCopyCode
 				},
 				"copyFunctionName": func() string {
-					return "CopyInto"
+					return "CopyInto" // TODO: is there a reason to make this customizable?
 				},
 			},
 		})

--- a/codegen/jennies/resourceobject.go
+++ b/codegen/jennies/resourceobject.go
@@ -65,6 +65,11 @@ type ResourceObjectGenerator struct {
 	// If nil, types will not implement OpenAPIModelNamer, which will cause problems with
 	// apiservers if using the default apiserver.AppInstaller.
 	OpenAPINamer func(OpenAPINamerInfo) string
+
+	// GoTypeCopyIntoFunction is the name of the "copy into" function for the go struct types that are subresources
+	// of the Object (spec, status, etc.). If left empty, the generated resource.Object will use resource.CopyObjectInto
+	// instead of calling a method on the subresource type for implementing DeepCopyObject.
+	GoTypeCopyIntoFunction string
 }
 
 func (*ResourceObjectGenerator) JennyName() string {
@@ -135,14 +140,15 @@ func (r *ResourceObjectGenerator) generateObjectFile(kind codegen.VersionedKind,
 		typePrefix = exportField(kind.Kind)
 	}
 	md := templates.ResourceObjectTemplateMetadata{
-		Package:              pkg,
-		TypeName:             kind.Kind,
-		SpecTypeName:         typePrefix + "Spec",
-		ObjectTypeName:       "Object", // Package is the machine name of the object, so this makes it machinename.Object
-		ObjectShortName:      "o",
-		Subresources:         make([]templates.SubresourceMetadata, 0),
-		CustomMetadataFields: customMetadataFields,
-		OpenAPIModelName:     openAPIName,
+		Package:               pkg,
+		TypeName:              kind.Kind,
+		SpecTypeName:          typePrefix + "Spec",
+		ObjectTypeName:        "Object", // Package is the machine name of the object, so this makes it machinename.Object
+		ObjectShortName:       "o",
+		Subresources:          make([]templates.SubresourceMetadata, 0),
+		CustomMetadataFields:  customMetadataFields,
+		OpenAPIModelName:      openAPIName,
+		SubresourceCopyMethod: r.GoTypeCopyIntoFunction,
 	}
 	it, err := kind.Schema.Fields()
 	if err != nil {

--- a/codegen/templates/custom/Custom.tmpl
+++ b/codegen/templates/custom/Custom.tmpl
@@ -1,0 +1,7 @@
+{{- define "object_all_custom_methods" -}}
+{{ template "openapimodelname" .Object }}
+{{- $cc := generateCopyCode -}}
+{{- if $cc -}}
+{{ template "object_copy_method" .Object }}
+{{- end -}}
+{{- end -}}

--- a/codegen/templates/custom/DeepCopyObject.tmpl
+++ b/codegen/templates/custom/DeepCopyObject.tmpl
@@ -23,8 +23,7 @@
     {{- if $resolved.Struct -}}
         {{- if $isPtr -}}
             if {{ $src }} != nil {
-                {{ $deref := $type|noPtr }}
-                {{ $dst }} = new({{ template "print_type" (arr $deref $root) }})
+                {{ $dst }} = new({{ $type | formatType | dePointer }})
                 {{ $src }}.{{ copyFunctionName }}({{ $dst }})
             }
         {{- else -}}
@@ -54,10 +53,12 @@
                 {{ $dst }}[key] = mapVal
             }
             {{- else if and $mapValResolved.Struct $mapValType.Nullable }}
+            // FIXME: this should be unreachable via cog+CUE, but is here just in case
             for key, val := range {{ $src }} {
                 var mapVal {{ template "print_type" (arr $mapValType $root) }}
                 if val != nil {
-                    val.{{ copyFunctionName }}(&mapVal)
+                    mapVal = new({{ $mapValType | formatType | dePointer }})
+                    val.{{ copyFunctionName }}(mapVal)
                 }
                 {{ $dst }}[key] = mapVal
             }

--- a/codegen/templates/custom/DeepCopyObject.tmpl
+++ b/codegen/templates/custom/DeepCopyObject.tmpl
@@ -1,0 +1,99 @@
+{{- define "print_type" -}}
+    {{- $type := index . 0 -}}
+    {{- $root := index . 1 -}}
+    {{- if $type.Ref -}}
+        {{- formatType $type -}}
+    {{- else if $type.Map -}}
+        map[{{- template "print_type" (arr $type.Map.IndexType $root) -}}]{{- template "print_type" (arr $type.Map.ValueType $root) -}}
+    {{- else if $type.Array -}}
+        []{{- template "print_type" (arr $type.Array.ValueType $root) -}}
+    {{- else if $type.Scalar }}
+        {{- $type.Scalar.ScalarKind -}}
+    {{- else -}}
+        any
+    {{- end -}}
+{{- end -}}
+{{- define "copy_type_statement" -}}
+    {{- $src := index . 0 -}}
+    {{- $dst := index . 1 -}}
+    {{- $type := index . 2 -}}
+    {{- $isPtr := index . 3 -}}
+    {{- $root := index . 4 -}}
+    {{- $resolved := $type|resolveRefs }}
+    {{- if $resolved.Struct -}}
+        {{- if $isPtr -}}
+            if {{ $src }} != nil {
+                {{ $deref := $type|noPtr }}
+                {{ $dst }} = new({{ template "print_type" (arr $deref $root) }})
+                {{ $src }}.{{ copyFunctionName }}({{ $dst }})
+            }
+        {{- else -}}
+            {{ $src }}.{{ copyFunctionName }}(&{{ $dst }})
+        {{- end -}}
+    {{- else if $resolved.Array -}}
+        if {{ $src }} != nil {
+            {{ $dst }} = make({{ template "print_type" (arr $resolved $root) }}, len({{ $src }}))
+            {{- $resolvedArray := $resolved.Array.ValueType|resolveRefs -}}
+            {{- if or $resolvedArray.Struct $resolvedArray.Map $resolvedArray.Array }}
+                for idx, val := range {{ $src }} {
+                    {{ template "copy_type_statement" (arr "val" (concat $dst "[idx]") $resolved.Array.ValueType false $root) }}
+                }
+            {{- else }}
+            copy({{ $dst }}, {{ $src }})
+            {{- end }}
+        }
+    {{- else if $resolved.Map -}}
+        if {{ $src }} != nil {
+            {{ $dst }} = make({{ template "print_type" (arr $resolved $root) }})
+            {{- $mapValType := $resolved.Map.ValueType -}}
+            {{- $mapValResolved := $mapValType|resolveRefs -}}
+            {{- if and $mapValResolved.Struct (not $mapValType.Nullable) }}
+            for key, val := range {{ $src }} {
+                var mapVal {{ template "print_type" (arr $mapValType $root) }}
+                val.{{ copyFunctionName }}(&mapVal)
+                {{ $dst }}[key] = mapVal
+            }
+            {{- else if and $mapValResolved.Struct $mapValType.Nullable }}
+            for key, val := range {{ $src }} {
+                var mapVal {{ template "print_type" (arr $mapValType $root) }}
+                if val != nil {
+                    val.{{ copyFunctionName }}(&mapVal)
+                }
+                {{ $dst }}[key] = mapVal
+            }
+            {{- else }}
+            for key, val := range {{ $src }} {
+                {{ template "copy_type_statement" (arr "val" (concat $dst "[key]") $mapValType false $root) }}
+            }
+            {{- end }}
+        }
+    {{- else if $resolved.Disjunction -}}
+    // FIXME: This should never happen, disjunctions are not supported in go
+    {{- else if $resolved.Enum -}}
+    {{ $dst }} = {{ $src }}
+    {{- else if $resolved.Intersection -}}
+    // FIXME: This should never happen, intersections are not supported in go
+    {{- else -}}
+        {{- if $isPtr -}}
+        if {{ $src }} != nil {
+            tmp := *{{ $src }}
+            {{ $dst }} = &tmp
+        }
+        {{- else -}}
+        {{ $dst }} = {{ $src }}
+        {{- end -}}
+    {{- end }}
+{{- end -}}
+{{- define "object_copy_method" -}}
+{{ $obj := . }}
+{{ $objName := $obj.Name|formatObjectName }}
+{{- if $obj.Type.Struct -}}
+// {{ copyFunctionName }} copies the object into another object
+func (o {{ $objName }}) {{ copyFunctionName }}(dst *{{ $objName }}) {
+    {{- range $obj.Type.Struct.Fields -}}
+	    {{- $field := .Name|formatFieldName }}
+	    {{ template "copy_type_statement" (arr (concat "o." $field) (concat "dst." $field) .Type (not .Required) $obj) }}
+	{{- end -}}
+}
+{{- end -}}
+{{- end -}}

--- a/codegen/templates/custom/OpenAPIModelName.tmpl
+++ b/codegen/templates/custom/OpenAPIModelName.tmpl
@@ -1,6 +1,7 @@
-{{- define "object_all_custom_methods" -}}
-{{ $objName := .Object.Name|formatObjectName }}
-{{- if or .Object.Type.Struct .Object.Type.Enum .Object.Type.Map -}}
+{{- define "openapimodelname" -}}
+{{ $obj := . }}
+{{ $objName := $obj.Name|formatObjectName }}
+{{- if or $obj.Type.Struct $obj.Type.Enum $obj.Type.Map -}}
 // OpenAPIModelName returns the OpenAPI model name for {{ $objName }}.
 func ({{ $objName }}) OpenAPIModelName() string {
 	return "{{ namerFunc $objName }}"

--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -295,7 +295,11 @@ func (s *{{.SpecTypeName}}) DeepCopy() *{{.SpecTypeName}} {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *{{.SpecTypeName}}) DeepCopyInto(dst *{{.SpecTypeName}}) {
+	{{- if .SubresourceCopyMethod }}
+	s.{{ .SubresourceCopyMethod }}(dst)
+	{{- else }}
 	resource.CopyObjectInto(dst, s)
+	{{- end }}
 }
 
 {{ range .Subresources }}// DeepCopy creates a full deep copy of {{.TypeName}}
@@ -307,6 +311,10 @@ func(s *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
 
 // DeepCopyInto deep copies {{.TypeName}} into another {{.TypeName}} object
 func(s *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
+	{{- if $.SubresourceCopyMethod }}
+	s.{{ $.SubresourceCopyMethod }}(dst)
+	{{- else }}
 	resource.CopyObjectInto(dst, s)
+	{{- end }}
 }
 {{ end }}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -106,14 +106,15 @@ var (
 
 // ResourceObjectTemplateMetadata is the metadata required by the Resource Object template
 type ResourceObjectTemplateMetadata struct {
-	Package              string
-	TypeName             string
-	SpecTypeName         string
-	ObjectTypeName       string
-	ObjectShortName      string
-	OpenAPIModelName     string
-	Subresources         []SubresourceMetadata
-	CustomMetadataFields []ObjectMetadataField
+	Package               string
+	TypeName              string
+	SpecTypeName          string
+	ObjectTypeName        string
+	ObjectShortName       string
+	OpenAPIModelName      string
+	SubresourceCopyMethod string
+	Subresources          []SubresourceMetadata
+	CustomMetadataFields  []ObjectMetadataField
 }
 
 // SubresourceMetadata is subresource information used in templates

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *CustomKindSpec) DeepCopy() *CustomKindSpec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *CustomKindSpec) DeepCopyInto(dst *CustomKindSpec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of CustomKindStatus
@@ -330,5 +330,5 @@ func (s *CustomKindStatus) DeepCopy() *CustomKindStatus {
 
 // DeepCopyInto deep copies CustomKindStatus into another CustomKindStatus object
 func (s *CustomKindStatus) DeepCopyInto(dst *CustomKindStatus) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_spec_gen.go.txt
@@ -17,3 +17,9 @@ func NewCustomKindSpec() *CustomKindSpec {
 func (CustomKindSpec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v0_0.CustomKindSpec"
 }
+
+// CopyInto copies the object into another object
+func (o CustomKindSpec) CopyInto(dst *CustomKindSpec) {
+	dst.Field1 = o.Field1
+	dst.DeprecatedField = o.DeprecatedField
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (CustomKindstatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v0_0.CustomKindstatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o CustomKindstatusOperatorState) CopyInto(dst *CustomKindstatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type CustomKindStatus struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewCustomKindStatus() *CustomKindStatus {
 // OpenAPIModelName returns the OpenAPI model name for CustomKindStatus.
 func (CustomKindStatus) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v0_0.CustomKindStatus"
+}
+
+// CopyInto copies the object into another object
+func (o CustomKindStatus) CopyInto(dst *CustomKindStatus) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]CustomKindstatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal CustomKindstatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
@@ -350,7 +350,7 @@ func (s *CustomKindSpec) DeepCopy() *CustomKindSpec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *CustomKindSpec) DeepCopyInto(dst *CustomKindSpec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of CustomKindStatus
@@ -362,5 +362,5 @@ func (s *CustomKindStatus) DeepCopy() *CustomKindStatus {
 
 // DeepCopyInto deep copies CustomKindStatus into another CustomKindStatus object
 func (s *CustomKindStatus) DeepCopyInto(dst *CustomKindStatus) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
@@ -28,6 +28,32 @@ func (CustomKindInnerObject1) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindInnerObject1"
 }
 
+// CopyInto copies the object into another object
+func (o CustomKindInnerObject1) CopyInto(dst *CustomKindInnerObject1) {
+	dst.InnerField1 = o.InnerField1
+	if o.InnerField2 != nil {
+		dst.InnerField2 = make([]string, len(o.InnerField2))
+		copy(dst.InnerField2, o.InnerField2)
+	}
+	if o.InnerField3 != nil {
+		dst.InnerField3 = make([]CustomKindInnerObject2, len(o.InnerField3))
+		for idx, val := range o.InnerField3 {
+			val.CopyInto(&dst.InnerField3[idx])
+		}
+	}
+	if o.InnerField4 != nil {
+		dst.InnerField4 = make([]map[string]any, len(o.InnerField4))
+		for idx, val := range o.InnerField4 {
+			if val != nil {
+				dst.InnerField4[idx] = make(map[string]any)
+				for key, val := range val {
+					dst.InnerField4[idx][key] = val
+				}
+			}
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type CustomKindInnerObject2 struct {
 	Name    string                 `json:"name"`
@@ -44,6 +70,17 @@ func NewCustomKindInnerObject2() *CustomKindInnerObject2 {
 // OpenAPIModelName returns the OpenAPI model name for CustomKindInnerObject2.
 func (CustomKindInnerObject2) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindInnerObject2"
+}
+
+// CopyInto copies the object into another object
+func (o CustomKindInnerObject2) CopyInto(dst *CustomKindInnerObject2) {
+	dst.Name = o.Name
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -65,6 +102,15 @@ func (CustomKindType1) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindType1"
 }
 
+// CopyInto copies the object into another object
+func (o CustomKindType1) CopyInto(dst *CustomKindType1) {
+	dst.Group = o.Group
+	if o.Options != nil {
+		dst.Options = make([]string, len(o.Options))
+		copy(dst.Options, o.Options)
+	}
+}
+
 // +k8s:openapi-gen=true
 type CustomKindType2 struct {
 	Group   string                 `json:"group"`
@@ -83,6 +129,17 @@ func (CustomKindType2) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindType2"
 }
 
+// CopyInto copies the object into another object
+func (o CustomKindType2) CopyInto(dst *CustomKindType2) {
+	dst.Group = o.Group
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type CustomKindRecursiveList struct {
 	Val  string                   `json:"val"`
@@ -97,6 +154,16 @@ func NewCustomKindRecursiveList() *CustomKindRecursiveList {
 // OpenAPIModelName returns the OpenAPI model name for CustomKindRecursiveList.
 func (CustomKindRecursiveList) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindRecursiveList"
+}
+
+// CopyInto copies the object into another object
+func (o CustomKindRecursiveList) CopyInto(dst *CustomKindRecursiveList) {
+	dst.Val = o.Val
+	if o.Next != nil {
+
+		dst.Next = new(CustomKindRecursiveList)
+		o.Next.CopyInto(dst.Next)
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -129,6 +196,29 @@ func NewCustomKindSpec() *CustomKindSpec {
 // OpenAPIModelName returns the OpenAPI model name for CustomKindSpec.
 func (CustomKindSpec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindSpec"
+}
+
+// CopyInto copies the object into another object
+func (o CustomKindSpec) CopyInto(dst *CustomKindSpec) {
+	dst.Field1 = o.Field1
+	o.Inner.CopyInto(&dst.Inner)
+	dst.Union = o.Union
+	if o.Map != nil {
+		dst.Map = make(map[string]CustomKindType2)
+		for key, val := range o.Map {
+			var mapVal CustomKindType2
+			val.CopyInto(&mapVal)
+			dst.Map[key] = mapVal
+		}
+	}
+	dst.Timestamp = o.Timestamp
+	dst.Enum = o.Enum
+	dst.I32 = o.I32
+	dst.I64 = o.I64
+	dst.BoolField = o.BoolField
+	dst.FloatField = o.FloatField
+	o.LinkedList.CopyInto(&dst.LinkedList)
+	dst.ExclusiveInt = o.ExclusiveInt
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_spec_gen.go.txt
@@ -160,7 +160,6 @@ func (CustomKindRecursiveList) OpenAPIModelName() string {
 func (o CustomKindRecursiveList) CopyInto(dst *CustomKindRecursiveList) {
 	dst.Val = o.Val
 	if o.Next != nil {
-
 		dst.Next = new(CustomKindRecursiveList)
 		o.Next.CopyInto(dst.Next)
 	}

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (CustomKindstatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindstatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o CustomKindstatusOperatorState) CopyInto(dst *CustomKindstatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type CustomKindStatus struct {
 	StatusField1 string `json:"statusField1"`
@@ -43,6 +59,25 @@ func NewCustomKindStatus() *CustomKindStatus {
 // OpenAPIModelName returns the OpenAPI model name for CustomKindStatus.
 func (CustomKindStatus) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindStatus"
+}
+
+// CopyInto copies the object into another object
+func (o CustomKindStatus) CopyInto(dst *CustomKindStatus) {
+	dst.StatusField1 = o.StatusField1
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]CustomKindstatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal CustomKindstatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *TestKind2Spec) DeepCopy() *TestKind2Spec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *TestKind2Spec) DeepCopyInto(dst *TestKind2Spec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of TestKind2Status
@@ -330,5 +330,5 @@ func (s *TestKind2Status) DeepCopy() *TestKind2Status {
 
 // DeepCopyInto deep copies TestKind2Status into another TestKind2Status object
 func (s *TestKind2Status) DeepCopyInto(dst *TestKind2Status) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_spec_gen.go.txt
@@ -16,3 +16,8 @@ func NewTestKind2Spec() *TestKind2Spec {
 func (TestKind2Spec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKind2Spec"
 }
+
+// CopyInto copies the object into another object
+func (o TestKind2Spec) CopyInto(dst *TestKind2Spec) {
+	dst.TestField = o.TestField
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_status_gen.go.txt
@@ -25,6 +25,22 @@ func (TestKind2statusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKind2statusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o TestKind2statusOperatorState) CopyInto(dst *TestKind2statusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type TestKind2Status struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewTestKind2Status() *TestKind2Status {
 // OpenAPIModelName returns the OpenAPI model name for TestKind2Status.
 func (TestKind2Status) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKind2Status"
+}
+
+// CopyInto copies the object into another object
+func (o TestKind2Status) CopyInto(dst *TestKind2Status) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]TestKind2statusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal TestKind2statusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *TestKindSpec) DeepCopy() *TestKindSpec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *TestKindSpec) DeepCopyInto(dst *TestKindSpec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of TestKindStatus
@@ -330,5 +330,5 @@ func (s *TestKindStatus) DeepCopy() *TestKindStatus {
 
 // DeepCopyInto deep copies TestKindStatus into another TestKindStatus object
 func (s *TestKindStatus) DeepCopyInto(dst *TestKindStatus) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_spec_gen.go.txt
@@ -16,3 +16,8 @@ func NewTestKindSpec() *TestKindSpec {
 func (TestKindSpec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKindSpec"
 }
+
+// CopyInto copies the object into another object
+func (o TestKindSpec) CopyInto(dst *TestKindSpec) {
+	dst.StringField = o.StringField
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (TestKindstatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKindstatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o TestKindstatusOperatorState) CopyInto(dst *TestKindstatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type TestKindStatus struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewTestKindStatus() *TestKindStatus {
 // OpenAPIModelName returns the OpenAPI model name for TestKindStatus.
 func (TestKindStatus) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v1.TestKindStatus"
+}
+
+// CopyInto copies the object into another object
+func (o TestKindStatus) CopyInto(dst *TestKindStatus) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]TestKindstatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal TestKindstatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *TestKindSpec) DeepCopy() *TestKindSpec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *TestKindSpec) DeepCopyInto(dst *TestKindSpec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of TestKindStatus
@@ -330,5 +330,5 @@ func (s *TestKindStatus) DeepCopy() *TestKindStatus {
 
 // DeepCopyInto deep copies TestKindStatus into another TestKindStatus object
 func (s *TestKindStatus) DeepCopyInto(dst *TestKindStatus) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_spec_gen.go.txt
@@ -22,3 +22,10 @@ func NewTestKindSpec() *TestKindSpec {
 func (TestKindSpec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v2.TestKindSpec"
 }
+
+// CopyInto copies the object into another object
+func (o TestKindSpec) CopyInto(dst *TestKindSpec) {
+	dst.StringField = o.StringField
+	dst.IntField = o.IntField
+	dst.TimeField = o.TimeField
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (TestKindstatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v2.TestKindstatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o TestKindstatusOperatorState) CopyInto(dst *TestKindstatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type TestKindStatus struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewTestKindStatus() *TestKindStatus {
 // OpenAPIModelName returns the OpenAPI model name for TestKindStatus.
 func (TestKindStatus) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v2.TestKindStatus"
+}
+
+// CopyInto copies the object into another object
+func (o TestKindStatus) CopyInto(dst *TestKindStatus) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]TestKindstatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal TestKindstatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *TestKindSpec) DeepCopy() *TestKindSpec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *TestKindSpec) DeepCopyInto(dst *TestKindSpec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of TestKindStatus
@@ -330,5 +330,5 @@ func (s *TestKindStatus) DeepCopy() *TestKindStatus {
 
 // DeepCopyInto deep copies TestKindStatus into another TestKindStatus object
 func (s *TestKindStatus) DeepCopyInto(dst *TestKindStatus) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_spec_gen.go.txt
@@ -23,3 +23,11 @@ func NewTestKindSpec() *TestKindSpec {
 func (TestKindSpec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v3.TestKindSpec"
 }
+
+// CopyInto copies the object into another object
+func (o TestKindSpec) CopyInto(dst *TestKindSpec) {
+	dst.StringField = o.StringField
+	dst.IntField = o.IntField
+	dst.TimeField = o.TimeField
+	dst.BoolField = o.BoolField
+}

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (TestKindstatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v3.TestKindstatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o TestKindstatusOperatorState) CopyInto(dst *TestKindstatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type TestKindStatus struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewTestKindStatus() *TestKindStatus {
 // OpenAPIModelName returns the OpenAPI model name for TestKindStatus.
 func (TestKindStatus) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.testapp.v3.TestKindStatus"
+}
+
+// CopyInto copies the object into another object
+func (o TestKindStatus) CopyInto(dst *TestKindStatus) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]TestKindstatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal TestKindstatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_object_gen.go.txt
@@ -318,7 +318,7 @@ func (s *Spec) DeepCopy() *Spec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *Spec) DeepCopyInto(dst *Spec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of Status
@@ -330,5 +330,5 @@ func (s *Status) DeepCopy() *Status {
 
 // DeepCopyInto deep copies Status into another Status object
 func (s *Status) DeepCopyInto(dst *Status) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_spec_gen.go.txt
@@ -17,3 +17,9 @@ func NewSpec() *Spec {
 func (Spec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v0_0.Spec"
 }
+
+// CopyInto copies the object into another object
+func (o Spec) CopyInto(dst *Spec) {
+	dst.Field1 = o.Field1
+	dst.DeprecatedField = o.DeprecatedField
+}

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (StatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v0_0.StatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o StatusOperatorState) CopyInto(dst *StatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type Status struct {
 	// operatorStates is a map of operator ID to operator state evaluations.
@@ -42,6 +58,24 @@ func NewStatus() *Status {
 // OpenAPIModelName returns the OpenAPI model name for Status.
 func (Status) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v0_0.Status"
+}
+
+// CopyInto copies the object into another object
+func (o Status) CopyInto(dst *Status) {
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]StatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal StatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
@@ -350,7 +350,7 @@ func (s *Spec) DeepCopy() *Spec {
 
 // DeepCopyInto deep copies Spec into another Spec object
 func (s *Spec) DeepCopyInto(dst *Spec) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }
 
 // DeepCopy creates a full deep copy of Status
@@ -362,5 +362,5 @@ func (s *Status) DeepCopy() *Status {
 
 // DeepCopyInto deep copies Status into another Status object
 func (s *Status) DeepCopyInto(dst *Status) {
-	resource.CopyObjectInto(dst, s)
+	s.CopyInto(dst)
 }

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
@@ -160,7 +160,6 @@ func (RecursiveList) OpenAPIModelName() string {
 func (o RecursiveList) CopyInto(dst *RecursiveList) {
 	dst.Val = o.Val
 	if o.Next != nil {
-
 		dst.Next = new(RecursiveList)
 		o.Next.CopyInto(dst.Next)
 	}

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_spec_gen.go.txt
@@ -28,6 +28,32 @@ func (InnerObject1) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.InnerObject1"
 }
 
+// CopyInto copies the object into another object
+func (o InnerObject1) CopyInto(dst *InnerObject1) {
+	dst.InnerField1 = o.InnerField1
+	if o.InnerField2 != nil {
+		dst.InnerField2 = make([]string, len(o.InnerField2))
+		copy(dst.InnerField2, o.InnerField2)
+	}
+	if o.InnerField3 != nil {
+		dst.InnerField3 = make([]InnerObject2, len(o.InnerField3))
+		for idx, val := range o.InnerField3 {
+			val.CopyInto(&dst.InnerField3[idx])
+		}
+	}
+	if o.InnerField4 != nil {
+		dst.InnerField4 = make([]map[string]any, len(o.InnerField4))
+		for idx, val := range o.InnerField4 {
+			if val != nil {
+				dst.InnerField4[idx] = make(map[string]any)
+				for key, val := range val {
+					dst.InnerField4[idx][key] = val
+				}
+			}
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type InnerObject2 struct {
 	Name    string                 `json:"name"`
@@ -44,6 +70,17 @@ func NewInnerObject2() *InnerObject2 {
 // OpenAPIModelName returns the OpenAPI model name for InnerObject2.
 func (InnerObject2) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.InnerObject2"
+}
+
+// CopyInto copies the object into another object
+func (o InnerObject2) CopyInto(dst *InnerObject2) {
+	dst.Name = o.Name
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -65,6 +102,15 @@ func (Type1) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.Type1"
 }
 
+// CopyInto copies the object into another object
+func (o Type1) CopyInto(dst *Type1) {
+	dst.Group = o.Group
+	if o.Options != nil {
+		dst.Options = make([]string, len(o.Options))
+		copy(dst.Options, o.Options)
+	}
+}
+
 // +k8s:openapi-gen=true
 type Type2 struct {
 	Group   string                 `json:"group"`
@@ -83,6 +129,17 @@ func (Type2) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.Type2"
 }
 
+// CopyInto copies the object into another object
+func (o Type2) CopyInto(dst *Type2) {
+	dst.Group = o.Group
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type RecursiveList struct {
 	Val  string         `json:"val"`
@@ -97,6 +154,16 @@ func NewRecursiveList() *RecursiveList {
 // OpenAPIModelName returns the OpenAPI model name for RecursiveList.
 func (RecursiveList) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.RecursiveList"
+}
+
+// CopyInto copies the object into another object
+func (o RecursiveList) CopyInto(dst *RecursiveList) {
+	dst.Val = o.Val
+	if o.Next != nil {
+
+		dst.Next = new(RecursiveList)
+		o.Next.CopyInto(dst.Next)
+	}
 }
 
 // +k8s:openapi-gen=true
@@ -129,6 +196,29 @@ func NewSpec() *Spec {
 // OpenAPIModelName returns the OpenAPI model name for Spec.
 func (Spec) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.Spec"
+}
+
+// CopyInto copies the object into another object
+func (o Spec) CopyInto(dst *Spec) {
+	dst.Field1 = o.Field1
+	o.Inner.CopyInto(&dst.Inner)
+	dst.Union = o.Union
+	if o.Map != nil {
+		dst.Map = make(map[string]Type2)
+		for key, val := range o.Map {
+			var mapVal Type2
+			val.CopyInto(&mapVal)
+			dst.Map[key] = mapVal
+		}
+	}
+	dst.Timestamp = o.Timestamp
+	dst.Enum = o.Enum
+	dst.I32 = o.I32
+	dst.I64 = o.I64
+	dst.BoolField = o.BoolField
+	dst.FloatField = o.FloatField
+	o.LinkedList.CopyInto(&dst.LinkedList)
+	dst.ExclusiveInt = o.ExclusiveInt
 }
 
 // +k8s:openapi-gen=true

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_status_gen.go.txt
@@ -25,6 +25,22 @@ func (StatusOperatorState) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.StatusOperatorState"
 }
 
+// CopyInto copies the object into another object
+func (o StatusOperatorState) CopyInto(dst *StatusOperatorState) {
+	dst.LastEvaluation = o.LastEvaluation
+	dst.State = o.State
+	if o.DescriptiveState != nil {
+		tmp := *o.DescriptiveState
+		dst.DescriptiveState = &tmp
+	}
+	if o.Details != nil {
+		dst.Details = make(map[string]any)
+		for key, val := range o.Details {
+			dst.Details[key] = val
+		}
+	}
+}
+
 // +k8s:openapi-gen=true
 type Status struct {
 	StatusField1 string `json:"statusField1"`
@@ -43,6 +59,25 @@ func NewStatus() *Status {
 // OpenAPIModelName returns the OpenAPI model name for Status.
 func (Status) OpenAPIModelName() string {
 	return "codegen-tests.pkg.generated.customkind.v1_0.Status"
+}
+
+// CopyInto copies the object into another object
+func (o Status) CopyInto(dst *Status) {
+	dst.StatusField1 = o.StatusField1
+	if o.OperatorStates != nil {
+		dst.OperatorStates = make(map[string]StatusOperatorState)
+		for key, val := range o.OperatorStates {
+			var mapVal StatusOperatorState
+			val.CopyInto(&mapVal)
+			dst.OperatorStates[key] = mapVal
+		}
+	}
+	if o.AdditionalFields != nil {
+		dst.AdditionalFields = make(map[string]any)
+		for key, val := range o.AdditionalFields {
+			dst.AdditionalFields[key] = val
+		}
+	}
 }
 
 // +k8s:openapi-gen=true


### PR DESCRIPTION
## What Changed? Why?

Use cog custom templates to generate `CopyInto` methods for all generated struct types, which can be used instead of `resource.CopyObjectInto` (which uses reflection) for DeepCopy methods on the `resource.Object`. `CopyInto` methods are generated and used only when `codegen.enableGeneratedCopyCode` is set to true in the config CUE (defaults to false), making this an opt-in feature, to see if it (a) improves performance when opted in, and (b) doesn't result in any bugs/missed fields in the generated copy code (if it does, the user can revert to using `resource.CopyObjectInto` by just setting the flag to false or removing it).

### How was it tested?

Codegen tests, and tested in a local project generating a kind with:
```cue
schema: {
        #InnerObject1: {
            innerField1: string
            innerField2: [...string]
            innerField3: [...#InnerObject2]
            innerField4: [...{
                [string]: _
            }]
        }
        #InnerObject2: {
            name: string
            details: {
                [string]: _
            }
        }
        #Type1: {
            group: string
            options?: [...string]
        }
        #Type2: {
            group: string
            details: {
                [string]: _
            }
        }
        #RecursiveList: {
            val: string
            next?: #RecursiveList
        }
        #UnionType: #Type1 | #Type2
        spec: {
            field1: string
            inner:  #InnerObject1
            union:  #UnionType
            map: {
                [string]: #Type2
            }
            timestamp:  string & time.Time
            enum:       "val1" | "val2" | "val3" | "val4" | *"default"
            i32:        int32 & <=123456
            i64:        int64 & >=123456
            boolField:  bool | *false
            floatField: float64
            linkedList: #RecursiveList
            exclusiveInt: int & < 100 & > 10
        }
        status: {
            statusField1: string
            [string]:     _
        } @cog(open=true)
        metadata: {
            customMetadataField: string
            otherMetadataField:  string
        }
    }
```
And testing that a deep copy works:
```golang
func TestSpecCopyInto(t *testing.T) {
	orig := Spec{
		Field1: "foo",
		Inner: InnerObject1{
			InnerField1: "inner1",
			InnerField2: []string{"a", "b"},
			InnerField3: []InnerObject2{
				{Name: "n1", Details: map[string]interface{}{"k": "v"}},
			},
			InnerField4: []map[string]interface{}{
				{"k2": "v2"},
			},
		},
		Union: "union-value",
		Map: map[string]Type2{
			"key": {Group: "g", Details: map[string]interface{}{"dk": "dv"}},
		},
		Timestamp:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
		Enum:         SpecEnumVal1,
		I32:          42,
		I64:          100,
		BoolField:    true,
		FloatField:   3.14,
		LinkedList:   RecursiveList{Val: "head", Next: &RecursiveList{Val: "tail"}},
		ExclusiveInt: 7,
	}
	cpy := Spec{}
	orig.CopyInto(&cpy)
	assert.Equal(t, orig, cpy)
	// check that the linkedlist pointers are different
	if orig.LinkedList.Next == cpy.LinkedList.Next {
		assert.Fail(t, "LinkedList pointers should be different")
	}
}
```

### Where did you document your changes?

Documented in the CUE definition for the config value, as well as in the godocs for the Generator and Jennies.

### Notes to Reviewers

