### PR TITLE
fix: remote client transport setting

### DIFF
--- a/k8s/client.go
+++ b/k8s/client.go
@@ -169,6 +169,7 @@ func overlayRemoteRestConfig(kubeConfig rest.Config, remoteCfg *RemoteRestConfig
 		kubeConfig.CertFile = ""
 		kubeConfig.KeyData = nil
 		kubeConfig.KeyFile = ""
+		kubeConfig.Transport = nil
 	}
 
 	return kubeConfig


### PR DESCRIPTION
Fix regression introduced by:
https://github.com/grafana/grafana-enterprise/pull/12647

Setting explicitly Transport to `nil` fixes the issue for remote clients