### PR TITLE
Support creating a cuekind.Cue instance from a cue value

### DIFF
--- a/codegen/cuekind/cue.go
+++ b/codegen/cuekind/cue.go
@@ -37,6 +37,18 @@ func LoadCue(files fs.FS) (*Cue, error) {
 	}, nil
 }
 
+func FromCueValue(value cue.Value) (*Cue, error) {
+	defs, err := loadDefs()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cue{
+		Root: value,
+		Defs: defs,
+	}, nil
+}
+
 func loadRoot(files fs.FS) (cue.Value, error) {
 	// Load the FS
 	// Get the module from cue.mod/module.cue


### PR DESCRIPTION
## What Changed? Why?

Support creating a `cuekind.Cue` instance from a cue value in addition to a `fs.FS`.

This is useful for https://github.com/grafana/terraform-provider-grafana/pull/2569 where the script loads remote CUE files itself and delegates parsing the manifest to `grafana-app-sdk`.

See usage in https://github.com/grafana/terraform-provider-grafana/pull/2569/changes#diff-0cf205d2262e07cf000f738cbe5d93dadd08a27f72cb8ce1b3ce061f4b2deb55R16-R40