### PR TITLE
fix: handle data race

### DIFF
--- a/k8s/telemetry.go
+++ b/k8s/telemetry.go
@@ -23,7 +23,14 @@ func SetTracer(t trace.Tracer) {
 // otel.GetTracerProvider().Tracer("k8s") if none has been set.
 func GetTracer() trace.Tracer {
 	tracerMux.RLock()
-	defer tracerMux.RUnlock()
+	t := tracer
+	tracerMux.RUnlock()
+	if t != nil {
+		return t
+	}
+
+	tracerMux.Lock()
+	defer tracerMux.Unlock()
 	if tracer == nil {
 		tracer = otel.GetTracerProvider().Tracer("k8s")
 	}

--- a/operator/telemetry.go
+++ b/operator/telemetry.go
@@ -23,7 +23,14 @@ func SetTracer(t trace.Tracer) {
 // otel.GetTracerProvider().Tracer("k8s") if none has been set.
 func GetTracer() trace.Tracer {
 	tracerMux.RLock()
-	defer tracerMux.RUnlock()
+	t := tracer
+	tracerMux.RUnlock()
+	if t != nil {
+		return t
+	}
+
+	tracerMux.Lock()
+	defer tracerMux.Unlock()
 	if tracer == nil {
 		tracer = otel.GetTracerProvider().Tracer("sdk-operator")
 	}


### PR DESCRIPTION
## What Changed? Why?

Small change to work around a data race related to a lazy-init pattern.

Multiple reflector goroutines call `GetTracer()` concurrently from hot paths.
When `tracer` is still nil, each goroutine acquires an read lock, sees nil, and then writes to `tracer`.


```
==================
WARNING: DATA RACE
Read at 0x00010aba8020 by goroutine 218:
  github.com/grafana/grafana-app-sdk/operator.GetTracer()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/github.com/grafana/grafana-app-sdk/operator/telemetry.go:27 +0x78
  github.com/grafana/grafana-app-sdk/operator.NewKubernetesBasedInformer.NewListerWatcher.func2()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/github.com/grafana/grafana-app-sdk/operator/informer_customcache.go:330 +0x54
  k8s.io/client-go/tools/cache.(*ListWatch).WatchWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/listwatch.go:309 +0xd4
  k8s.io/client-go/tools/cache.(*Reflector).watchList()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:771 +0x670
  k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:423 +0x280
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x40
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x30
  k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0x7c
  k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xb0
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x78
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:368 +0x30c
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext-fm()
      <autogenerated>:1 +0x3c
  k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:63 +0x48
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x74

Previous write at 0x00010aba8020 by goroutine 165:
  github.com/grafana/grafana-app-sdk/operator.GetTracer()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/github.com/grafana/grafana-app-sdk/operator/telemetry.go:28 +0xfc
  github.com/grafana/grafana-app-sdk/operator.NewKubernetesBasedInformer.NewListerWatcher.func2()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/github.com/grafana/grafana-app-sdk/operator/informer_customcache.go:330 +0x54
  k8s.io/client-go/tools/cache.(*ListWatch).WatchWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/listwatch.go:309 +0xd4
  k8s.io/client-go/tools/cache.(*Reflector).watchList()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:771 +0x670
  k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:423 +0x280
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:369 +0x40
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x30
  k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0x7c
  k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xb0
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x78
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/client-go/tools/cache/reflector.go:368 +0x30c
  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext-fm()
      <autogenerated>:1 +0x3c
  k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:63 +0x48
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /Users/progers/dev/src/github.com/grafana/enterprise-logs/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x74
```

Addresses Issue #<!-- [Enter issue number here] -->

### How was it tested?

`go test -race ./k8s/...` passed cleanly. 

`go test -race ./operator/...` still reports races in unrelated tests (`TestConcurrentWatcher`, `TestInformerController_Run_WithRetries`, `TestCustomCacheInformer_Run`); none involve `telemetry.go` or `GetTracer()`.

### Where did you document your changes?

### Notes to Reviewers
