### PR TITLE
fix(apiserver): align EmptyObject OpenAPI key with its OpenAPIModelName

### DIFF
--- a/k8s/apiserver/installer.go
+++ b/k8s/apiserver/installer.go
@@ -1566,7 +1566,7 @@ func copySpec3MediaType(mt *spec3.MediaType) *spec3.MediaType {
 type EmptyObject struct{}
 
 func (EmptyObject) OpenAPIModelName() string {
-	return "com.github.grafana-app-sdk.k8s.apiserver.EmptyObject"
+	return "com.github.grafana.grafana-app-sdk.k8s.apiserver.EmptyObject"
 }
 
 func fieldLabelConversionFuncForKind(kind resource.Kind) func(label, value string) (string, string, error) {

--- a/k8s/apiserver/installer_test.go
+++ b/k8s/apiserver/installer_test.go
@@ -177,6 +177,45 @@ func TestDefaultInstaller_GetOpenAPIDefinitions(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
+// TestEmptyObject_OpenAPIDefinitionKeyMatchesModelName guards the invariant
+// that EmptyObject's OpenAPI definition is registered under the same key the
+// builder uses to look it up (its OpenAPIModelName()). A mismatch produces a
+// dangling $ref in the served OpenAPI document for custom routes that fall
+// back to EmptyObject as their response type.
+func TestEmptyObject_OpenAPIDefinitionKeyMatchesModelName(t *testing.T) {
+	sch, err := app.VersionSchemaFromMap(map[string]any{
+		"spec": map[string]any{"type": "object"},
+	}, TestKind.Kind())
+	require.Nil(t, err)
+	md := app.ManifestData{
+		Group: TestKind.Group(),
+		Versions: []app.ManifestVersion{{
+			Name: TestKind.Version(),
+			Kinds: []app.ManifestVersionKind{{
+				Kind:   TestKind.Kind(),
+				Schema: sch,
+				Routes: map[string]spec3.PathProps{
+					"/foo": {Get: &spec3.Operation{}},
+				},
+			}},
+		}},
+	}
+	installer, err := NewDefaultAppInstaller(simple.NewAppProvider(app.NewEmbeddedManifest(md), nil, nil), app.Config{}, &mockGoTypeResolver{
+		KindToGoTypeFunc: func(k, v string) (resource.Kind, bool) {
+			return TestKind, true
+		},
+	})
+	require.Nil(t, err)
+	scheme := newScheme()
+	require.Nil(t, installer.AddToScheme(scheme))
+	defs := installer.GetOpenAPIDefinitions(func(path string) spec.Ref {
+		ref, _ := spec.NewRef(path)
+		return ref
+	})
+	_, ok := defs[EmptyObject{}.OpenAPIModelName()]
+	assert.True(t, ok, "EmptyObject must be registered in GetOpenAPIDefinitions under its OpenAPIModelName %q", EmptyObject{}.OpenAPIModelName())
+}
+
 type getFooResponse struct{}
 
 func TestDefaultInstaller_InstallAPIs(t *testing.T) {


### PR DESCRIPTION
EmptyObject's OpenAPI definition was registered under
"com.github.grafana.grafana-app-sdk.k8s.apiserver.EmptyObject", but
EmptyObject.OpenAPIModelName() returned the same string minus the
".grafana" segment. Since the installer looks up schemas by
OpenAPIModelName(), custom routes that fell back to EmptyObject as
their response type produced a dangling $ref in the served OpenAPI
document.

Adds a regression test asserting GetOpenAPIDefinitions contains an
entry keyed by EmptyObject{}.OpenAPIModelName().
