### PR TITLE
feat: Serve App custom routes from operator.Runner

### DIFF
--- a/k8s/custom_route_handler.go
+++ b/k8s/custom_route_handler.go
@@ -1,0 +1,180 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+const apisBasePath = "/apis"
+
+// CustomRouteCaller is the subset of app.App that the CustomRouteHandler depends on. Any
+// app.App implementation satisfies it, but tests and adapters can supply a narrower implementation.
+type CustomRouteCaller interface {
+	CallCustomRoute(ctx context.Context, w app.CustomRouteResponseWriter, r *app.CustomRouteRequest) error
+}
+
+// CustomRouteHandlerConfig is the configuration for a CustomRouteHandler.
+type CustomRouteHandlerConfig struct {
+	// Caller handles inbound requests via CallCustomRoute. An app.App satisfies this interface.
+	Caller CustomRouteCaller
+	// Manifest is validated at construction time and used by Register to install one
+	// literal-plural pattern per kind (namespaced or cluster-scoped according to the kind's
+	// Scope), plus two version-level fallback patterns per version. Only Group and
+	// Versions[*].Kinds[*] (Kind, Plural, Scope) are read; admission and conversion fields are
+	// ignored.
+	Manifest app.ManifestData
+}
+
+// CustomRouteHandler installs ServeMux patterns that expose the custom routes of an app.App
+// on the same URL grammar used by the aggregated Kubernetes API server:
+//
+//	/apis/<group>/<version>/<plural>/<name>/<subresource...>                   (cluster-scoped subresource)
+//	/apis/<group>/<version>/namespaces/<ns>/<plural>/<name>/<subresource...>   (namespaced subresource)
+//	/apis/<group>/<version>/<path...>                                          (cluster-scoped version-level)
+//	/apis/<group>/<version>/namespaces/<ns>/<path...>                          (namespaced version-level)
+//
+// Inbound requests are translated into an app.CustomRouteRequest and dispatched via
+// Caller.CallCustomRoute. Patterns are installed onto a parent http.ServeMux via Register.
+type CustomRouteHandler struct {
+	caller   CustomRouteCaller
+	manifest app.ManifestData
+}
+
+// NewCustomRouteHandler creates a new CustomRouteHandler. Caller is required. The Manifest is
+// validated for duplicate plurals; pattern registration itself is deferred to Register.
+func NewCustomRouteHandler(cfg CustomRouteHandlerConfig) (*CustomRouteHandler, error) {
+	if cfg.Caller == nil {
+		return nil, errors.New("config.Caller is required")
+	}
+
+	// Validate that no group/version has two kinds with the same plural — that would create
+	// duplicate ServeMux patterns at Register time, which would panic.
+	registered := make(map[string]string)
+	for _, v := range cfg.Manifest.Versions {
+		for _, k := range v.Kinds {
+			if k.Plural == "" || k.Kind == "" {
+				continue
+			}
+			key := fmt.Sprintf("%s/%s/%s", cfg.Manifest.Group, v.Name, k.Plural)
+			if existing, ok := registered[key]; ok {
+				return nil, fmt.Errorf("duplicate plural %q for group %q version %q: kinds %q and %q",
+					k.Plural, cfg.Manifest.Group, v.Name, existing, k.Kind)
+			}
+			registered[key] = k.Kind
+		}
+	}
+
+	return &CustomRouteHandler{
+		caller:   cfg.Caller,
+		manifest: cfg.Manifest,
+	}, nil
+}
+
+// Register installs the custom route handler on the provided mux.
+func (h *CustomRouteHandler) Register(mux *http.ServeMux) {
+	for _, v := range h.manifest.Versions {
+		versionPath := fmt.Sprintf("%s/%s/%s", apisBasePath, h.manifest.Group, v.Name)
+
+		for _, k := range v.Kinds {
+			if k.Plural == "" || k.Kind == "" {
+				continue
+			}
+			pattern := fmt.Sprintf("%s/namespaces/{namespace}/%s/{name}/{path...}", versionPath, k.Plural)
+			if resource.SchemaScope(k.Scope) == resource.ClusterScope {
+				pattern = fmt.Sprintf("%s/%s/{name}/{path...}", versionPath, k.Plural)
+			}
+			mux.HandleFunc(pattern, h.dispatchRoute(h.manifest.Group, v.Name, k.Kind, k.Plural))
+		}
+
+		// Version-level routes leave kind/plural empty.
+		mux.HandleFunc(
+			versionPath+"/namespaces/{namespace}/{path...}",
+			h.dispatchRoute(h.manifest.Group, v.Name, "", ""),
+		)
+		mux.HandleFunc(
+			versionPath+"/{path...}",
+			h.dispatchRoute(h.manifest.Group, v.Name, "", ""),
+		)
+	}
+
+	// Catch-all under /apis/ for any URL that didn't match the patterns above. Scoped to
+	// /apis/ rather than / so it doesn't shadow other handlers the caller has installed.
+	mux.HandleFunc(apisBasePath+"/", func(w http.ResponseWriter, r *http.Request) {
+		writeStatusError(w, http.StatusNotFound, metav1.StatusReasonNotFound,
+			fmt.Sprintf("path %q is not a valid /apis/<group>/<version>/... URL", r.URL.Path))
+	})
+}
+
+func (h *CustomRouteHandler) dispatchRoute(group, version, kind, plural string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := resource.FullIdentifier{
+			Group:     group,
+			Version:   version,
+			Namespace: r.PathValue("namespace"),
+			Kind:      kind,
+			Plural:    plural,
+			Name:      r.PathValue("name"),
+		}
+		routeReq := &app.CustomRouteRequest{
+			ResourceIdentifier: id,
+			Path:               r.PathValue("path"),
+			URL:                r.URL,
+			Method:             r.Method,
+			Headers:            r.Header,
+			Body:               r.Body,
+		}
+		err := h.caller.CallCustomRoute(r.Context(), w, routeReq)
+		if err == nil {
+			logging.FromContext(r.Context()).Debug("custom route handler returned success",
+				"method", r.Method, "path", r.URL.Path)
+			return
+		}
+		logging.FromContext(r.Context()).Error("custom route handler returned error",
+			"error", err, "method", r.Method, "path", r.URL.Path)
+		writeError(w, r, err)
+	}
+}
+
+func writeError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, app.ErrCustomRouteNotFound) {
+		writeStatusError(w, http.StatusNotFound, metav1.StatusReasonNotFound,
+			fmt.Sprintf("custom route %s %s not found", r.Method, r.URL.Path))
+		return
+	}
+
+	code := int32(http.StatusInternalServerError)
+	reason := metav1.StatusReasonInternalError
+	var apiStatus apierrors.APIStatus
+	if errors.As(err, &apiStatus) {
+		st := apiStatus.Status()
+		if st.Code != 0 {
+			code = st.Code
+		}
+		if st.Reason != "" {
+			reason = st.Reason
+		}
+	}
+	writeStatusError(w, code, reason, err.Error())
+}
+
+func writeStatusError(w http.ResponseWriter, code int32, reason metav1.StatusReason, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(int(code))
+	_ = json.NewEncoder(w).Encode(metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Code:     code,
+		Reason:   reason,
+		Message:  message,
+	})
+}

--- a/k8s/custom_route_handler_test.go
+++ b/k8s/custom_route_handler_test.go
@@ -1,0 +1,325 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+)
+
+// stubApp implements CustomRouteCaller for testing.
+type stubApp struct {
+	called   *app.CustomRouteRequest
+	bodyRead string
+	respond  func(w app.CustomRouteResponseWriter) error
+	err      error
+}
+
+func (s *stubApp) CallCustomRoute(_ context.Context, w app.CustomRouteResponseWriter, r *app.CustomRouteRequest) error {
+	s.called = r
+	if r.Body != nil {
+		b, _ := io.ReadAll(r.Body)
+		s.bodyRead = string(b)
+	}
+	if s.respond != nil {
+		return s.respond(w)
+	}
+	return s.err
+}
+
+func testManifest() app.ManifestData {
+	return app.ManifestData{
+		Group: "test.grafana.app",
+		Versions: []app.ManifestVersion{{
+			Name: "v1",
+			Kinds: []app.ManifestVersionKind{{
+				Kind:   "Foo",
+				Plural: "foos",
+				Scope:  string(resource.NamespacedScope),
+			}, {
+				Kind:   "Cluz",
+				Plural: "cluzes",
+				Scope:  string(resource.ClusterScope),
+			}},
+		}},
+	}
+}
+
+func TestNewCustomRouteHandler(t *testing.T) {
+	t.Run("missing app", func(t *testing.T) {
+		_, err := NewCustomRouteHandler(CustomRouteHandlerConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Caller")
+	})
+	t.Run("duplicate plural", func(t *testing.T) {
+		_, err := NewCustomRouteHandler(CustomRouteHandlerConfig{
+			Caller: &stubApp{},
+			Manifest: app.ManifestData{
+				Group: "g",
+				Versions: []app.ManifestVersion{{Name: "v1", Kinds: []app.ManifestVersionKind{
+					{Kind: "A", Plural: "things", Scope: "Namespaced"},
+					{Kind: "B", Plural: "things", Scope: "Namespaced"},
+				}}},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate plural")
+	})
+	t.Run("ok", func(t *testing.T) {
+		h, err := NewCustomRouteHandler(CustomRouteHandlerConfig{
+			Caller:   &stubApp{},
+			Manifest: testManifest(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+	})
+}
+
+// newTestMux returns a parent ServeMux with the handler's patterns already installed via
+// Register. Tests dispatch through the parent mux, exercising the public composition path.
+func newTestMux(t *testing.T, stub *stubApp) *http.ServeMux {
+	t.Helper()
+	h, err := NewCustomRouteHandler(CustomRouteHandlerConfig{
+		Caller:   stub,
+		Manifest: testManifest(),
+	})
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+func TestCustomRouteHandler_Dispatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		wantGroup     string
+		wantVersion   string
+		wantNamespace string
+		wantKind      string
+		wantPlural    string
+		wantName      string
+		wantSubPath   string
+	}{
+		{
+			name:      "cluster-scoped single-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/things",
+			wantGroup: "test.grafana.app", wantVersion: "v1",
+			wantSubPath: "things",
+		},
+		{
+			name:      "cluster-scoped multi-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/things/nested",
+			wantGroup: "test.grafana.app", wantVersion: "v1",
+			wantSubPath: "things/nested",
+		},
+		{
+			name:      "cluster-scoped subresource single-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/cluzes/mycluz/details",
+			wantGroup: "test.grafana.app", wantVersion: "v1",
+			wantKind: "Cluz", wantPlural: "cluzes", wantName: "mycluz", wantSubPath: "details",
+		},
+		{
+			name:      "cluster-scoped subresource multi-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/cluzes/mycluz/blah/details",
+			wantGroup: "test.grafana.app", wantVersion: "v1",
+			wantKind: "Cluz", wantPlural: "cluzes", wantName: "mycluz", wantSubPath: "blah/details",
+		},
+		{
+			name:      "namespace-scoped single-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/namespaces/ns1/things",
+			wantGroup: "test.grafana.app", wantVersion: "v1", wantNamespace: "ns1",
+			wantSubPath: "things",
+		},
+		{
+			name:      "namespace-scoped multi-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/namespaces/ns1/things/nested",
+			wantGroup: "test.grafana.app", wantVersion: "v1", wantNamespace: "ns1",
+			wantSubPath: "things/nested",
+		},
+		{
+			name:      "namespace-scoped subresource single-segment route",
+			method:    http.MethodPost,
+			path:      "/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/reboot",
+			wantGroup: "test.grafana.app", wantVersion: "v1", wantNamespace: "ns1",
+			wantKind: "Foo", wantPlural: "foos", wantName: "myfoo", wantSubPath: "reboot",
+		},
+		{
+			name:      "namespace-scoped subresource multi-segment route",
+			method:    http.MethodGet,
+			path:      "/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/logs/stream",
+			wantGroup: "test.grafana.app", wantVersion: "v1", wantNamespace: "ns1",
+			wantKind: "Foo", wantPlural: "foos", wantName: "myfoo", wantSubPath: "logs/stream",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubApp{}
+			mux := newTestMux(t, stub)
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			require.NotNil(t, stub.called, "CallCustomRoute was not invoked")
+			id := stub.called.ResourceIdentifier
+			assert.Equal(t, tt.wantGroup, id.Group)
+			assert.Equal(t, tt.wantVersion, id.Version)
+			assert.Equal(t, tt.wantNamespace, id.Namespace)
+			assert.Equal(t, tt.wantKind, id.Kind)
+			assert.Equal(t, tt.wantPlural, id.Plural)
+			assert.Equal(t, tt.wantName, id.Name)
+			assert.Equal(t, tt.wantSubPath, stub.called.Path)
+			assert.Equal(t, tt.method, stub.called.Method)
+		})
+	}
+}
+
+func TestCustomRouteHandler_BodyHeadersURL(t *testing.T) {
+	stub := &stubApp{}
+	mux := newTestMux(t, stub)
+	req := httptest.NewRequest(http.MethodPost,
+		"/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/echo?q=1",
+		strings.NewReader(`{"hello":"world"}`))
+	req.Header.Set("X-Test", "yes")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.NotNil(t, stub.called)
+	assert.Equal(t, `{"hello":"world"}`, stub.bodyRead)
+	assert.Equal(t, "yes", stub.called.Headers.Get("X-Test"))
+	require.NotNil(t, stub.called.URL)
+	assert.Equal(t, "1", stub.called.URL.Query().Get("q"))
+}
+
+func TestCustomRouteHandler_Errors(t *testing.T) {
+	t.Run("malformed /apis path", func(t *testing.T) {
+		// The /apis/ catch-all installed by Register returns a metav1.Status JSON 404 for any
+		// /apis/... URL that doesn't match a more-specific pattern.
+		mux := newTestMux(t, &stubApp{})
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/apis/", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		var st metav1.Status
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &st))
+		assert.Equal(t, metav1.StatusFailure, st.Status)
+	})
+	t.Run("plural with no name dispatches as version-level", func(t *testing.T) {
+		// A URL like /apis/.../namespaces/ns1/foos with no /<name>/<sub> tail no longer
+		// matches the literal-plural subresource pattern; it falls through to the version-level
+		// fallback with Path="foos". The caller is expected to return ErrCustomRouteNotFound,
+		// which the handler translates to a JSON 404.
+		stub := &stubApp{err: app.ErrCustomRouteNotFound}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/ns1/foos", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		require.NotNil(t, stub.called)
+		assert.Equal(t, "foos", stub.called.Path)
+		assert.Empty(t, stub.called.ResourceIdentifier.Kind)
+	})
+	t.Run("namespaces/ with no namespace dispatches as version-level", func(t *testing.T) {
+		// /apis/g/v1/namespaces/ doesn't match the namespaced pattern (no value for {namespace}).
+		// It falls through to the cluster version-level fallback with Path="namespaces/", and
+		// the caller's not-found result becomes a JSON 404.
+		stub := &stubApp{err: app.ErrCustomRouteNotFound}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+	t.Run("unknown group/version short-circuits to 404", func(t *testing.T) {
+		// Patterns are registered with literal group/version, so a URL for a group or version
+		// not in the manifest doesn't match any version-specific pattern. The /apis/ catch-all
+		// returns a JSON 404 without invoking the caller.
+		stub := &stubApp{}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/other.grafana.app/v1/anything", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Nil(t, stub.called, "caller should not be invoked for unknown group")
+
+		rec = httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v9/anything", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Nil(t, stub.called, "caller should not be invoked for unknown version")
+	})
+	t.Run("ErrCustomRouteNotFound -> 404", func(t *testing.T) {
+		stub := &stubApp{err: app.ErrCustomRouteNotFound}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/missing", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		var st metav1.Status
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &st))
+		assert.Equal(t, metav1.StatusReasonNotFound, st.Reason)
+	})
+	t.Run("generic error -> 500", func(t *testing.T) {
+		stub := &stubApp{err: errors.New("boom")}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/sub", nil))
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+	t.Run("APIStatus error preserves code", func(t *testing.T) {
+		stub := &stubApp{err: apierrors.NewBadRequest("nope")}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/sub", nil))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+	t.Run("handler writes response without error", func(t *testing.T) {
+		stub := &stubApp{respond: func(w app.CustomRouteResponseWriter) error {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = w.Write([]byte("brewing"))
+			return nil
+		}}
+		mux := newTestMux(t, stub)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+			"/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/sub", nil))
+		assert.Equal(t, http.StatusTeapot, rec.Code)
+		assert.Equal(t, "brewing", rec.Body.String())
+	})
+}
+
+func TestCustomRouteHandler_Register(t *testing.T) {
+	stub := &stubApp{}
+	h, err := NewCustomRouteHandler(CustomRouteHandlerConfig{Caller: stub, Manifest: testManifest()})
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/echo")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.NotNil(t, stub.called)
+	assert.Equal(t, "echo", stub.called.Path)
+}

--- a/k8s/webhooks.go
+++ b/k8s/webhooks.go
@@ -61,6 +61,7 @@ type WebhookServer struct {
 	validatingControllers     map[string]validatingAdmissionControllerTuple
 	mutatingControllers       map[string]mutatingAdmissionControllerTuple
 	converters                map[string]Converter
+	customRoutes              *CustomRouteHandler
 	port                      int
 	tlsConfig                 TLSConfig
 }
@@ -138,6 +139,12 @@ func (w *WebhookServer) AddMutatingAdmissionController(controller resource.Mutat
 	}
 }
 
+// SetCustomRouteHandler attaches a CustomRouteHandler to the WebhookServer. It must be called
+// before Run; later calls have no effect on an already-running server.
+func (w *WebhookServer) SetCustomRouteHandler(h *CustomRouteHandler) {
+	w.customRoutes = h
+}
+
 // AddConverter adds a Converter to the WebhookServer, associated with the given group and kind.
 func (w *WebhookServer) AddConverter(converter Converter, groupKind metav1.GroupKind) {
 	if w.converters == nil {
@@ -154,6 +161,9 @@ func (w *WebhookServer) Run(closeChan <-chan struct{}) error {
 	mux.HandleFunc("/validate", w.HandleValidateHTTP)
 	mux.HandleFunc("/mutate", w.HandleMutateHTTP)
 	mux.HandleFunc("/convert", w.HandleConvertHTTP)
+	if w.customRoutes != nil {
+		w.customRoutes.Register(mux)
+	}
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", w.port),
 		Handler:           mux,

--- a/k8s/webhooks_test.go
+++ b/k8s/webhooks_test.go
@@ -625,3 +625,47 @@ func (tmac *testMutatingAdmissionController) Mutate(ctx context.Context, request
 	}
 	return nil, nil
 }
+
+func TestWebhookServer_CustomRoutes(t *testing.T) {
+	t.Run("SetCustomRouteHandler post-construction", func(t *testing.T) {
+		srv, err := NewWebhookServer(WebhookServerConfig{
+			Port:      1234,
+			TLSConfig: TLSConfig{CertPath: "x", KeyPath: "y"},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, srv.customRoutes)
+		stub := &stubApp{}
+		h, err := NewCustomRouteHandler(CustomRouteHandlerConfig{Caller: stub, Manifest: testManifest()})
+		require.NoError(t, err)
+		srv.SetCustomRouteHandler(h)
+		assert.Same(t, h, srv.customRoutes)
+	})
+
+	t.Run("served on shared mux alongside webhook paths", func(t *testing.T) {
+		// Mirror the mux that Run() builds, since Run() itself requires real TLS files.
+		stub := &stubApp{}
+		h, err := NewCustomRouteHandler(CustomRouteHandlerConfig{Caller: stub, Manifest: testManifest()})
+		require.NoError(t, err)
+		srv, err := NewWebhookServer(WebhookServerConfig{
+			Port:      1234,
+			TLSConfig: TLSConfig{CertPath: "x", KeyPath: "y"},
+		})
+		require.NoError(t, err)
+		srv.SetCustomRouteHandler(h)
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/validate", srv.HandleValidateHTTP)
+		mux.HandleFunc("/mutate", srv.HandleMutateHTTP)
+		mux.HandleFunc("/convert", srv.HandleConvertHTTP)
+		srv.customRoutes.Register(mux)
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/apis/test.grafana.app/v1/namespaces/ns1/foos/myfoo/echo")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NotNil(t, stub.called, "custom route handler was not invoked through shared mux")
+		assert.Equal(t, "echo", stub.called.Path)
+	})
+}

--- a/operator/runner.go
+++ b/operator/runner.go
@@ -85,8 +85,10 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 
 // RunnerConfig contains configuration information for the Runner.
 type RunnerConfig struct {
-	// WebhookConfig contains configuration information for exposing k8s webhooks.
-	// This can be empty if your App does not implement ValidatorApp, MutatorApp, or ConversionApp
+	// WebhookConfig contains configuration information for exposing k8s webhooks and the App's
+	// custom routes. The webhook server hosts both admission/conversion endpoints and the
+	// /apis/... custom route paths on the same HTTPS port. This can be empty only if the App
+	// has no admission, conversion, or custom route capabilities.
 	WebhookConfig RunnerWebhookConfig
 	// MetricsConfig contains the configuration for exposing prometheus metrics, if desired
 	MetricsConfig RunnerMetricsConfig
@@ -112,6 +114,7 @@ type RunnerWebhookConfig struct {
 	// Port is the port to open the webhook server on
 	Port int
 	// TLSConfig is the TLS Cert and Key to use for the HTTPS endpoints exposed for webhooks
+	// and custom routes.
 	TLSConfig k8s.TLSConfig
 }
 
@@ -194,9 +197,10 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 			}
 		}
 	}
-	if anyWebhooks {
+	anyCustomRoutes := manifestHasCustomRoutes(manifestData)
+	if anyWebhooks || anyCustomRoutes {
 		if s.webhookServer == nil {
-			return errors.New("app has capabilities that require webhooks, but webhook server was not provided TLS config")
+			return errors.New("app has capabilities that require the webhook server (admission, conversion, or custom routes), but no TLS config was provided")
 		}
 		for _, kind := range a.ManagedKinds() {
 			c, ok := vkCapabilities[fmt.Sprintf("%s/%s", kind.Kind(), kind.Version())]
@@ -224,6 +228,16 @@ func (s *Runner) Run(ctx context.Context, provider app.Provider) error {
 					Kind:  kind.Kind(),
 				})
 			}
+		}
+		if anyCustomRoutes {
+			handler, err := k8s.NewCustomRouteHandler(k8s.CustomRouteHandlerConfig{
+				Caller:   a,
+				Manifest: *manifestData,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create custom route handler: %w", err)
+			}
+			s.webhookServer.SetCustomRouteHandler(handler)
 		}
 		runner.AddRunnable(s.webhookServer)
 	}
@@ -343,6 +357,22 @@ func (s *simpleK8sConverter) Convert(obj k8s.RawKind, targetAPIVersion string) (
 	return s.convertFunc(obj, targetAPIVersion)
 }
 
+// manifestHasCustomRoutes reports whether the manifest declares any kind subresource routes
+// or any version-level routes.
+func manifestHasCustomRoutes(md *app.ManifestData) bool {
+	for _, version := range md.Versions {
+		if len(version.Routes.Namespaced) > 0 || len(version.Routes.Cluster) > 0 {
+			return true
+		}
+		for _, kind := range version.Kinds {
+			if len(kind.Routes) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func newWebhookServerRunner(ws *k8s.WebhookServer) *webhookServerRunner {
 	return &webhookServerRunner{
 		server: ws,
@@ -371,6 +401,10 @@ func (s *webhookServerRunner) AddMutatingAdmissionController(controller resource
 
 func (s *webhookServerRunner) AddConverter(converter k8s.Converter, groupKind metav1.GroupKind) {
 	s.server.AddConverter(converter, groupKind)
+}
+
+func (s *webhookServerRunner) SetCustomRouteHandler(h *k8s.CustomRouteHandler) {
+	s.server.SetCustomRouteHandler(h)
 }
 
 type k8sRunner interface {


### PR DESCRIPTION
Adds support for serving an app.App's custom routes (non-CRUD endpoints)
through the same WebhookServer that already handles admission and conversion
webhooks reusing its HTTPS port and TLS config.
