### PR TITLE
Validate searchFields at codegen time

### DIFF
--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -530,7 +530,10 @@ type simpleOpenAPIDoc[T any] struct {
 }
 
 //nolint:revive,funlen,unparam,gocognit
-func processKindVersion(vk codegen.VersionedKind, _ string, includeSchema bool) (app.ManifestVersionKind, error) {
+func processKindVersion(vk codegen.VersionedKind, version string, includeSchema bool) (app.ManifestVersionKind, error) {
+	if err := validateSearchFields(vk, version); err != nil {
+		return app.ManifestVersionKind{}, err
+	}
 	mver := app.ManifestVersionKind{
 		Kind:         vk.Kind,
 		Plural:       vk.PluralName,

--- a/codegen/jennies/search_fields.go
+++ b/codegen/jennies/search_fields.go
@@ -1,0 +1,205 @@
+package jennies
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"cuelang.org/go/cue"
+
+	"github.com/grafana/grafana-app-sdk/codegen"
+)
+
+// stringOnlySearchCapabilities are the search capabilities that rely on text or
+// keyword analysis and therefore only make sense on string-typed fields. This
+// mirrors the capability matrix the consuming search backend enforces at
+// runtime, see Grafana's validateSearchFieldDefinitions:
+// https://github.com/grafana/grafana/blob/0adfec05289ea611cbbcfc9b5e57acd94a65230d/pkg/storage/unified/resource/search_field.go#L444
+var stringOnlySearchCapabilities = []string{"text", "partial", "facet", "sort"}
+
+// validateSearchFields checks every search field declared on a kind version:
+// capabilities that need text or keyword analysis must only appear on
+// string-typed fields, and each non-empty path must resolve against the
+// version schema to a field whose type is compatible with the declared type.
+func validateSearchFields(vk codegen.VersionedKind, version string) error {
+	for _, sf := range vk.SearchFields {
+		if err := validateSearchFieldCapabilities(sf); err != nil {
+			return fmt.Errorf("kind %q version %q search field %q: %w", vk.Kind, version, sf.Name, err)
+		}
+		if sf.Path == "" || !vk.Schema.Exists() {
+			continue
+		}
+		leaf, resolved, err := resolveSearchFieldPath(vk.Schema, sf.Path)
+		if err != nil {
+			return fmt.Errorf("kind %q version %q search field %q: %w", vk.Kind, version, sf.Name, err)
+		}
+		// resolved is false (with no error) when the path crosses a CUE
+		// disjunction; the type cannot be checked against a single variant, so
+		// the field is left as-is.
+		if resolved {
+			warning, err := searchFieldTypeCompatibility(leaf, sf.Type)
+			if err != nil {
+				return fmt.Errorf("kind %q version %q search field %q: %w", vk.Kind, version, sf.Name, err)
+			}
+			if warning != "" {
+				fmt.Printf("[WARN] kind %q version %q search field %q: %s\n", vk.Kind, version, sf.Name, warning)
+			}
+		}
+	}
+	return nil
+}
+
+func validateSearchFieldCapabilities(sf codegen.SearchField) error {
+	if sf.Type == "string" {
+		return nil
+	}
+	for _, c := range sf.Capabilities {
+		if slices.Contains(stringOnlySearchCapabilities, c) {
+			return fmt.Errorf("capability %q requires a string-typed field, but type is %q", c, sf.Type)
+		}
+	}
+	return nil
+}
+
+type pathSegment struct {
+	name       string
+	projection bool
+}
+
+func parseSearchFieldPath(path string) ([]pathSegment, error) {
+	parts := strings.Split(path, ".")
+	segs := make([]pathSegment, len(parts))
+	for i, p := range parts {
+		projection := strings.HasSuffix(p, "[*]")
+		name := strings.TrimSuffix(p, "[*]")
+		if name == "" {
+			return nil, fmt.Errorf("invalid path %q", path)
+		}
+		segs[i] = pathSegment{name: name, projection: projection}
+	}
+	return segs, nil
+}
+
+// resolveSearchFieldPath walks a dot-separated path (with optional "[*]" array
+// projection segments) against the schema. It returns the resolved leaf value
+// and resolved=true when every segment resolves to a concrete field. It returns
+// resolved=false with a nil error when the path descends into a CUE disjunction,
+// since the leaf type cannot be pinned to a single variant. It returns an error
+// when the path does not resolve (in any variant) or uses "[*]" on a non-list.
+func resolveSearchFieldPath(schema cue.Value, path string) (cue.Value, bool, error) {
+	segs, err := parseSearchFieldPath(path)
+	if err != nil {
+		return cue.Value{}, false, err
+	}
+	leaf, resolved, err := resolveSegments(schema, segs)
+	if err != nil {
+		return cue.Value{}, false, fmt.Errorf("path %q does not resolve: %w", path, err)
+	}
+	return leaf, resolved, nil
+}
+
+// resolveSegments walks segs against v. When a segment is not a direct field of
+// v and v is a disjunction, it resolves the remaining path against each non-null
+// variant: the path is accepted (resolved=false, because the leaf type spans
+// variants) only if it fully resolves in at least one variant, and rejected
+// when it resolves in none. This validates the entire path, including segments
+// nested inside a variant, rather than stopping at the first variant match.
+func resolveSegments(v cue.Value, segs []pathSegment) (cue.Value, bool, error) {
+	for i, seg := range segs {
+		next, ok := lookupSchemaField(v, seg.name)
+		if !ok {
+			if variants, _ := disjunctionVariants(v); len(variants) > 0 {
+				remaining := segs[i:]
+				for _, variant := range variants {
+					if _, _, err := resolveSegments(variant, remaining); err == nil {
+						return cue.Value{}, false, nil
+					}
+				}
+				return cue.Value{}, false, fmt.Errorf("field %q not found in any schema variant", seg.name)
+			}
+			return cue.Value{}, false, fmt.Errorf("field %q not found", seg.name)
+		}
+		v = next
+
+		if seg.projection {
+			elem := v.LookupPath(cue.MakePath(cue.AnyIndex))
+			if !elem.Exists() {
+				return cue.Value{}, false, fmt.Errorf("field %q is not a list but is used with [*]", seg.name)
+			}
+			v = elem
+		}
+	}
+	return v, true, nil
+}
+
+// searchFieldTypeCompatibility classifies a declared search field type against
+// the schema type at the resolved leaf. It returns an error for a clear
+// contradiction (for example a boolean type declared on a string field) and a
+// non-empty warning for a compatible-but-lossy declaration (a fractional schema
+// field indexed as int64, which the extractor rounds rather than drops).
+//
+// The accepted sets mirror what the consuming extractor can coerce at runtime,
+// so a declaration that passes here is never silently dropped during indexing.
+// The only consumer today is Grafana's coerceScalar:
+// https://github.com/grafana/grafana/blob/0adfec05289ea611cbbcfc9b5e57acd94a65230d/pkg/storage/unified/resource/path_extract.go#L138
+// This mapping is duplicated by convention across the two repositories; a
+// future change could move extraction into generated code or this library so
+// the two cannot drift. The rule of thumb is that this validator may be more
+// lenient than a given consumer, but must not accept a type the consumer
+// cannot extract. Kinds it cannot classify (structs other than time.Time, or
+// anything unresolved) are skipped rather than flagged.
+func searchFieldTypeCompatibility(leaf cue.Value, declared string) (warning string, err error) {
+	// A list-typed leaf (a field that is itself an array, declared with
+	// array: true and no "[*]" projection) is checked against its element type.
+	if leaf.IncompleteKind() == cue.ListKind {
+		if elem := leaf.LookupPath(cue.MakePath(cue.AnyIndex)); elem.Exists() {
+			leaf = elem
+		}
+	}
+
+	compatible := searchTypesForSchema(leaf)
+	if compatible == nil {
+		return "", nil
+	}
+	if !slices.Contains(compatible, declared) {
+		return "", fmt.Errorf("declared type %q is not compatible with schema type %s", declared, leaf.IncompleteKind())
+	}
+	if declared == "int64" {
+		switch leaf.IncompleteKind() {
+		case cue.NumberKind, cue.FloatKind:
+			return fmt.Sprintf("schema type %s indexed as int64 will be rounded at extraction", leaf.IncompleteKind()), nil
+		}
+	}
+	return "", nil
+}
+
+// searchTypesForSchema returns the search field types a schema value can back,
+// or nil when the value's kind cannot be classified (and so should not be
+// checked). The sets mirror the extractor's runtime coercion: a string can back
+// a date (it is kept verbatim), and either numeric kind can back int64 or
+// double (the extractor rounds or widens as needed). time.Time resolves to
+// StringKind, so timestamps fall into the string set.
+func searchTypesForSchema(v cue.Value) []string {
+	switch v.IncompleteKind() {
+	case cue.StringKind:
+		return []string{"string", "date"}
+	case cue.IntKind, cue.NumberKind, cue.FloatKind:
+		return []string{"int64", "double"}
+	case cue.BoolKind:
+		return []string{"boolean"}
+	}
+	return nil
+}
+
+// lookupSchemaField resolves a single field name against a schema value,
+// trying both the required and optional forms.
+func lookupSchemaField(v cue.Value, name string) (cue.Value, bool) {
+	p := cue.MakePath(cue.Str(name))
+	if l := v.LookupPath(p); l.Exists() {
+		return l, true
+	}
+	if l := v.LookupPath(p.Optional()); l.Exists() {
+		return l, true
+	}
+	return cue.Value{}, false
+}

--- a/codegen/jennies/search_fields_test.go
+++ b/codegen/jennies/search_fields_test.go
@@ -1,0 +1,205 @@
+package jennies
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/codegen"
+)
+
+func TestValidateSearchFieldPath(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{
+		spec: {
+			email: string
+			panelRef?: {
+				dashboardUID: string
+				panelID: int64
+			}
+			expressions: [...{ datasourceUID?: string }]
+			notificationSettings?: {
+				simplifiedRouting?: { receiver: string }
+			} | { namedRoutingTree?: { routingTree: string } }
+		}
+	}`)
+	require.NoError(t, schema.Err())
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "plain nested path", path: "spec.email"},
+		{name: "optional parent", path: "spec.panelRef.dashboardUID"},
+		{name: "int leaf", path: "spec.panelRef.panelID"},
+		{name: "array projection", path: "spec.expressions[*].datasourceUID"},
+		{name: "missing top field", path: "spec.nope", wantErr: true},
+		{name: "missing leaf", path: "spec.panelRef.nope", wantErr: true},
+		{name: "projection on non-list", path: "spec.email[*].foo", wantErr: true},
+		{name: "empty segment", path: "spec..email", wantErr: true},
+		// Path crosses a disjunction into a field that exists in one variant: not
+		// statically resolvable to a single variant, so it is allowed.
+		{name: "disjunction crossing, field in a variant", path: "spec.notificationSettings.simplifiedRouting.receiver"},
+		{name: "disjunction crossing, field in other variant", path: "spec.notificationSettings.namedRoutingTree.routingTree"},
+		// Segment after a disjunction matches no variant: a typo, so it errors.
+		{name: "disjunction typo", path: "spec.notificationSettings.typo", wantErr: true},
+		// Typo nested inside a matching variant: the leading segment matches a
+		// variant but the remainder does not, so it still errors.
+		{name: "disjunction nested typo", path: "spec.notificationSettings.simplifiedRouting.typo", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := resolveSearchFieldPath(schema, tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSearchFieldType(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`
+import "time"
+
+spec: {
+	name: string
+	count: int64
+	ratio: float
+	enabled: bool
+	seen: string & time.Time
+	tags: [...string]
+}
+`)
+	require.NoError(t, schema.Err())
+
+	tests := []struct {
+		name     string
+		path     string
+		declared string
+		wantErr  bool
+		wantWarn bool
+	}{
+		{name: "string as string", path: "spec.name", declared: "string"},
+		{name: "string as date (kept verbatim)", path: "spec.name", declared: "date"},
+		{name: "string as boolean", path: "spec.name", declared: "boolean", wantErr: true},
+		{name: "int as int64", path: "spec.count", declared: "int64"},
+		{name: "int as double (widening)", path: "spec.count", declared: "double"},
+		{name: "int as date", path: "spec.count", declared: "date", wantErr: true},
+		{name: "int as string", path: "spec.count", declared: "string", wantErr: true},
+		{name: "float as double", path: "spec.ratio", declared: "double"},
+		{name: "float as int64 (rounded, warns)", path: "spec.ratio", declared: "int64", wantWarn: true},
+		{name: "bool as boolean", path: "spec.enabled", declared: "boolean"},
+		{name: "bool as string", path: "spec.enabled", declared: "string", wantErr: true},
+		{name: "time as date", path: "spec.seen", declared: "date"},
+		{name: "time as string (kept verbatim)", path: "spec.seen", declared: "string"},
+		{name: "string list element", path: "spec.tags", declared: "string"},
+		{name: "string list element as boolean", path: "spec.tags", declared: "boolean", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leaf, resolved, err := resolveSearchFieldPath(schema, tt.path)
+			require.NoError(t, err)
+			require.True(t, resolved)
+			warning, err := searchFieldTypeCompatibility(leaf, tt.declared)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.wantWarn {
+				assert.NotEmpty(t, warning)
+			} else {
+				assert.Empty(t, warning)
+			}
+		})
+	}
+}
+
+func TestValidateSearchFields_PerVersionSchema(t *testing.T) {
+	ctx := cuecontext.New()
+	// The same field path is valid against v2's schema but absent from v1's.
+	// validateSearchFields receives the version's own VersionedKind.Schema, so a
+	// path that does not exist in that version must fail for that version only.
+	v1Schema := ctx.CompileString(`{ spec: { name: string } }`)
+	v2Schema := ctx.CompileString(`{ spec: { name: string, region: string } }`)
+	require.NoError(t, v1Schema.Err())
+	require.NoError(t, v2Schema.Err())
+
+	searchFields := []codegen.SearchField{
+		{Name: "region", Path: "spec.region", Type: "string", Capabilities: []string{"filter"}},
+	}
+
+	errV1 := validateSearchFields(codegen.VersionedKind{Kind: "Widget", Schema: v1Schema, SearchFields: searchFields}, "v1")
+	assert.Error(t, errV1, "spec.region is absent from v1's schema")
+
+	errV2 := validateSearchFields(codegen.VersionedKind{Kind: "Widget", Schema: v2Schema, SearchFields: searchFields}, "v2")
+	assert.NoError(t, errV2, "spec.region exists in v2's schema")
+}
+
+func TestValidateSearchFieldCapabilities(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   codegen.SearchField
+		wantErr bool
+	}{
+		{name: "string with text", field: codegen.SearchField{Type: "string", Capabilities: []string{"filter", "text", "sort"}}},
+		{name: "int with filter only", field: codegen.SearchField{Type: "int64", Capabilities: []string{"filter", "retrieve"}}},
+		{name: "int with sort", field: codegen.SearchField{Type: "int64", Capabilities: []string{"sort"}}, wantErr: true},
+		{name: "boolean with facet", field: codegen.SearchField{Type: "boolean", Capabilities: []string{"facet"}}, wantErr: true},
+		{name: "date with text", field: codegen.SearchField{Type: "date", Capabilities: []string{"text"}}, wantErr: true},
+		{name: "double with partial", field: codegen.SearchField{Type: "double", Capabilities: []string{"partial"}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSearchFieldCapabilities(tt.field)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestProcessKindVersion_RejectsInvalidSearchFieldPath(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{ spec: { email: string } }`)
+	require.NoError(t, schema.Err())
+
+	vk := codegen.VersionedKind{
+		Kind:   "Widget",
+		Scope:  "Namespaced",
+		Schema: schema,
+		SearchFields: []codegen.SearchField{
+			{Name: "email", Path: "spec.nope", Type: "string", Capabilities: []string{"filter"}},
+		},
+	}
+	_, err := processKindVersion(vk, "v1", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `search field "email"`)
+}
+
+func TestValidateSearchFields_ErrorMentionsKindAndField(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{ spec: { email: string } }`)
+	require.NoError(t, schema.Err())
+
+	vk := codegen.VersionedKind{
+		Kind:   "Widget",
+		Schema: schema,
+		SearchFields: []codegen.SearchField{
+			{Name: "missing", Path: "spec.nope", Type: "string", Capabilities: []string{"filter"}},
+		},
+	}
+	err := validateSearchFields(vk, "v1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `kind "Widget"`)
+	assert.Contains(t, err.Error(), `version "v1"`)
+	assert.Contains(t, err.Error(), `search field "missing"`)
+}


### PR DESCRIPTION
Adds a codegen-time check for each declared search field, so authoring mistakes fail at `make generate` instead of at runtime:

- Capabilities that rely on text or keyword analysis (`text`, `partial`, `facet`, `sort`) must only appear on string-typed fields.
- Every non-empty `path` must resolve against the version's schema, including array projections (`[*]`) and fields nested inside disjunction variants. A path that matches no field, in any variant, is rejected.
- The declared `type` must be compatible with the schema type at that path. A fractional field declared as `int64` is allowed but warns, matching the consuming extractor which rounds rather than drops.

The accepted type sets mirror the consuming extractor's runtime coercion, so a declaration that passes here is never silently dropped during indexing. There is no validation beyond this; the check is conservative and skips paths it cannot statically resolve.

Follows #1431 (merged). Part of grafana/search-and-storage-team#827.
