### PR TITLE
fix(codegen): reject generated code with duplicate top-level declarations

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -3,8 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/spf13/cobra"
@@ -76,6 +81,12 @@ func generateCmdFunc(cmd *cobra.Command, _ []string) error {
 		}
 		files, err := generateKindsCue(parser, cfg)
 		if err != nil {
+			return err
+		}
+
+		// Fail fast (before writing) if codegen produced Go that would not
+		// compile due to duplicate top-level declarations. See grafana/grafana-app-sdk#1043.
+		if err = validateGeneratedGoDecls(files); err != nil {
 			return err
 		}
 
@@ -208,6 +219,72 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 	allFiles = append(allFiles, manifestFiles...)
 	allFiles = append(allFiles, goManifestFiles...)
 	return allFiles, nil
+}
+
+// collidableDeclNames returns top-level names (type/func/const/var) sharing Go's
+// package namespace. Blank "_" and init funcs (legal repeats) are excluded.
+func collidableDeclNames(file *ast.File) []string {
+	var names []string
+	for _, d := range file.Decls {
+		switch decl := d.(type) {
+		case *ast.GenDecl: // type / const / var
+			for _, spec := range decl.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					names = append(names, s.Name.Name)
+				case *ast.ValueSpec:
+					for _, n := range s.Names {
+						names = append(names, n.Name)
+					}
+				default:
+				}
+			}
+		case *ast.FuncDecl:
+			if decl.Recv == nil && decl.Name.Name != "init" { // top-level func, not a method or init
+				names = append(names, decl.Name.Name)
+			}
+		default:
+		}
+	}
+	return slices.DeleteFunc(names, func(n string) bool { return n == "_" })
+}
+
+// validateGeneratedGoDecls errors if a generated Go package declares the same
+// top-level name in two files ("redeclared in this block"). See grafana-app-sdk#1043.
+func validateGeneratedGoDecls(files codejen.Files) error {
+	type ref struct{ dir, name string }
+	// (dir, name) -> files declaring it (with repeats); >=2 occurrences collide.
+	decls := make(map[ref][]string)
+	fset := token.NewFileSet()
+	for _, f := range files {
+		if !strings.HasSuffix(f.RelativePath, ".go") {
+			continue
+		}
+		parsed, err := goparser.ParseFile(fset, f.RelativePath, f.Data, 0)
+		if err != nil {
+			return fmt.Errorf("generated file %s does not parse: %w", f.RelativePath, err)
+		}
+		dir, base := filepath.Dir(f.RelativePath), filepath.Base(f.RelativePath)
+		for _, name := range collidableDeclNames(parsed) {
+			r := ref{dir: dir, name: name}
+			decls[r] = append(decls[r], base)
+		}
+	}
+
+	var collisions []string
+	for r, where := range decls {
+		if len(where) < 2 {
+			continue
+		}
+		slices.Sort(where)
+		where = slices.Compact(where) // distinct files for the message
+		collisions = append(collisions, fmt.Sprintf("  - %q redeclared in %s (%s)", r.name, r.dir, strings.Join(where, ", ")))
+	}
+	if len(collisions) == 0 {
+		return nil
+	}
+	slices.Sort(collisions)
+	return fmt.Errorf("generated Go will not compile (duplicate declarations); a schema field or definition is likely named after a generated type such as Spec, Status, or JSONCodec:\n%s", strings.Join(collisions, "\n"))
 }
 
 func postGenerateFilesCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files, error) {

--- a/cmd/grafana-app-sdk/generate_test.go
+++ b/cmd/grafana-app-sdk/generate_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/codejen"
+)
+
+func TestValidateGeneratedGoDecls(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     codejen.Files
+		wantErr   bool
+		wantInErr []string
+	}{
+		{
+			name: "no collisions",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_spec_gen.go", Data: []byte("package v1\ntype Spec struct{}\nfunc NewSpec() *Spec { return &Spec{} }\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_status_gen.go", Data: []byte("package v1\ntype Status struct{}\nfunc NewStatus() *Status { return &Status{} }\n")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type and constructor redeclared across files (issue #1043)",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_spec_gen.go", Data: []byte("package v1\ntype Status struct{}\nfunc NewStatus() *Status { return &Status{} }\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_status_gen.go", Data: []byte("package v1\ntype Status struct{}\nfunc NewStatus() *Status { return &Status{} }\n")},
+			},
+			wantErr:   true,
+			wantInErr: []string{"Status", "NewStatus", "foo_spec_gen.go", "foo_status_gen.go"},
+		},
+		{
+			name: "same identifier in different packages is fine",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_status_gen.go", Data: []byte("package v1\ntype Status struct{}\n")},
+				{RelativePath: "pkg/generated/bar/v1/bar_status_gen.go", Data: []byte("package v1\ntype Status struct{}\n")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "methods with the same name on different types do not collide",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_spec_gen.go", Data: []byte("package v1\ntype Spec struct{}\nfunc (Spec) OpenAPIModelName() string { return \"\" }\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_status_gen.go", Data: []byte("package v1\ntype Status struct{}\nfunc (Status) OpenAPIModelName() string { return \"\" }\n")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "non-go files are ignored",
+			files: codejen.Files{
+				{RelativePath: "definitions/foo.json", Data: []byte("{ not go }")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "a const colliding with a type is detected",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_status_gen.go", Data: []byte("package v1\ntype Status struct{}\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_spec_gen.go", Data: []byte("package v1\nconst Status = \"x\"\n")},
+			},
+			wantErr:   true,
+			wantInErr: []string{"Status"},
+		},
+		{
+			name: "repeated blank identifier vars do not collide",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_object_gen.go", Data: []byte("package v1\ntype Corpus struct{}\nvar _ = Corpus{}\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_client_gen.go", Data: []byte("package v1\ntype Client struct{}\nvar _ = Client{}\n")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "repeated init funcs do not collide",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_a_gen.go", Data: []byte("package v1\nfunc init() {}\n")},
+				{RelativePath: "pkg/generated/foo/v1/foo_b_gen.go", Data: []byte("package v1\nfunc init() {}\n")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "duplicate names within a single file are detected",
+			files: codejen.Files{
+				{RelativePath: "pkg/generated/foo/v1/foo_spec_gen.go", Data: []byte("package v1\ntype Status struct{}\nconst Status = \"x\"\n")},
+			},
+			wantErr:   true,
+			wantInErr: []string{"Status", "foo_spec_gen.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGeneratedGoDecls(tt.files)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			for _, want := range tt.wantInErr {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What Changed? Why?

`grafana-app-sdk generate` can emit Go that does not compile. When a schema field
or CUE definition produces a top-level Go name that the generator also emits for
the kind (e.g. `Spec`, `Status`, or `JSONCodec`), two declarations of that name end
up in the same package and Go rejects it with `redeclared in this block`. Today
`generate` exits 0 and writes the broken files, so the failure only appears later
on `go build`.

This adds a post-generation check that parses the generated Go and, before any
file is written, fails with a clear error if any package declares the same
top-level `type`/`func`/`const`/`var` name more than once — across files or within
a single file. Blank identifiers (`_`) and `init` functions are excluded, since Go
permits those to repeat. The check is purely syntactic (`go/parser`), adds no
dependencies, and runs on the in-memory output.

This follows the "fail codegen and surface a readable error" direction from the
issue (option 3), without spawning a compiler.

Addresses Issue #1043

### How was it tested?
- New unit tests in `cmd/grafana-app-sdk/generate_test.go` (9 cases): cross-file
  collision, const-vs-type collision, same-file duplicate, and negative cases
  (different packages, methods, `_` vars, `init` funcs, non-Go files).
- Manual: a kind whose schema defines a `#Status` CUE definition. Before this
  change, `generate` exits 0 and `go build` fails with `Status redeclared in this
  block`; after, `generate` exits non-zero, lists the collision, and writes
  nothing. Generation without the colliding kind is unaffected.
- `go test ./cmd/... ./codegen/...`, `golangci-lint`, `gofmt` pass;
  `make update-workspace` produces no diff.

### Where did you document your changes?
The CLI error message is self-documenting and the new test cases document the
rules. No user-facing docs change.

### Notes to Reviewers
- The check is intentionally syntactic and scoped to the `redeclared in this block`
  class, not a full compile.
- `Metadata` is in the issue title but no longer collides on current `main` (the
  generator no longer emits a standalone `Metadata` type; `Spec`/`Status`/
  `JSONCodec` still do). The check is generic, so it covers whatever names the
  generator emits now or later.