### PR TITLE
Disable dependabot workflow until token broker is implemented

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,71 +1,71 @@
-name: "Update Go Workspace for Dependabot PRs"
-on:
-  pull_request:
-    branches:
-      - main
-      - 'lts/**'
-    paths:
-      - .github/workflows/dependabot.yml
-      - go.mod
-      - go.sum
-      - go.work
-      - go.work.sum
-      - '**/go.mod'
-      - '**/go.sum'
-      - '**.go'
-permissions:
-  contents: write
-  id-token: write
-jobs:
-  update:
-    runs-on: "ubuntu-latest"
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
-    continue-on-error: true
-    steps:
-    - name: Retrieve GitHub App secrets
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@93f1ff8d6267af9094e988eb79c1fbb184d04e24
-      with:
-        repo_secrets: |
-          APP_ID=grafana-go-workspace-bot:app-id
-          APP_INSTALLATION_ID=grafana-go-workspace-bot:app-installation-id
-          PRIVATE_KEY=grafana-go-workspace-bot:private-key
-
-    - name: Generate GitHub App token
-      id: generate_token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
-      with:
-        app-id: ${{ env.APP_ID }}
-        private-key: ${{ env.PRIVATE_KEY }}
-
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ steps.generate_token.outputs.token }}
-        persist-credentials: true
-
-    - name: Set go version
-      uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4
-      with:
-        go-version-file: go.mod
-    
-    - name: Configure Git
-      run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git config --local --add --bool push.autoSetupRemote true
-
-    - name: Update workspace
-      run: make update-workspace
-
-    - name: Commit and push workspace changes
-      env:
-        BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
-      run: |
-        if ! git diff --exit-code --quiet; then
-          echo "Committing and pushing workspace changes"
-          git commit -a -m "update workspace"
-          git push origin $BRANCH_NAME
-        fi
+#name: "Update Go Workspace for Dependabot PRs"
+#on:
+#  pull_request:
+#    branches:
+#      - main
+#      - 'lts/**'
+#    paths:
+#      - .github/workflows/dependabot.yml
+#      - go.mod
+#      - go.sum
+#      - go.work
+#      - go.work.sum
+#      - '**/go.mod'
+#      - '**/go.sum'
+#      - '**.go'
+#permissions:
+#  contents: write
+#  id-token: write
+#jobs:
+#  update:
+#    runs-on: "ubuntu-latest"
+#    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+#    continue-on-error: true
+#    steps:
+#    - name: Retrieve GitHub App secrets
+#      id: get-secrets
+#      uses: grafana/shared-workflows/actions/get-vault-secrets@93f1ff8d6267af9094e988eb79c1fbb184d04e24
+#      with:
+#        repo_secrets: |
+#          APP_ID=grafana-go-workspace-bot:app-id
+#          APP_INSTALLATION_ID=grafana-go-workspace-bot:app-installation-id
+#          PRIVATE_KEY=grafana-go-workspace-bot:private-key
+#
+#    - name: Generate GitHub App token
+#      id: generate_token
+#      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+#      with:
+#        app-id: ${{ env.APP_ID }}
+#        private-key: ${{ env.PRIVATE_KEY }}
+#
+#    - name: Checkout repository
+#      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+#      with:
+#        repository: ${{ github.event.pull_request.head.repo.full_name }}
+#        ref: ${{ github.event.pull_request.head.ref }}
+#        token: ${{ steps.generate_token.outputs.token }}
+#        persist-credentials: true
+#
+#    - name: Set go version
+#      uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4
+#      with:
+#        go-version-file: go.mod
+#    
+#    - name: Configure Git
+#      run: |
+#          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+#          git config --local user.name "github-actions[bot]"
+#          git config --local --add --bool push.autoSetupRemote true
+#
+#    - name: Update workspace
+#      run: make update-workspace
+#
+#    - name: Commit and push workspace changes
+#      env:
+#        BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+#      run: |
+#        if ! git diff --exit-code --quiet; then
+#          echo "Committing and pushing workspace changes"
+#          git commit -a -m "update workspace"
+#          git push origin $BRANCH_NAME
+#        fi


### PR DESCRIPTION
## What Changed? Why?

Disable dependabot workflow until token broker is implemented to fix zizmor checks. Until re-enabled, dependabot PRs will need manual intervention to run `make update-workspace`.

### How was it tested?

### Where did you document your changes?

### Notes to Reviewers
