### PR TITLE
chore: update default group suffix from *.ext.grafana.com to *.ext.grafana.app

### DIFF
--- a/app/manifest.go
+++ b/app/manifest.go
@@ -91,7 +91,7 @@ type ManifestData struct {
 	// AppDisplayName is the human-readable display name of the app. Unlike the AppName, any printable characters are allowed in this field
 	AppDisplayName string `json:"appDisplayName" yaml:"appDisplayName"`
 	// Group is the group used for all kinds maintained by this app.
-	// This is usually "<AppName>.ext.grafana.com"
+	// This is usually "<AppName>.ext.grafana.app"
 	Group string `json:"group" yaml:"group"`
 	// Versions is a list of versions supported by this App
 	Versions []ManifestVersion `json:"versions" yaml:"versions"`

--- a/cmd/grafana-app-sdk/templates/manifest.cue.tmpl
+++ b/cmd/grafana-app-sdk/templates/manifest.cue.tmpl
@@ -5,7 +5,7 @@ manifest: {
 	// and to generate the group used by your app in the app platform API.
 	appName: "{{ .AppName }}"
 	// groupOverride can be used to specify a non-appName-based API group.
-	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.com,
+	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.app,
 	// but there are cases where this needs to be changed.
 	// Keep in mind that changing this after an app is deployed can cause problems with clients and/or kind data.
 	// groupOverride: foo.ext.grafana.app

--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -379,7 +379,7 @@ Manifest: S={
 		if S.groupOverride != _|_ {
 			strings.ToLower(S.groupOverride)
 		},
-		strings.ToLower(strings.Replace(S.group, "_", "-", -1)) + ".ext.grafana.com", // TODO: change to ext.grafana.app?
+		strings.ToLower(strings.Replace(S.group, "_", "-", -1)) + ".ext.grafana.app",
 	]
 
 	// fullGroup is used as the CRD group name in the GVK.

--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -66,7 +66,7 @@ func (m *ManifestGenerator) Generate(appManifest codegen.AppManifest) (codejen.F
 			return nil, errors.New("all APIResource kinds must have a non-empty group")
 		}
 		// No kinds, make an assumption for the group name
-		manifestData.Group = fmt.Sprintf("%s.ext.grafana.com", manifestData.AppName)
+		manifestData.Group = fmt.Sprintf("%s.ext.grafana.app", manifestData.AppName)
 	}
 
 	// Whether or not the schema is CRD-compatible determines which version of AppManifest to use.
@@ -136,7 +136,7 @@ func (g *ManifestGoGenerator) Generate(appManifest codegen.AppManifest) (codejen
 			return nil, errors.New("all APIResource kinds must have a non-empty group")
 		}
 		// No kinds, make an assumption for the group name
-		manifestData.Group = fmt.Sprintf("%s.ext.grafana.com", manifestData.AppName)
+		manifestData.Group = fmt.Sprintf("%s.ext.grafana.app", manifestData.AppName)
 	}
 
 	buf := bytes.Buffer{}

--- a/codegen/testing/golden_generated/crd/customkind.customapp.ext.grafana.app.json.txt
+++ b/codegen/testing/golden_generated/crd/customkind.customapp.ext.grafana.app.json.txt
@@ -2,10 +2,10 @@
     "kind": "CustomResourceDefinition",
     "apiVersion": "apiextensions.k8s.io/v1",
     "metadata": {
-        "name": "customkinds.customapp.ext.grafana.com"
+        "name": "customkinds.customapp.ext.grafana.app"
     },
     "spec": {
-        "group": "customapp.ext.grafana.com",
+        "group": "customapp.ext.grafana.app",
         "versions": [
             {
                 "name": "v0-0",

--- a/codegen/testing/golden_generated/crd/customkind.customapp.ext.grafana.app.yaml.txt
+++ b/codegen/testing/golden_generated/crd/customkind.customapp.ext.grafana.app.yaml.txt
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: customkinds.customapp.ext.grafana.com
+  name: customkinds.customapp.ext.grafana.app
 spec:
-  group: customapp.ext.grafana.com
+  group: customapp.ext.grafana.app
   names:
     kind: CustomKind
     plural: customkinds

--- a/codegen/testing/golden_generated/crd/testkind.testapp.ext.grafana.app.json.txt
+++ b/codegen/testing/golden_generated/crd/testkind.testapp.ext.grafana.app.json.txt
@@ -2,10 +2,10 @@
     "kind": "CustomResourceDefinition",
     "apiVersion": "apiextensions.k8s.io/v1",
     "metadata": {
-        "name": "testkinds.testapp.ext.grafana.com"
+        "name": "testkinds.testapp.ext.grafana.app"
     },
     "spec": {
-        "group": "testapp.ext.grafana.com",
+        "group": "testapp.ext.grafana.app",
         "versions": [
             {
                 "name": "v1",

--- a/codegen/testing/golden_generated/crd/testkind.testapp.ext.grafana.app.yaml.txt
+++ b/codegen/testing/golden_generated/crd/testkind.testapp.ext.grafana.app.yaml.txt
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: testkinds.testapp.ext.grafana.com
+  name: testkinds.testapp.ext.grafana.app
 spec:
   conversion:
     strategy: webhook
@@ -10,7 +10,7 @@ spec:
         url: http://foo.bar/convert
       conversionReviewVersions:
       - v1
-  group: testapp.ext.grafana.com
+  group: testapp.ext.grafana.app
   names:
     kind: TestKind
     plural: testkinds

--- a/codegen/testing/golden_generated/crd/testkind2.testapp.ext.grafana.app.json.txt
+++ b/codegen/testing/golden_generated/crd/testkind2.testapp.ext.grafana.app.json.txt
@@ -2,10 +2,10 @@
     "kind": "CustomResourceDefinition",
     "apiVersion": "apiextensions.k8s.io/v1",
     "metadata": {
-        "name": "testkind2s.testapp.ext.grafana.com"
+        "name": "testkind2s.testapp.ext.grafana.app"
     },
     "spec": {
-        "group": "testapp.ext.grafana.com",
+        "group": "testapp.ext.grafana.app",
         "versions": [
             {
                 "name": "v1",

--- a/codegen/testing/golden_generated/crd/testkind2.testapp.ext.grafana.app.yaml.txt
+++ b/codegen/testing/golden_generated/crd/testkind2.testapp.ext.grafana.app.yaml.txt
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: testkind2s.testapp.ext.grafana.com
+  name: testkind2s.testapp.ext.grafana.app
 spec:
-  group: testapp.ext.grafana.com
+  group: testapp.ext.grafana.app
   names:
     kind: TestKind2
     plural: testkind2s

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "customapp.ext.grafana.com"
+	APIGroup = "customapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v0-0"
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v0_0/customkind_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.com", "v0-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
+	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.app", "v0-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
 		resource.WithPlural("customkinds"), resource.WithScope(resource.NamespacedScope))
 	kindCustomKind = resource.Kind{
 		Schema: schemaCustomKind,

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "customapp.ext.grafana.com"
+	APIGroup = "customapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v1-0"
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.com", "v1-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
+	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.app", "v1-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
 		resource.WithPlural("customkinds"), resource.WithScope(resource.NamespacedScope))
 	kindCustomKind = resource.Kind{
 		Schema: schemaCustomKind,

--- a/codegen/testing/golden_generated/go/groupbygroup/manifestdata/customapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/manifestdata/customapp_manifest.go.txt
@@ -32,7 +32,7 @@ var (
 var appManifestData = app.ManifestData{
 	AppName:          "custom-app",
 	AppDisplayName:   "custom-app",
-	Group:            "customapp.ext.grafana.com",
+	Group:            "customapp.ext.grafana.app",
 	PreferredVersion: "v1-0",
 	Versions: []app.ManifestVersion{
 		{

--- a/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
@@ -39,7 +39,7 @@ var (
 var appManifestData = app.ManifestData{
 	AppName:          "test-app",
 	AppDisplayName:   "test-app",
-	Group:            "testapp.ext.grafana.com",
+	Group:            "testapp.ext.grafana.app",
 	PreferredVersion: "v1",
 	Versions: []app.ManifestVersion{
 		{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "testapp.ext.grafana.com"
+	APIGroup = "testapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v1"
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind2_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaTestKind2 = resource.NewSimpleSchema("testapp.ext.grafana.com", "v1", NewTestKind2(), &TestKind2List{}, resource.WithKind("TestKind2"),
+	schemaTestKind2 = resource.NewSimpleSchema("testapp.ext.grafana.app", "v1", NewTestKind2(), &TestKind2List{}, resource.WithKind("TestKind2"),
 		resource.WithPlural("testkind2s"), resource.WithScope(resource.NamespacedScope))
 	kindTestKind2 = resource.Kind{
 		Schema: schemaTestKind2,

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v1/testkind_schema_gen.go.txt
@@ -12,7 +12,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.com", "v1", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
+	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.app", "v1", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
 		resource.WithPlural("testkinds"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{resource.SelectableField{
 			FieldSelector: ".spec.stringField",
 			FieldValueFunc: func(o resource.Object) (string, error) {

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "testapp.ext.grafana.com"
+	APIGroup = "testapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v2"
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v2/testkind_schema_gen.go.txt
@@ -13,7 +13,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.com", "v2", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
+	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.app", "v2", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
 		resource.WithPlural("testkinds"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{resource.SelectableField{
 			FieldSelector: ".spec.stringField",
 			FieldValueFunc: func(o resource.Object) (string, error) {

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/client_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/client_gen.go.txt
@@ -22,7 +22,7 @@ func NewCustomRouteClient(client resource.CustomRouteClient) *CustomRouteClient 
 
 func NewCustomRouteClientFromGenerator(generator resource.ClientGenerator, defaultNamespace string) (*CustomRouteClient, error) {
 	client, err := generator.GetCustomRouteClient(schema.GroupVersion{
-		Group:   "testapp.ext.grafana.com",
+		Group:   "testapp.ext.grafana.app",
 		Version: "v3",
 	}, defaultNamespace)
 	if err != nil {

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "testapp.ext.grafana.com"
+	APIGroup = "testapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v3"
 )

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/testkind_schema_gen.go.txt
@@ -13,7 +13,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.com", "v3", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
+	schemaTestKind = resource.NewSimpleSchema("testapp.ext.grafana.app", "v3", NewTestKind(), &TestKindList{}, resource.WithKind("TestKind"),
 		resource.WithPlural("testkinds"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{resource.SelectableField{
 			FieldSelector: ".spec.stringField",
 			FieldValueFunc: func(o resource.Object) (string, error) {

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "customapp.ext.grafana.com"
+	APIGroup = "customapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v0-0"
 )

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v0_0/customkind_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.com", "v0-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
+	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.app", "v0-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
 		resource.WithPlural("customkinds"), resource.WithScope(resource.NamespacedScope))
 	kindCustomKind = resource.Kind{
 		Schema: schemaCustomKind,

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/constants.go.txt
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
 	// APIGroup is the API group used by all kinds in this package
-	APIGroup = "customapp.ext.grafana.com"
+	APIGroup = "customapp.ext.grafana.app"
 	// APIVersion is the API version used by all kinds in this package
 	APIVersion = "v1-0"
 )

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_schema_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_schema_gen.go.txt
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.com", "v1-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
+	schemaCustomKind = resource.NewSimpleSchema("customapp.ext.grafana.app", "v1-0", NewCustomKind(), &CustomKindList{}, resource.WithKind("CustomKind"),
 		resource.WithPlural("customkinds"), resource.WithScope(resource.NamespacedScope))
 	kindCustomKind = resource.Kind{
 		Schema: schemaCustomKind,

--- a/codegen/testing/golden_generated/go/groupbykind/manifestdata/customapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/manifestdata/customapp_manifest.go.txt
@@ -32,7 +32,7 @@ var (
 var appManifestData = app.ManifestData{
 	AppName:          "custom-app",
 	AppDisplayName:   "custom-app",
-	Group:            "customapp.ext.grafana.com",
+	Group:            "customapp.ext.grafana.app",
 	PreferredVersion: "v1-0",
 	Versions: []app.ManifestVersion{
 		{

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.json.txt
@@ -7,7 +7,7 @@
     "spec": {
         "appName": "custom-app",
         "appDisplayName": "custom-app",
-        "group": "customapp.ext.grafana.com",
+        "group": "customapp.ext.grafana.app",
         "versions": [
             {
                 "name": "v0-0",

--- a/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/custom-app-manifest.yaml.txt
@@ -5,7 +5,7 @@ metadata:
 spec:
   appDisplayName: custom-app
   appName: custom-app
-  group: customapp.ext.grafana.com
+  group: customapp.ext.grafana.app
   preferredVersion: v1-0
   roleBindings:
     admin:

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.json.txt
@@ -7,7 +7,7 @@
     "spec": {
         "appName": "test-app",
         "appDisplayName": "test-app",
-        "group": "testapp.ext.grafana.com",
+        "group": "testapp.ext.grafana.app",
         "versions": [
             {
                 "name": "v1",

--- a/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
+++ b/codegen/testing/golden_generated/manifest/test-app-manifest.yaml.txt
@@ -13,7 +13,7 @@ spec:
       - watch
       group: foo.bar
       resource: foos
-  group: testapp.ext.grafana.com
+  group: testapp.ext.grafana.app
   operator:
     url: https://foo.bar:8443
     webhooks:

--- a/docs/app-manifest.md
+++ b/docs/app-manifest.md
@@ -14,7 +14,7 @@ metadata:
   name: issue-tracker-project
 spec:
   appName: example
-  group: example.ext.grafana.com
+  group: example.ext.grafana.app
   versions:
     - name: v1alpha1
       served: true
@@ -50,7 +50,7 @@ spec:
           - watch
   preferredVersion: "v1alpha1"
 ```
-This manifest describes an app which is called `example` (each appName must be unique), with the API group `example.ext.grafana.com`. 
+This manifest describes an app which is called `example` (each appName must be unique), with the API group `example.ext.grafana.app`. 
 This app has a kind it manages called `Foo`, which is has the capability to **validate** and **mutate**. 
 Finally, it requires permissions to get, list, and watch `playlists` from the `playlist.grafana.app` group.
 
@@ -109,7 +109,7 @@ different values for each version of the kind).
 
 The default preferred API version for clients to use is whichever is highest, but can be manually specified with the manifest's
 `preferredVersion` field.
-This manifest uses the API group `exampleapp.ext.grafana.com`, as the default group is automatically determined from the app name. 
+This manifest uses the API group `exampleapp.ext.grafana.app`, as the default group is automatically determined from the app name. 
 If you are working from an app written in a much older version of the app-sdk, or otherwise need to change the group, 
 you can add a `groupOverride` field with a fully-qualified group name to keep your current group. 
 This manifest also requires the same extra permissions for playlists as the YAML example manifest above.

--- a/docs/custom-kinds/README.md
+++ b/docs/custom-kinds/README.md
@@ -17,7 +17,7 @@ In a kubernetes-compatible API server, a kind is identified by the top-level att
 
 Kinds are the core of apps, as they are the data structure for all app data. Apps interact with an API server to read, write, update, delete, list and watch kinds. For more on this, see [Operators and Event-Based Design](../operators.md).
 
-Kinds belong to groups, which generally correlate to apps. In kubernetes, your kind's identifier when quering the API is `<group>/<version>/<plural>`, with `group` being the kind's full group (excepting very specific circumstances, this is your app name + `.ext.grafana.com`), `version` being the version you wish to use, and `plural` being the plural name of the kind (unless changed, this defaults to `LOWER(<kind>) + 's')`).
+Kinds belong to groups, which generally correlate to apps. In kubernetes, your kind's identifier when quering the API is `<group>/<version>/<plural>`, with `group` being the kind's full group (excepting very specific circumstances, this is your app name + `.ext.grafana.app`), `version` being the version you wish to use, and `plural` being the plural name of the kind (unless changed, this defaults to `LOWER(<kind>) + 's')`).
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../diagrams/kind-overview-dark.png">

--- a/docs/tutorials/issue-tracker/03-generate-kind-code.md
+++ b/docs/tutorials/issue-tracker/03-generate-kind-code.md
@@ -13,7 +13,7 @@ manifest: {
 	// and to generate the group used by your app in the app platform API.
 	appName: "issue-tracker-project"
 	// groupOverride can be used to specify a non-appName-based API group.
-	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.com,
+	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.app,
 	// but there are cases where this needs to be changed.
 	// Keep in mind that changing this after an app is deployed can cause problems with clients and/or kind data.
 	// groupOverride: foo.ext.grafana.app
@@ -102,7 +102,7 @@ $ make generate
  * Writing file plugin/src/generated/issue/v1alpha1/types.metadata.gen.ts
  * Writing file plugin/src/generated/issue/v1alpha1/types.spec.gen.ts
  * Writing file plugin/src/generated/issue/v1alpha1/types.status.gen.ts
- * Writing file definitions/issue.issuetrackerproject.ext.grafana.com.json
+ * Writing file definitions/issue.issuetrackerproject.ext.grafana.app.json
  * Writing file definitions/issue-tracker-project-manifest.json
  * Writing file pkg/generated/manifestdata/issuetrackerproject_manifest.go
 ```
@@ -114,7 +114,7 @@ $ tree .
 │   └── operator
 ├── definitions
 │   ├── issue-tracker-project-manifest.json
-│   └── issue.issuetrackerproject.ext.grafana.com.json
+│   └── issue.issuetrackerproject.ext.grafana.app.json
 ├── go.mod
 ├── go.sum
 ├── kinds
@@ -232,7 +232,7 @@ We also have a manifest here, which will be used by the grafana API server in th
 $ tree definitions
 definitions
 ├── issue-tracker-project-manifest.json
-└── issue.issuetrackerproject.ext.grafana.com.json
+└── issue.issuetrackerproject.ext.grafana.app.json
 
 1 directory, 2 files
 ```

--- a/docs/tutorials/issue-tracker/04-boilerplate.md
+++ b/docs/tutorials/issue-tracker/04-boilerplate.md
@@ -169,7 +169,7 @@ For our purposes, we care about the secureJSONData because we're going to store 
 > The backend (go) plugin code in your app is meant to serve as a proxy to the API server backend. 
 > This is legacy behavior that is still supported for a few specialized edge cases, 
 > but for most use-cases you will want to have your front-end talk directly to the grafana API server at 
-> `/apis/issuetrackerproject.ext.grafana.com/v1alpha1`, rather than via the `/api/plugins/issuetrackerproject-app/resources` endpoint
+> `/apis/issuetrackerproject.ext.grafana.app/v1alpha1`, rather than via the `/api/plugins/issuetrackerproject-app/resources` endpoint
 
 The code in `pkg/plugin` is split into two files: 
 * `plugin.go`, which defines our `Plugin` type we'll run everything from, which embeds a router and defines routes.

--- a/docs/tutorials/issue-tracker/05-local-deployment.md
+++ b/docs/tutorials/issue-tracker/05-local-deployment.md
@@ -229,7 +229,7 @@ Our grafana is now available at [grafana.k3d.localhost:9999](http://grafana.k3d.
 By default, the credentials to log in are `admin`/`admin`. You'll be prompted to change the password upon logging in (though you can skip this). 
 Note that if you do, you'll need to modify the cURL commands used later in this tutorial. You can also click `Skip` to avoid updating the password. 
 Since our plugin is automatically installed, we can go to [grafana.k3d.localhost:9999/a/issuetrackerproject-app/](http://grafana.k3d.localhost:9999/a/issuetrackerproject-app/) and see the simple landing page that got generated for us, 
-and we can now interact with our exposed API at [grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues](http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues).
+and we can now interact with our exposed API at [grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues](http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues).
 
 Right now, if I do a curl to our plugin list endpoint, we'll get back a response with an empty list:
 ```shell
@@ -242,7 +242,7 @@ curl -u admin:admin http://grafana.k3d.localhost:9999/api/plugins/issuetrackerpr
 $ curl -u admin:admin http://grafana.k3d.localhost:9999/api/plugins/issuetrackerproject-app/resources/v1/issues | jq .
 {
   "kind": "IssueList",
-  "apiVersion": "issuetrackerproject.ext.grafana.com/v1alpha1",
+  "apiVersion": "issuetrackerproject.ext.grafana.app/v1alpha1",
   "metadata": {
     "resourceVersion": "1552"
   },
@@ -253,12 +253,12 @@ $ curl -u admin:admin http://grafana.k3d.localhost:9999/api/plugins/issuetracker
 Our kinds are also available via the grafana API server, located at [http://grafana.k3d.localhost:9999/apis]. This is a kubernetes-compatible API server, and we can interact with it via cURL, or kubectl. 
 Let's also list our issues that way:
 ```shell
-curl -u admin:admin http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues
+curl -u admin:admin http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues
 ```
 ```shell
-$ curl -u admin:admin http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues
+$ curl -u admin:admin http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues
 {
-  "apiVersion": "issuetrackerproject.ext.grafana.com/v1alpha1",
+  "apiVersion": "issuetrackerproject.ext.grafana.app/v1alpha1",
   "items": [],
   "kind": "IssueList",
   "metadata": {
@@ -270,19 +270,19 @@ $ curl -u admin:admin http://grafana.k3d.localhost:9999/apis/issuetrackerproject
 We can see the output is nearly identical, as the plugin backend is just a proxy to the API server. From this point, we could use the plugin backend or API server API, 
 but seeing as the plugin backend will eventually be phased out of the default path, let's use the API server here, and create an Issue:
 ```shell
-curl -u admin:admin -X POST -H "content-type:application/json" -d '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.com/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Test","description":"A test issue","status":"open"}}' http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues
+curl -u admin:admin -X POST -H "content-type:application/json" -d '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.app/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Test","description":"A test issue","status":"open"}}' http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues
 ```
 ```shell
-$ curl -u admin:admin -X POST -H "content-type:application/json" -d '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.com/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Test","description":"A test issue","status":"open"}}' http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues
+$ curl -u admin:admin -X POST -H "content-type:application/json" -d '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.app/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Test","description":"A test issue","status":"open"}}' http://grafana.k3d.localhost:9999/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues
 {
-  "apiVersion": "issuetrackerproject.ext.grafana.com/v1alpha1",
+  "apiVersion": "issuetrackerproject.ext.grafana.app/v1alpha1",
   "kind": "Issue",
   "metadata": {
     "creationTimestamp": "2025-07-10T15:58:33Z",
     "generation": 1,
     "managedFields": [
       {
-        "apiVersion": "issuetrackerproject.ext.grafana.com/v1alpha1",
+        "apiVersion": "issuetrackerproject.ext.grafana.app/v1alpha1",
         "fieldsType": "FieldsV1",
         "fieldsV1": {
           "f:spec": {
@@ -319,7 +319,7 @@ kubectl get issue test-issue -o yaml
 ```
 ```shell
 $ kubectl get issue test-issue -o yaml
-apiVersion: issuetrackerproject.ext.grafana.com/v1alpha1
+apiVersion: issuetrackerproject.ext.grafana.app/v1alpha1
 kind: Issue
 metadata:
   creationTimestamp: "2025-07-10T15:58:33Z"

--- a/docs/tutorials/issue-tracker/07-operator-watcher.md
+++ b/docs/tutorials/issue-tracker/07-operator-watcher.md
@@ -295,11 +295,11 @@ make local/down && make local/up
 ```
 Now, if you make a new issue, you'll see the `status.processedTimestamp` get updated.
 ```shell
-echo '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.com/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Foo","description":"bar","status":"open"}}' | kubectl create -f -
+echo '{"kind":"Issue","apiVersion":"issuetrackerproject.ext.grafana.app/v1alpha1","metadata":{"name":"test-issue","namespace":"default"},"spec":{"title":"Foo","description":"bar","status":"open"}}' | kubectl create -f -
 ```
 ```
 % kubectl get issue test-issue -oyaml
-apiVersion: issuetrackerproject.ext.grafana.com/v1alpha1
+apiVersion: issuetrackerproject.ext.grafana.app/v1alpha1
 kind: Issue
 metadata:
   creationTimestamp: "2025-07-10T16:21:45Z"

--- a/docs/tutorials/issue-tracker/frontend-files/issue-client.ts
+++ b/docs/tutorials/issue-tracker/frontend-files/issue-client.ts
@@ -10,13 +10,13 @@ export class IssueClient {
     apiEndpoint: string
 
     constructor() {
-        this.apiEndpoint = '/apis/issuetrackerproject.ext.grafana.com/v1alpha1/namespaces/default/issues';
+        this.apiEndpoint = '/apis/issuetrackerproject.ext.grafana.app/v1alpha1/namespaces/default/issues';
     }
 
     async create(title: string, description: string): Promise<FetchResponse<Issue>> {
         let issue = {
             kind: 'Issue',
-            apiVersion: 'issuetrackerproject.ext.grafana.com/v1alpha1',
+            apiVersion: 'issuetrackerproject.ext.grafana.app/v1alpha1',
             spec: {
                 title: title,
                 description: description,

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -197,7 +197,7 @@ func NewApp(cfg app.Config) (app.App, error) {
 }
 ```
 You can connect this to a kubernetes API server by changing `"local.kubeconfig"` (or populating that file), 
-and making sure the `MyKind` CRD exists by applying the generated `definitions/mykind.testapp.ext.grafana.com.json` file.
+and making sure the `MyKind` CRD exists by applying the generated `definitions/mykind.testapp.ext.grafana.app.json` file.
 
 You can expand on this to add Validation or Mutation (or conversion), but keep in mind you'll need to add a WebhookConfig 
 to the `operator.RunnerConfig`, and set up the webhook configurations in your kubernetes API server. 

--- a/examples/apiserver/kinds/manifest.cue
+++ b/examples/apiserver/kinds/manifest.cue
@@ -24,6 +24,9 @@ manifest: {
 	// appName is the unique name of your app. It is used to reference the app from other config objects,
 	// and to generate the group used by your app in the app platform API.
 	appName: "example"
+	// groupOverride pins this example's API group so the README curls keep working.
+	// Without it, the auto-generated group would be `example.ext.grafana.app`.
+	groupOverride: "example.ext.grafana.com"
 	// versions is a map of versions supported by your app. Version names should follow the format "v<integer>" or
 	// "v<integer>(alpha|beta)<integer>". Each version contains the kinds your app manages for that version.
 	// If your app needs access to kinds managed by another app, use permissions.accessKinds to allow your app access.


### PR DESCRIPTION
## What Changed? Why?

Default API group suffix for new apps changes from `*.ext.grafana.com` to `*.ext.grafana.app`.

The Grafana app manifest API server only admits groups ending in `.ext.grafana.app`; the `.com` suffix is the legacy convention used by the now-deprecated `cloud-apps-platform`. New apps generated by `grafana-app-sdk` were getting a group the platform wouldn't accept.

Scope:
- Default in `codegen/cuekind/def.cue` (`_computedGroups`) and `codegen/jennies/manifest.go` fallback.
- Project init template (`cmd/grafana-app-sdk/templates/manifest.cue.tmpl`) and `app/manifest.go` doc comment.
- Docs: tutorial and `app-manifest.md` references.
- Regenerated codegen golden files.

Existing apps with a `groupOverride` are unaffected. Apps relying on the implicit default will pick up the new suffix on next `grafana-app-sdk generate`.

### How was it tested?

`make test` passes. `make regenerate-codegen-test-files` followed by `go test ./codegen/...` confirms goldens match.

### Where did you document your changes?

Updated `docs/custom-kinds/README.md`, `docs/app-manifest.md`, and the issue-tracker tutorial.

### Notes to Reviewers

PR description generated by Claude Code.