### PR TITLE
fix(codegen): Emit valid Go for multi-line schema descriptions in app manifest

### DIFF
--- a/codegen/cuekind/testing/testkind.cue
+++ b/codegen/cuekind/testing/testkind.cue
@@ -56,6 +56,9 @@ testManifestV3: {
 		"/foobar": {
 			"POST": {
 				name: "createFoobar"
+				// Key identifies a foobar entry.
+				// It is referenced by a custom route, so its multi-line
+				// description exercises the route schema codegen path.
 				#Key: {
 					name: string
 					match?: string

--- a/codegen/templates/manifest_go.tmpl
+++ b/codegen/templates/manifest_go.tmpl
@@ -24,7 +24,7 @@ import (
 SchemaProps: spec.SchemaProps{
     {{ if .Type }}Type: []string{ {{ range $index, $type := .Type }}{{ if $index }}, {{ end }}"{{$type}}"{{ end }} },{{ end }}{{ if .Format }}
     Format: "{{.Format}}",{{ end }}{{ if .Description }}
-    Description: "{{ escapeQuotes .Description }}",{{ end }}{{ if .Enum }}
+    Description: {{ goString .Description }},{{ end }}{{ if .Enum }}
     Enum: []interface{}{ {{ range .Enum }}
         "{{.}}",{{ end }}
     },{{ end }}{{ if .Properties }}
@@ -59,7 +59,7 @@ VendorExtensible: spec.VendorExtensible{
     ParameterProps: spec3.ParameterProps{
         Name: "{{.Name}}",{{ end }}{{ if .In }}
         In: "{{.In}}",{{ end }}{{ if .Description }}
-        Description: "{{ escapeQuotes .Description }}",{{ end }}{{ if .Required }}
+        Description: {{ goString .Description }},{{ end }}{{ if .Required }}
         Required: {{.Required}},{{ end }}{{ if .Schema }}
         Schema: &spec.Schema{ {{ template "schema" .Schema }}
         },
@@ -74,7 +74,7 @@ MediaTypeProps: spec3.MediaTypeProps{
         {{ range $key, $example := .Examples }}"{{$key}}": {
             ExampleProps: spec3.ExampleProps{
                 {{ if $example.Summary }}Summary: "{{$example.Summary}}",{{ end }}
-                {{ if $example.Description }}Description: "{{ escapeQuotes $example.Description }}",{{ end }}
+                {{ if $example.Description }}Description: {{ goString $example.Description }},{{ end }}
                 {{ if $example.Value }}Value: map[string]interface{}{
                     {{- range $k, $v := $example.Value }}
                     "{{$k}}": {{- if eq (printf "%T" $v) "string" -}}"{{$v}}"{{- else -}}{{printf "%#v" $v}}{{- end -}},
@@ -97,7 +97,7 @@ ResponsesProps: spec3.ResponsesProps{
 {{ define "response" }}
 &spec3.Response{
     ResponseProps: spec3.ResponseProps{
-        {{ if .Description }}Description: "{{ escapeQuotes .Description }}",{{ end }}
+        {{ if .Description }}Description: {{ goString .Description }},{{ end }}
         {{ if .Content }}Content: map[string]*spec3.MediaType{ {{ range $contentType, $mediaType := .Content }}
             "{{$contentType}}": { {{ template "mediaTypeContent" $mediaType }} },{{ end }}
         },{{ end }}
@@ -106,7 +106,7 @@ ResponsesProps: spec3.ResponsesProps{
 
 {{ define "requestBody" }}
 RequestBodyProps: spec3.RequestBodyProps{
-    {{ if .Description }}Description: "{{ escapeQuotes .Description }}",{{ end }}
+    {{ if .Description }}Description: {{ goString .Description }},{{ end }}
     {{ if .Required }}Required: {{.Required}},{{ end }}
     {{ if .Content }}Content: map[string]*spec3.MediaType{ {{ range $contentType, $mediaType := .Content }}
         "{{$contentType}}": { {{ template "mediaTypeContent" $mediaType }} },{{ end }}
@@ -116,12 +116,12 @@ RequestBodyProps: spec3.RequestBodyProps{
 {{ define "operation" }}
 OperationProps: spec3.OperationProps{
     {{ if .Summary }}Summary: "{{.Summary}}",{{ end }}
-    {{ if .Description }}Description: "{{ escapeQuotes .Description }}",{{ end }}
+    {{ if .Description }}Description: {{ goString .Description }},{{ end }}
     {{ if .OperationId }}OperationId: "{{.OperationId}}",{{ end }}
     {{ if .Tags }}Tags: []string{ {{ range $index, $tag := .Tags }}{{ if $index }}, {{ end }}"{{$tag}}"{{ end }} },{{ end }}
     {{ if .ExternalDocs }}ExternalDocs: &spec3.ExternalDocumentation{
         {{ if .ExternalDocs.URL }}URL: "{{.ExternalDocs.URL}}",{{ end }}
-        {{ if .ExternalDocs.Description }}Description: "{{ escapeQuotes .ExternalDocs.Description }}",{{ end }}
+        {{ if .ExternalDocs.Description }}Description: {{ goString .ExternalDocs.Description }},{{ end }}
     },{{ end }}
     {{ if .Parameters }}Parameters: []*spec3.Parameter{ {{ range .Parameters }}
         {{ template "parameter" . }}{{ end }}
@@ -137,7 +137,7 @@ OperationProps: spec3.OperationProps{
     {{ if .Servers }}Servers: []*spec3.Server{ {{ range .Servers }}
         {
             {{ if .URL }}URL: "{{.URL}}",{{ end }}
-            {{ if .Description }}Description: "{{ escapeQuotes .Description }}",{{ end }}
+            {{ if .Description }}Description: {{ goString .Description }},{{ end }}
         },{{ end }}
     },{{ end }}
 },{{ if .Extensions }}
@@ -189,7 +189,7 @@ var appManifestData = app.ManifestData{
                 Routes: map[string]spec3.PathProps{ {{ range $path, $props := .Routes }}{{ if $props }}
                     "{{$path}}": { {{ if $props.Summary }}
                         Summary: "{{$props.Summary}}",{{ end }}{{ if $props.Description }}
-                        Description: "{{ (escapeQuotes $props.Description) }}",{{ end }}{{ if $props.Parameters }}
+                        Description: {{ goString $props.Description }},{{ end }}{{ if $props.Parameters }}
                         Parameters: []spec3.Parameter{ {{ range $props.Parameters }}
                             {{ template "parameter" . }}{{ end }}
                         },{{ end }}{{ if $props.Get }}
@@ -211,7 +211,7 @@ var appManifestData = app.ManifestData{
                 Namespaced: map[string]spec3.PathProps{ {{ range $path, $props := .Routes.Namespaced }}{{ if $props }}
                     "{{$path}}": { {{ if $props.Summary }}
                         Summary: "{{$props.Summary}}",{{ end }}{{ if $props.Description }}
-                        Description: "{{ escapeQuotes $props.Description }}",{{ end }}{{ if $props.Parameters }}
+                        Description: {{ goString $props.Description }},{{ end }}{{ if $props.Parameters }}
                         Parameters: []spec3.Parameter{ {{ range $props.Parameters }}
                             {{ template "parameter" . }}{{ end }}
                         },{{ end }}{{ if $props.Get }}
@@ -230,7 +230,7 @@ var appManifestData = app.ManifestData{
                 Cluster: map[string]spec3.PathProps{ {{ range $path, $props := .Routes.Cluster }}{{ if $props }}
                     "{{$path}}": { {{ if $props.Summary }}
                         Summary: "{{$props.Summary}}",{{ end }}{{ if $props.Description }}
-                        Description: "{{ escapeQuotes $props.Description }}",{{ end }}{{ if $props.Parameters }}
+                        Description: {{ goString $props.Description }},{{ end }}{{ if $props.Parameters }}
                         Parameters: []spec3.Parameter{ {{ range $props.Parameters }}
                             {{ template "parameter" . }}{{ end }}
                         },{{ end }}{{ if $props.Get }}
@@ -274,8 +274,8 @@ var appManifestData = app.ManifestData{
     },{{ end }}{{ if .ManifestData.Roles }}
     Roles: map[string]app.ManifestRole{
         {{ range $key := $.SortedRoleKeys }}{{ $val := index $.ManifestData.Roles $key }}"{{ $key }}": {
-            Title: "{{ $val.Title }}",
-            Description: "{{ $val.Description }}",
+            Title: {{ goString $val.Title }},
+            Description: {{ goString $val.Description }},
             Kinds: []app.ManifestRoleKind{ {{ range $val.Kinds }}
                 {
                     Kind: "{{ .Kind }}",{{ if .PermissionSet }}{{ $needs_str_ptr_func = true }}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -37,8 +38,12 @@ var (
 		"refString": func(ref spec.Ref) string {
 			return ref.String()
 		},
-		"escapeQuotes": func(s string) string {
-			return strings.ReplaceAll(s, `"`, `\"`)
+		// goString renders s as a valid, fully-escaped Go double-quoted string
+		// literal (including the surrounding quotes). It escapes quotes, newlines,
+		// backslashes and control characters, so descriptions sourced from
+		// multi-line CUE doc comments produce parseable Go.
+		"goString": func(s string) string {
+			return strconv.Quote(s)
 		},
 	}
 

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -39,12 +39,10 @@ var (
 			return ref.String()
 		},
 		// goString renders s as a valid, fully-escaped Go double-quoted string
-		// literal (including the surrounding quotes). It escapes quotes, newlines,
-		// backslashes and control characters, so descriptions sourced from
-		// multi-line CUE doc comments produce parseable Go.
-		"goString": func(s string) string {
-			return strconv.Quote(s)
-		},
+		// literal (including the surrounding quotes). strconv.Quote escapes quotes,
+		// newlines, backslashes and control characters, so descriptions sourced
+		// from multi-line CUE doc comments produce parseable Go.
+		"goString": strconv.Quote,
 	}
 
 	templateResourceObject, _         = template.ParseFS(templates, "resourceobject.tmpl")

--- a/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/manifestdata/testapp_manifest.go.txt
@@ -473,7 +473,8 @@ var appManifestData = app.ManifestData{
 				Schemas: map[string]spec.Schema{
 					"createFoobarKey": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"object"},
+							Type:        []string{"object"},
+							Description: "Key identifies a foobar entry.\nIt is referenced by a custom route, so its multi-line\ndescription exercises the route schema codegen path.",
 							Properties: map[string]spec.Schema{
 								"match": {
 									SchemaProps: spec.SchemaProps{

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_request_body_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_request_body_types_gen.go.txt
@@ -2,6 +2,9 @@
 
 package v3
 
+// Key identifies a foobar entry.
+// It is referenced by a custom route, so its multi-line
+// description exercises the route schema codegen path.
 type CreateFoobarRequestKey struct {
 	Name  string  `json:"name"`
 	Match *string `json:"match,omitempty"`

--- a/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_body_types_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/testapp/v3/createfoobar_response_body_types_gen.go.txt
@@ -2,6 +2,9 @@
 
 package v3
 
+// Key identifies a foobar entry.
+// It is referenced by a custom route, so its multi-line
+// description exercises the route schema codegen path.
 // +k8s:openapi-gen=true
 type CreateFoobarKey struct {
 	Name  string  `json:"name"`


### PR DESCRIPTION
Fixes #1420

## Problem

`grafana-app-sdk generate` produced invalid Go for the app manifest when an app had custom routes whose request/response types referenced CUE schema definitions carrying multi-line doc comments. The generator failed parsing its own output:

```
Error: 1 error occurred:
	* ManifestGoGenerator: 634:18: string literal not terminated (and N more errors) for input "<appName>"
```

## Root cause

Route (and route-additional-schema) descriptions were rendered as Go **double-quoted** string literals via the `escapeQuotes` template helper, which only escaped `"`. A multi-line doc comment became a description with embedded newlines, emitted as a Go string literal spanning multiple physical lines → `string literal not terminated`. Kind schemas were unaffected because they are emitted as backtick raw strings via `ToJSONBacktickString`.

## Fix

- Replace `escapeQuotes` with a `goString` helper backed by `strconv.Quote`, which escapes quotes, newlines, backslashes and control characters and emits its own surrounding quotes.
- Use `goString` for every description field in `manifest_go.tmpl` (schema / parameter / mediaType / response / requestBody / operation / route path-props), and also harden the role `Title`/`Description` fields, which previously emitted raw quoted values with no escaping at all.

## Test coverage

Added a multi-line doc comment to the route-referenced `#Key` definition in the codegen test fixtures (`testkind.cue`). This exercises the route schema codegen path that existing kind golden tests didn't cover. Verified it reproduces the exact `string literal not terminated` error against the old template, then regenerated golden files with the fix — the description is now a properly escaped single-line literal (`"Key identifies a foobar entry.\nIt is referenced..."`).

The full `./codegen/...` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)