### PR TITLE
fix(operator): Deliver delete events wrapped in cache.DeletedFinalStateUnknown tombstones

### DIFF
--- a/operator/informer_customcache_test.go
+++ b/operator/informer_customcache_test.go
@@ -344,15 +344,31 @@ func (lw *mockListWatcher) Watch(options metav1.ListOptions) (watch.Interface, e
 	return nil, nil
 }
 
+// mockWatch implements watch.Interface and resource.WatchResponse, so it can be returned from a
+// ListWatchClient's Watch call. WatchEvents is a stub: consumers check KubernetesCompatibleWatch
+// first and use the underlying watch.Interface directly.
 type mockWatch struct {
 	events chan watch.Event
 }
+
+var (
+	_ resource.WatchResponse    = &mockWatch{}
+	_ KubernetesCompatibleWatch = &mockWatch{}
+)
 
 func (w *mockWatch) ResultChan() <-chan watch.Event {
 	return w.events
 }
 
 func (*mockWatch) Stop() {}
+
+func (*mockWatch) WatchEvents() <-chan resource.WatchEvent {
+	return nil
+}
+
+func (w *mockWatch) KubernetesWatch() watch.Interface {
+	return w
+}
 
 func newUnsafeCache() *unsafeCache {
 	return &unsafeCache{

--- a/operator/informer_kubernetes.go
+++ b/operator/informer_kubernetes.go
@@ -249,6 +249,15 @@ func toResourceObject(obj any, kind resource.Kind) (resource.Object, error) {
 		err := cast.Into(newObj, kind.Codec(resource.KindEncodingJSON))
 		return newObj, err
 	}
+
+	// Deletes which are missed while the watch is disconnected are delivered on relist
+	// as cache.DeletedFinalStateUnknown tombstones wrapping the last known state of the object
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		if tombstone.Obj == nil {
+			return nil, fmt.Errorf("cannot convert DeletedFinalStateUnknown tombstone for %q: it contains no object", tombstone.Key)
+		}
+		return toResourceObject(tombstone.Obj, kind)
+	}
 	// TODO: other methods...?
 
 	return nil, fmt.Errorf("unable to cast %v into resource.Object", reflect.TypeOf(obj))

--- a/operator/informer_kubernetes_test.go
+++ b/operator/informer_kubernetes_test.go
@@ -2,10 +2,15 @@ package operator
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 )
@@ -55,6 +60,166 @@ func TestKubernetesBasedInformer_HealthCheckName(t *testing.T) {
 			inf, err := NewKubernetesBasedInformer(test.kind, &mockListWatchClient{}, test.opts)
 			require.Nil(t, err)
 			assert.Equal(t, test.expected, inf.HealthCheckName())
+		})
+	}
+}
+
+func TestKubernetesBasedInformer_Run_TombstoneDelete(t *testing.T) {
+	obj := &resource.UntypedObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "foo",
+			ResourceVersion: "1",
+		},
+	}
+	initialEventsBookmark := func(resourceVersion string) *resource.UntypedObject {
+		return &resource.UntypedObject{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: resourceVersion,
+				Annotations: map[string]string{
+					metav1.InitialEventsAnnotationKey: "true",
+				},
+			},
+		}
+	}
+
+	mux := sync.Mutex{}
+	listCalls := 0
+	watchCalls := 0
+	firstWatch := make(chan watch.Event, 2)
+	client := &mockListWatchClient{
+		ListIntoFunc: func(_ context.Context, _ string, _ resource.ListOptions, into resource.ListObject) error {
+			mux.Lock()
+			defer mux.Unlock()
+			listCalls++
+			if listCalls == 1 {
+				into.SetResourceVersion("1")
+				into.SetItems([]resource.Object{obj})
+				return nil
+			}
+			// The object is gone server-side by the time the informer relists
+			into.SetResourceVersion("2")
+			return nil
+		},
+		WatchFunc: func(_ context.Context, _ string, options resource.WatchOptions) (resource.WatchResponse, error) {
+			mux.Lock()
+			defer mux.Unlock()
+			watchCalls++
+			if watchCalls == 1 {
+				if options.SendInitialEvents != nil && *options.SendInitialEvents {
+					// WatchList, the initial state is streamed as watch events followed by a bookmark
+					firstWatch <- watch.Event{Type: watch.Added, Object: obj}
+					firstWatch <- watch.Event{Type: watch.Bookmark, Object: initialEventsBookmark("1")}
+				}
+				return &mockWatch{events: firstWatch}, nil
+			}
+			events := make(chan watch.Event, 1)
+			if options.SendInitialEvents != nil && *options.SendInitialEvents {
+				// The object is gone server-side by the time the informer re-establishes the watch
+				events <- watch.Event{Type: watch.Bookmark, Object: initialEventsBookmark("2")}
+			}
+			// Close the channel so re-established watches end immediately, forcing the reflector
+			// to relist rather than hang on an empty watch
+			close(events)
+			return &mockWatch{events: events}, nil
+		},
+	}
+
+	handlerErrs := make(chan error, 10)
+	inf, err := NewKubernetesBasedInformer(untypedKind, client, InformerOptions{
+		ErrorHandler: func(_ context.Context, err error) {
+			handlerErrs <- err
+		},
+	})
+	require.NoError(t, err)
+
+	addCh := make(chan resource.Object, 2)
+	deleteCh := make(chan resource.Object, 2)
+	err = inf.AddEventHandler(&SimpleWatcher{
+		AddFunc: func(_ context.Context, object resource.Object) error {
+			addCh <- object
+			return nil
+		},
+		DeleteFunc: func(_ context.Context, object resource.Object) error {
+			deleteCh <- object
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go inf.Run(ctx)
+	select {
+	case <-addCh:
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for the add event")
+	}
+
+	// Close the watch to force a relist: a watch that ends without delivering any events makes the
+	// reflector restart its list/watch cycle with a fresh list. The object is missing from that list,
+	// so DeltaFIFO delivers its delete as a cache.DeletedFinalStateUnknown tombstone (see issue #1352)
+	close(firstWatch)
+	select {
+	case deleted := <-deleteCh:
+		assert.Same(t, obj, deleted)
+	case err := <-handlerErrs:
+		t.Fatalf("informer dropped the delete event: %v", err)
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for the delete event")
+	}
+}
+
+func TestToResourceObject(t *testing.T) {
+	obj := &resource.UntypedObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "foo",
+			ResourceVersion: "1",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		input   any
+		want    resource.Object
+		wantErr bool
+	}{{
+		name:  "resource.Object passes through",
+		input: obj,
+		want:  obj,
+	}, {
+		name:    "nil errors",
+		input:   nil,
+		wantErr: true,
+	}, {
+		name:    "uncastable errors",
+		input:   "not an object",
+		wantErr: true,
+	}, {
+		// DeltaFIFO wraps deletes missed during a relist in a tombstone (see issue #1352)
+		name:  "DeletedFinalStateUnknown is unwrapped",
+		input: cache.DeletedFinalStateUnknown{Key: "default/foo", Obj: obj},
+		want:  obj,
+	}, {
+		name:    "DeletedFinalStateUnknown wrapping an uncastable object errors",
+		input:   cache.DeletedFinalStateUnknown{Key: "default/foo", Obj: "not an object"},
+		wantErr: true,
+	}, {
+		name:    "DeletedFinalStateUnknown with no object errors",
+		input:   cache.DeletedFinalStateUnknown{Key: "default/foo"},
+		wantErr: true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := toResourceObject(test.input, untypedKind)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Same(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1352

## What is broken

When an informer's watch is disconnected and a delete happens before it relists, client-go's `DeltaFIFO` delivers the delete as a `cache.DeletedFinalStateUnknown` tombstone wrapping the last known state of the object. `toResourceObject` did not recognize the tombstone, so the cast failed with:

```
unable to cast cache.DeletedFinalStateUnknown into resource.Object
```

and the delete event was dropped before reaching the event handlers. `KubernetesBasedInformer` and `CustomCacheInformer` share the helper, so both were affected.

Operators using `OpinionatedWatcher` were shielded by the finalizer-based `DeletionTimestamp` path, but operators watching resources without finalizers silently missed every delete that crossed a relist.

## The fix

`toResourceObject` now unwraps the tombstone and converts the wrapped object through the existing cast chain, which also covers tombstones wrapping `ResourceObjectWrapper` or `ConvertableIntoResourceObject` instances. When the tombstone carries no object (client-go emits these when the known-objects lookup fails during `Replace`), a descriptive error naming the tombstone key is returned instead of the generic cast error.

## Tests

Both tests reproduce the issue and fail with the exact reported error without the fix:

- `TestToResourceObject`: table-driven unit test of the shared helper, including tombstone unwrap, tombstone wrapping an uncastable object, and tombstone with no object.
- `TestKubernetesBasedInformer_Run_TombstoneDelete`: behavioral test that drives a `KubernetesBasedInformer` through initial sync, then ends the watch so the reflector relists while the object is missing from the fresh list. Asserts the delete event is delivered to the handler instead of being dropped. On regression it fails fast with the cast error rather than a timeout.

`mockWatch` in the operator test package now also implements `resource.WatchResponse` so it can be returned directly from a `ListWatchClient`, reusable by future informer tests.

## Verification

- Full `./operator/...` package passes
- New behavioral test passes 20/20 consecutive runs and is clean under `-race`