### PR TITLE
fix: defaultInstaller to respect served: false 

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -509,6 +509,9 @@ func (r *defaultInstaller) InstallAPIs(server GenericAPIServer, optsGetter gener
 	// Make sure we didn't miss any versions that don't have any kinds registered
 	hasEnabledRoutes := make(map[string]bool)
 	for _, v := range r.appConfig.ManifestData.Versions {
+		if !v.Served {
+			continue
+		}
 		gv := schema.GroupVersion{Group: r.appConfig.ManifestData.Group, Version: v.Name}
 		for routePath := range v.Routes.Namespaced {
 			if r.isCustomRouteEnabled(gv, routePath) {
@@ -799,6 +802,9 @@ func (r *defaultInstaller) App() (app.App, error) {
 func (r *defaultInstaller) GroupVersions() []schema.GroupVersion {
 	groupVersions := make([]schema.GroupVersion, 0, len(r.appConfig.ManifestData.Versions))
 	for _, gv := range r.appConfig.ManifestData.Versions {
+		if !gv.Served {
+			continue
+		}
 		groupVersions = append(groupVersions, schema.GroupVersion{Group: r.appConfig.ManifestData.Group, Version: gv.Name})
 	}
 	return groupVersions
@@ -1132,6 +1138,9 @@ func (r *defaultInstaller) getKindsByGroupVersion() (map[schema.GroupVersion][]K
 	out := make(map[schema.GroupVersion][]KindAndManifestKind)
 	group := r.appConfig.ManifestData.Group
 	for _, v := range r.appConfig.ManifestData.Versions {
+		if !v.Served {
+			continue
+		}
 		for _, manifestKind := range v.Kinds {
 			gv := schema.GroupVersion{Group: group, Version: v.Name}
 			kind, ok := r.resolver.KindToGoType(manifestKind.Kind, v.Name)

--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -336,6 +336,9 @@ func (r *defaultInstaller) GetOpenAPIDefinitions(callback common.ReferenceCallba
 	res := map[string]common.OpenAPIDefinition{}
 	hasCustomRoutes := false
 	for _, v := range r.appConfig.ManifestData.Versions {
+		if !v.Served {
+			continue
+		}
 		for _, manifestKind := range v.Kinds {
 			kind, ok := r.resolver.KindToGoType(manifestKind.Kind, v.Name)
 			if !ok {


### PR DESCRIPTION
## What Changed? Why?

Following methods of `defaultInstaller` modified to respect the served param of the api version group:
1. GetOpenAPIDefinitions
2. InstallAPIs 
3. GroupVersions
4. getKindsByGroupVersion

Addresses Issue #<!-- [Enter issue number here] -->

### How was it tested?
Manually I've published a related PR in the grafana oss repo
https://github.com/grafana/grafana/pull/126270


### Notes to Reviewers
This is by no mean a well tested fix, rather an attempt of a fix and opportunity to learn about the app platform