### PR TITLE
fix(operator): Avoid panic for some malformed validate/mutate requests.

### DIFF
--- a/k8s/webhooks.go
+++ b/k8s/webhooks.go
@@ -202,6 +202,11 @@ func (w *WebhookServer) HandleValidateHTTP(writer http.ResponseWriter, req *http
 		logging.FromContext(req.Context()).Error("Couldn't unmarshal", "error", err)
 		return
 	}
+	if admRev.Request == nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		logging.FromContext(req.Context()).Error("Admission review missing request")
+		return
+	}
 
 	// Look up the schema and controller
 	var schema resource.Kind
@@ -279,6 +284,10 @@ func (w *WebhookServer) HandleMutateHTTP(writer http.ResponseWriter, req *http.R
 	// Unmarshal the admission review
 	admRev, err := unmarshalKubernetesAdmissionReview(body, resource.WireFormatJSON)
 	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if admRev.Request == nil {
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/k8s/webhooks_test.go
+++ b/k8s/webhooks_test.go
@@ -382,6 +382,12 @@ func TestWebhookServer_HandleMutateHTTP(t *testing.T) {
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
+			name:               "empty request body",
+			reqMethod:          http.MethodPost,
+			payload:            []byte("{}"),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
 			name: "converted resource uses resolved kind for lookup",
 			serverConfig: WebhookServerConfig{
 				MutatingControllers: map[*resource.Kind]resource.MutatingAdmissionController{
@@ -526,6 +532,12 @@ func TestWebhookServer_HandleValidateHTTP(t *testing.T) {
 			name:               "malformed request body: bad JSON",
 			reqMethod:          http.MethodPost,
 			payload:            []byte("{"),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "empty request body",
+			reqMethod:          http.MethodPost,
+			payload:            []byte("{}"),
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{


### PR DESCRIPTION
Fix nil-pointer panic in HandleValidateHTTP and HandleMutateHTTP when the
request body unmarshals to an AdmissionReview with a nil Request.
