### PR TITLE
feat(operator): add queue depth metric for ConcurrentInformer

### DIFF
--- a/operator/concurrentwatcher_test.go
+++ b/operator/concurrentwatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -387,6 +388,7 @@ func TestConcurrentInformer_PrometheusCollectors(t *testing.T) {
 	t.Run("implements metrics.Provider", func(t *testing.T) {
 		ci, err := NewConcurrentInformerFromOptions(&noopInformer{}, InformerOptions{
 			MetricsConfig: metrics.DefaultConfig("test"),
+			ResourceKind:  "test.example.com/v1, Kind=TestKind",
 		})
 		require.NoError(t, err)
 
@@ -438,6 +440,38 @@ func TestConcurrentInformer_PrometheusCollectors(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			return ci.sumQueueDepth() == 0
 		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("multiple informers with different kinds register without collision", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+
+		ci1, err := NewConcurrentInformerFromOptions(&noopInformer{}, InformerOptions{
+			MetricsConfig: metrics.DefaultConfig("test"),
+			ResourceKind:  "group1/v1, Kind=KindA",
+		})
+		require.NoError(t, err)
+		for _, c := range ci1.PrometheusCollectors() {
+			require.NoError(t, reg.Register(c))
+		}
+
+		ci2, err := NewConcurrentInformerFromOptions(&noopInformer{}, InformerOptions{
+			MetricsConfig: metrics.DefaultConfig("test"),
+			ResourceKind:  "group2/v1, Kind=KindB",
+		})
+		require.NoError(t, err)
+		for _, c := range ci2.PrometheusCollectors() {
+			require.NoError(t, reg.Register(c))
+		}
+
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		var found int
+		for _, mf := range mfs {
+			if mf.GetName() == "test_concurrent_watcher_queue_depth" {
+				found = len(mf.GetMetric())
+			}
+		}
+		assert.Equal(t, 2, found)
 	})
 
 	t.Run("deprecated constructor also creates metrics", func(t *testing.T) {

--- a/operator/concurrentwatcher_test.go
+++ b/operator/concurrentwatcher_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-app-sdk/metrics"
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
@@ -380,3 +382,77 @@ func (mw *mockWatcher) Delete(ctx context.Context, obj resource.Object) error {
 	mw.deleteAttempts.Add(1)
 	return mw.SimpleWatcher.Delete(ctx, obj)
 }
+
+func TestConcurrentInformer_PrometheusCollectors(t *testing.T) {
+	t.Run("implements metrics.Provider", func(t *testing.T) {
+		ci, err := NewConcurrentInformerFromOptions(&noopInformer{}, InformerOptions{
+			MetricsConfig: metrics.DefaultConfig("test"),
+		})
+		require.NoError(t, err)
+
+		var provider metrics.Provider = ci
+		collectors := provider.PrometheusCollectors()
+		assert.Len(t, collectors, 1)
+	})
+
+	t.Run("queue_depth reflects pending events", func(t *testing.T) {
+		blockCh := make(chan struct{})
+		mock := &mockWatcher{}
+		mock.AddFunc = func(ctx context.Context, o resource.Object) error {
+			<-blockCh
+			return nil
+		}
+
+		ci, err := NewConcurrentInformerFromOptions(&noopInformer{}, InformerOptions{
+			MaxConcurrentWorkers: 2,
+			MetricsConfig:        metrics.DefaultConfig("test"),
+		})
+		require.NoError(t, err)
+
+		err = ci.AddEventHandler(mock)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go ci.Run(ctx)
+
+		assert.Equal(t, float64(0), ci.sumQueueDepth())
+
+		ex := &resource.TypedSpecObject[string]{}
+		schema := resource.NewSimpleSchema("group", "version", ex, &resource.TypedList[*resource.TypedSpecObject[string]]{})
+
+		obj1 := schema.ZeroValue()
+		obj1.SetName("obj1")
+		obj2 := schema.ZeroValue()
+		obj2.SetName("obj2")
+
+		ci.watchers[0].Add(ctx, obj1)
+		ci.watchers[0].Add(ctx, obj2)
+
+		assert.Eventually(t, func() bool {
+			return ci.sumQueueDepth() > 0
+		}, time.Second, 10*time.Millisecond)
+
+		close(blockCh)
+
+		assert.Eventually(t, func() bool {
+			return ci.sumQueueDepth() == 0
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("deprecated constructor also creates metrics", func(t *testing.T) {
+		ci, err := NewConcurrentInformer(&noopInformer{}, ConcurrentInformerOptions{
+			MetricsConfig: metrics.DefaultConfig("test"),
+		})
+		require.NoError(t, err)
+
+		collectors := ci.PrometheusCollectors()
+		assert.Len(t, collectors, 1)
+	})
+}
+
+type noopInformer struct{}
+
+func (m *noopInformer) AddEventHandler(_ ResourceWatcher) error { return nil }
+func (m *noopInformer) Run(ctx context.Context) error           { <-ctx.Done(); return nil }
+func (m *noopInformer) WaitForSync(ctx context.Context) error   { return nil }

--- a/operator/informer_concurrent.go
+++ b/operator/informer_concurrent.go
@@ -43,6 +43,9 @@ type ConcurrentInformerOptions struct {
 	MaxConcurrentWorkers uint64
 	// MetricsConfig controls the namespace for Prometheus metrics exposed by the ConcurrentInformer.
 	MetricsConfig metrics.Config
+	// ResourceKind is used as the "kind" label on queue depth metrics.
+	// When empty, the label value defaults to an empty string.
+	ResourceKind string
 }
 
 // NewConcurrentInformer creates a new ConcurrentInformer wrapping the provided Informer.
@@ -63,10 +66,11 @@ func NewConcurrentInformer(inf Informer, opts ConcurrentInformerOptions) (
 		ci.maxConcurrentWorkers = opts.MaxConcurrentWorkers
 	}
 	ci.queueDepth = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: opts.MetricsConfig.Namespace,
-		Subsystem: "concurrent_watcher",
-		Name:      "queue_depth",
-		Help:      "Current number of pending events across all concurrent watcher worker queues.",
+		Namespace:   opts.MetricsConfig.Namespace,
+		Subsystem:   "concurrent_watcher",
+		Name:        "queue_depth",
+		Help:        "Current number of pending events across all concurrent watcher worker queues.",
+		ConstLabels: prometheus.Labels{"kind": opts.ResourceKind},
 	}, ci.sumQueueDepth)
 
 	return ci, nil
@@ -89,10 +93,11 @@ func NewConcurrentInformerFromOptions(inf Informer, opts InformerOptions) (
 		ci.maxConcurrentWorkers = opts.MaxConcurrentWorkers
 	}
 	ci.queueDepth = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: opts.MetricsConfig.Namespace,
-		Subsystem: "concurrent_watcher",
-		Name:      "queue_depth",
-		Help:      "Current number of pending events across all concurrent watcher worker queues.",
+		Namespace:   opts.MetricsConfig.Namespace,
+		Subsystem:   "concurrent_watcher",
+		Name:        "queue_depth",
+		Help:        "Current number of pending events across all concurrent watcher worker queues.",
+		ConstLabels: prometheus.Labels{"kind": opts.ResourceKind},
 	}, ci.sumQueueDepth)
 
 	return ci, nil

--- a/operator/informer_concurrent.go
+++ b/operator/informer_concurrent.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana-app-sdk/health"
+	"github.com/grafana/grafana-app-sdk/metrics"
 )
 
 var (
-	_ Informer       = &ConcurrentInformer{}
-	_ health.Checker = &ConcurrentInformer{}
+	_ Informer         = &ConcurrentInformer{}
+	_ health.Checker   = &ConcurrentInformer{}
+	_ metrics.Provider = &ConcurrentInformer{}
 )
 
 // ConcurrentInformer implements the Informer interface, wrapping another Informer implementation
@@ -23,6 +27,7 @@ type ConcurrentInformer struct {
 	informer             Informer
 	watchers             []*concurrentWatcher
 	maxConcurrentWorkers uint64
+	queueDepth           prometheus.GaugeFunc
 
 	mtx sync.RWMutex
 }
@@ -36,6 +41,8 @@ type ConcurrentInformerOptions struct {
 	// to the same worker, as to maintain the guarantee of in-order delivery of events per object.
 	// By default, a single worker is run to process all events sequentially.
 	MaxConcurrentWorkers uint64
+	// MetricsConfig controls the namespace for Prometheus metrics exposed by the ConcurrentInformer.
+	MetricsConfig metrics.Config
 }
 
 // NewConcurrentInformer creates a new ConcurrentInformer wrapping the provided Informer.
@@ -55,6 +62,12 @@ func NewConcurrentInformer(inf Informer, opts ConcurrentInformerOptions) (
 	if opts.MaxConcurrentWorkers > 0 {
 		ci.maxConcurrentWorkers = opts.MaxConcurrentWorkers
 	}
+	ci.queueDepth = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: opts.MetricsConfig.Namespace,
+		Subsystem: "concurrent_watcher",
+		Name:      "queue_depth",
+		Help:      "Current number of pending events across all concurrent watcher worker queues.",
+	}, ci.sumQueueDepth)
 
 	return ci, nil
 }
@@ -75,6 +88,12 @@ func NewConcurrentInformerFromOptions(inf Informer, opts InformerOptions) (
 	if opts.MaxConcurrentWorkers > 0 {
 		ci.maxConcurrentWorkers = opts.MaxConcurrentWorkers
 	}
+	ci.queueDepth = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: opts.MetricsConfig.Namespace,
+		Subsystem: "concurrent_watcher",
+		Name:      "queue_depth",
+		Help:      "Current number of pending events across all concurrent watcher worker queues.",
+	}, ci.sumQueueDepth)
 
 	return ci, nil
 }
@@ -129,4 +148,21 @@ func (ci *ConcurrentInformer) HealthChecks() []health.Check {
 // If the sync is not complete within the context deadline, it will return a timeout error.
 func (ci *ConcurrentInformer) WaitForSync(ctx context.Context) error {
 	return ci.informer.WaitForSync(ctx)
+}
+
+// PrometheusCollectors implements metrics.Provider.
+func (ci *ConcurrentInformer) PrometheusCollectors() []prometheus.Collector {
+	return []prometheus.Collector{ci.queueDepth}
+}
+
+func (ci *ConcurrentInformer) sumQueueDepth() float64 {
+	ci.mtx.RLock()
+	defer ci.mtx.RUnlock()
+	var total int64
+	for _, cw := range ci.watchers {
+		for _, q := range cw.workers {
+			total += q.Len()
+		}
+	}
+	return float64(total)
 }

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -82,6 +82,9 @@ type InformerOptions struct {
 	// MetricsConfig controls the namespace and histogram settings for Prometheus metrics
 	// exposed by components that use these options (e.g., ConcurrentInformer queue depth).
 	MetricsConfig metrics.Config
+	// ResourceKind is used as the "kind" label on queue depth metrics.
+	// When empty, the label value defaults to an empty string.
+	ResourceKind string
 }
 
 // NewKubernetesBasedInformer creates a new KubernetesBasedInformer for the provided kind and options,

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/grafana-app-sdk/health"
+	"github.com/grafana/grafana-app-sdk/metrics"
 	"github.com/grafana/grafana-app-sdk/resource"
 )
 
@@ -78,6 +79,9 @@ type InformerOptions struct {
 	// Events for a particular object are assigned to the same worker to maintain in-order delivery per object.
 	// An empty value (0) will use the default of 10 workers.
 	MaxConcurrentWorkers uint64
+	// MetricsConfig controls the namespace and histogram settings for Prometheus metrics
+	// exposed by components that use these options (e.g., ConcurrentInformer queue depth).
+	MetricsConfig metrics.Config
 }
 
 // NewKubernetesBasedInformer creates a new KubernetesBasedInformer for the provided kind and options,

--- a/operator/informer_processor.go
+++ b/operator/informer_processor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -160,6 +161,7 @@ type bufferedQueue struct {
 	buf            *buffer.RingGrowing //nolint:staticcheck
 	stopMux        sync.RWMutex
 	stopped        bool
+	depth          atomic.Int64
 }
 
 // newBufferedQueue returns a properly initialized bufferedQueue. The consumer
@@ -187,7 +189,13 @@ func (l *bufferedQueue) push(event any) {
 		return
 	}
 
+	l.depth.Add(1)
 	l.incomingEvents <- event
+}
+
+// Len returns the current number of pending events in the queue.
+func (l *bufferedQueue) Len() int64 {
+	return l.depth.Load()
 }
 
 // run will continuously read messages from the events channel, and write them to a buffer.
@@ -203,6 +211,7 @@ func (l *bufferedQueue) run() {
 	for {
 		select {
 		case nextCh <- event:
+			l.depth.Add(-1)
 			event, ok = l.buf.ReadOne()
 			if !ok {
 				nextCh = nil

--- a/operator/informer_processor_test.go
+++ b/operator/informer_processor_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,4 +25,49 @@ func TestBufferedQueue(t *testing.T) {
 		j := <-out
 		assert.Equal(t, i, j)
 	}
+}
+
+func TestBufferedQueue_Len(t *testing.T) {
+	t.Run("empty queue has zero depth", func(t *testing.T) {
+		queue := newBufferedQueue(2)
+		assert.Equal(t, int64(0), queue.Len())
+	})
+
+	t.Run("depth increments on push and decrements on consume", func(t *testing.T) {
+		queue := newBufferedQueue(4)
+		go queue.run()
+		defer queue.stop()
+
+		queue.push("a")
+		queue.push("b")
+		queue.push("c")
+
+		out := queue.events()
+
+		<-out
+		assert.Eventually(t, func() bool { return queue.Len() == 2 }, time.Second, 10*time.Millisecond)
+
+		<-out
+		assert.Eventually(t, func() bool { return queue.Len() == 1 }, time.Second, 10*time.Millisecond)
+
+		<-out
+		assert.Eventually(t, func() bool { return queue.Len() == 0 }, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("depth returns to zero after full drain", func(t *testing.T) {
+		queue := newBufferedQueue(2)
+		go queue.run()
+		defer queue.stop()
+
+		for i := 0; i < 10; i++ {
+			queue.push(i)
+		}
+
+		out := queue.events()
+		for i := 0; i < 10; i++ {
+			<-out
+		}
+
+		assert.Eventually(t, func() bool { return queue.Len() == 0 }, time.Second, 10*time.Millisecond)
+	})
 }

--- a/simple/app.go
+++ b/simple/app.go
@@ -149,6 +149,10 @@ var DefaultInformerSupplier = func(
 		return nil, err
 	}
 
+	if options.ResourceKind == "" {
+		options.ResourceKind = kind.GroupVersionKind().String()
+	}
+
 	inf, err := operator.NewKubernetesBasedInformer(kind, client, options)
 	if err != nil {
 		return nil, err
@@ -178,6 +182,10 @@ var OptimizedInformerSupplier = func(
 	client, err := clients.ClientFor(kind)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.ResourceKind == "" {
+		options.ResourceKind = kind.GroupVersionKind().String()
 	}
 
 	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)

--- a/simple/app.go
+++ b/simple/app.go
@@ -500,6 +500,9 @@ func (a *App) watchKind(kind AppUnmanagedKind) error {
 			LabelFilters:   kind.ReconcileOptions.LabelFilters,
 			FieldSelectors: kind.ReconcileOptions.FieldSelectors,
 		}
+		if opts.MetricsConfig == (metrics.Config{}) {
+			opts.MetricsConfig = a.cfg.InformerConfig.MetricsConfig
+		}
 
 		inf, err := infSupplier(kind.Kind, a.clientGenerator, opts)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add `concurrent_watcher_queue_depth` Prometheus gauge that reports the current number of pending events across all ConcurrentInformer worker queues
- Track depth via `atomic.Int64` counter on `bufferedQueue` — incremented on push, decremented on consume — zero overhead on the hot path
- `ConcurrentInformer` implements `metrics.Provider`, so the metric is automatically registered by `InformerController.PrometheusCollectors()`
- Propagate `MetricsConfig` through `InformerOptions` so `simple.App` users get the metric without extra configuration

Motivated by [grafana/slo#4583](https://github.com/grafana/slo/pull/4583) where the Slo team had to build a custom queue depth metric. This provides it out of the box.

## Test plan
- [x] `TestBufferedQueue_Len` — depth increments on push, decrements on consume, returns to zero after drain
- [x] `TestConcurrentInformer_PrometheusCollectors` — implements `metrics.Provider`, gauge reflects pending events, deprecated constructor also wires metrics
- [x] All existing `operator/` and `simple/` tests pass
- [x] `make lint` clean