### PR TITLE
Support for external Go types

### DIFF
--- a/codegen/cuekind/testing/customkind.cue
+++ b/codegen/cuekind/testing/customkind.cue
@@ -84,7 +84,7 @@ customKind: {
 				status: {
 					statusField1: string
 					[string]:     _
-				} @cog(open=true)
+				} @cog(open=true) @grafana_app_sdk(goType="codegen-tests/pkg/generated/shared.Status")
 				metadata: {
 					customMetadataField: string
 					otherMetadataField:  string

--- a/codegen/jennies/gotypes.go
+++ b/codegen/jennies/gotypes.go
@@ -1,6 +1,7 @@
 package jennies
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"go/format"
@@ -181,6 +182,23 @@ func (g *GoTypes) generateFilesAtDepth(v cue.Value, schemaPath cue.Path, currDep
 			return codejen.Files{}, nil
 		}
 
+		// If the field carries a `@grafana_app_sdk(goType="<import path>.<Type>")` attribute, we don't generate
+		// a go type for it. Instead, we emit a type alias to the externally-defined go type so that it can be
+		// shared across multiple kinds. The alias keeps the field-derived type name (e.g. Status), so the
+		// sibling resource-object/codec/schema jennies (which reference the subresource by name) are unaffected.
+		if importPath, externalType, ok := goTypeOverride(v); ok {
+			typeName := cfg.NamePrefix + exportField(strings.Join(fieldName, ""))
+			goBytes, err := renderGoTypeAlias(cfg.PackageName, typeName, importPath, externalType)
+			if err != nil {
+				return nil, fmt.Errorf("error generating go type alias for schema path %s.%s: %w", schemaPath.String(), fieldName, err)
+			}
+			return codejen.Files{codejen.File{
+				Data:         goBytes,
+				RelativePath: fmt.Sprintf(path.Join(cfg.PathPrefix, "%s_%s_gen.go"), strings.ToLower(cfg.MachineName), strings.Join(fieldName, "_")),
+				From:         []codejen.NamedJenny{g},
+			}}, nil
+		}
+
 		var namerFunc func(string) string
 		if g.OpenAPINamer != nil {
 			namerFunc = func(name string) string {
@@ -318,6 +336,64 @@ func sanitizeLabelString(s string) string {
 			return -1
 		}
 	}, s)
+}
+
+// goTypeOverride reads a `@grafana_app_sdk(goType="<import path>.<Type>")` attribute from the provided CUE value.
+// If present and well-formed, it returns the go import path and the type name within that package.
+// For example, `@grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")` returns
+// ("github.com/org/repo/apis/common", "Status", true).
+func goTypeOverride(v cue.Value) (importPath string, typeName string, ok bool) {
+	attr := v.Attribute("grafana_app_sdk")
+	if attr.Err() != nil {
+		return "", "", false
+	}
+	goType, found, err := attr.Lookup(0, "goType")
+	if err != nil || !found {
+		return "", "", false
+	}
+	// The Lookup value may retain surrounding quotes (the attribute value is typically quoted in CUE because
+	// it contains slashes and dots); strip them.
+	goType = strings.Trim(strings.TrimSpace(goType), `"`)
+	if goType == "" {
+		return "", "", false
+	}
+	// The value has the form "<import path>.<Type>". The type name is appended to the package (the final
+	// segment of the import path) with a ".". Package names and type names never contain "." or "/", so we
+	// isolate the final path segment (after the last "/") and split it on its "." to separate package from type.
+	// This is unambiguous even when the import path itself contains dots (e.g. gopkg.in/... or example.com/...).
+	segStart := strings.LastIndex(goType, "/") + 1
+	dot := strings.Index(goType[segStart:], ".")
+	if dot <= 0 || segStart+dot == len(goType)-1 {
+		return "", "", false
+	}
+	dot += segStart
+	return goType[:dot], goType[dot+1:], true
+}
+
+// renderGoTypeAlias produces the source for a generated file that aliases an externally-defined go type.
+// packageName is the package of the generated file, typeName is the name the alias should take within that
+// package (matching what sibling jennies expect, e.g. "Status" or "FooStatus"), and importPath/externalType
+// identify the shared type being aliased.
+func renderGoTypeAlias(packageName, typeName, importPath, externalType string) ([]byte, error) {
+	importAlias := sanitizeLabelString(path.Base(importPath))
+	if importAlias == "" {
+		importAlias = "external"
+	}
+	b := bytes.Buffer{}
+	if err := templates.WriteGoTypeAlias(templates.GoTypeAliasMetadata{
+		PackageName:  packageName,
+		ImportAlias:  importAlias,
+		ImportPath:   importPath,
+		TypeName:     typeName,
+		ExternalType: externalType,
+	}, &b); err != nil {
+		return nil, err
+	}
+	formatted, err := format.Source(b.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return formatted, nil
 }
 
 // exportField makes a field name exported

--- a/codegen/jennies/gotypes_test.go
+++ b/codegen/jennies/gotypes_test.go
@@ -1,0 +1,199 @@
+package jennies
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/codegen"
+)
+
+func TestGoTypeOverride(t *testing.T) {
+	ctx := cuecontext.New()
+	tests := []struct {
+		name           string
+		field          string
+		wantImportPath string
+		wantType       string
+		wantOK         bool
+	}{
+		{
+			name:           "quoted goType",
+			field:          `status: {bar: string} @grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")`,
+			wantImportPath: "github.com/org/repo/apis/common",
+			wantType:       "Status",
+			wantOK:         true,
+		},
+		{
+			name:           "import path containing dots",
+			field:          `status: {bar: string} @grafana_app_sdk(goType="gopkg.in/foo.v2/common.Status")`,
+			wantImportPath: "gopkg.in/foo.v2/common",
+			wantType:       "Status",
+			wantOK:         true,
+		},
+		{
+			name:           "goType alongside other keys",
+			field:          `status: {bar: string} @grafana_app_sdk(prefix=Foo,goType="example.com/pkg.MyStatus")`,
+			wantImportPath: "example.com/pkg",
+			wantType:       "MyStatus",
+			wantOK:         true,
+		},
+		{
+			name:           "import path without slashes",
+			field:          `status: {bar: string} @grafana_app_sdk(goType="time.Time")`,
+			wantImportPath: "time",
+			wantType:       "Time",
+			wantOK:         true,
+		},
+		{
+			name:   "no attribute",
+			field:  `status: {bar: string}`,
+			wantOK: false,
+		},
+		{
+			name:   "attribute without goType key",
+			field:  `status: {bar: string} @grafana_app_sdk(prefix=Foo)`,
+			wantOK: false,
+		},
+		{
+			name:   "goType without a type name",
+			field:  `status: {bar: string} @grafana_app_sdk(goType="github.com/org/repo/apis/common")`,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := ctx.CompileString("{" + tt.field + "}").LookupPath(cue.MakePath(cue.Str("status")))
+			require.NoError(t, v.Err())
+			importPath, typeName, ok := goTypeOverride(v)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantImportPath, importPath)
+				assert.Equal(t, tt.wantType, typeName)
+			}
+		})
+	}
+}
+
+func TestRenderGoTypeAlias(t *testing.T) {
+	got, err := renderGoTypeAlias("v1", "Status", "github.com/org/repo/apis/common", "Status")
+	require.NoError(t, err)
+	want := `// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1
+
+import common "github.com/org/repo/apis/common"
+
+// Status is a type alias to an externally-defined, shared type.
+type Status = common.Status
+
+// NewStatus creates a new Status object.
+func NewStatus() *Status {
+	return &Status{}
+}
+`
+	assert.Equal(t, want, string(got))
+}
+
+// TestGoTypes_GoTypeAliasGeneration exercises the full generateFilesAtDepth path (including real CUE attribute
+// reading) to confirm that a status field carrying a goType attribute produces an alias file rather than a
+// cog-generated type, while a sibling spec field is still generated normally.
+func TestGoTypes_GoTypeAliasGeneration(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{
+		spec: {foo: string}
+		status: {bar: string} @grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")
+	}`)
+	require.NoError(t, schema.Err())
+
+	g := &GoTypes{Depth: 1, OpenAPINamer: func(info OpenAPINamerInfo) string { return info.TypeName }}
+	files, err := g.generateFilesAtDepth(schema, schema.Path(), 0, goTypesGenerateFilesConfig{
+		PackageName: "v1",
+		KindName:    "Foo",
+		MachineName: "foo",
+	})
+	require.NoError(t, err)
+
+	byName := map[string]string{}
+	for _, f := range files {
+		byName[f.RelativePath] = string(f.Data)
+	}
+
+	// The status file should be an alias to the external type, with a matching constructor.
+	status, ok := byName["foo_status_gen.go"]
+	require.True(t, ok, "expected foo_status_gen.go to be generated, got files: %v", keys(byName))
+	assert.Contains(t, status, `import common "github.com/org/repo/apis/common"`)
+	assert.Contains(t, status, "type Status = common.Status")
+	assert.Contains(t, status, "func NewStatus() *Status {")
+	// It should NOT contain a generated struct for the status.
+	assert.NotContains(t, status, "type Status struct")
+
+	// The spec file should still be generated as a normal go type.
+	spec, ok := byName["foo_spec_gen.go"]
+	require.True(t, ok, "expected foo_spec_gen.go to be generated")
+	assert.Contains(t, spec, "type Spec struct")
+}
+
+// TestGoTypes_GoTypeAliasGeneration_Prefixed confirms the alias type name honors the configured NamePrefix
+// (used when kinds are grouped by kind, so subresource types are prefixed with the kind name).
+func TestGoTypes_GoTypeAliasGeneration_Prefixed(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{
+		status: {bar: string} @grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")
+	}`)
+	require.NoError(t, schema.Err())
+
+	g := &GoTypes{Depth: 1}
+	files, err := g.generateFilesAtDepth(schema, schema.Path(), 0, goTypesGenerateFilesConfig{
+		PackageName: "v1",
+		KindName:    "Foo",
+		MachineName: "foo",
+		NamePrefix:  "Foo",
+	})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	data := string(files[0].Data)
+	assert.Contains(t, data, "type FooStatus = common.Status")
+	assert.Contains(t, data, "func NewFooStatus() *FooStatus {")
+}
+
+// TestResourceObject_AliasedSubresourceHasNoMethods confirms the resource-object jenny does not emit
+// DeepCopy/DeepCopyInto methods on a subresource whose type is a goType alias (Go forbids methods on an
+// alias to a non-local type), while still emitting them for a normally-generated subresource, and still
+// delegating to the aliased type's DeepCopyInto from the object's own DeepCopyInto.
+func TestResourceObject_AliasedSubresourceHasNoMethods(t *testing.T) {
+	ctx := cuecontext.New()
+	schema := ctx.CompileString(`{
+		spec: {foo: string}
+		status: {bar: string} @grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")
+		other: {baz: string}
+	}`)
+	require.NoError(t, schema.Err())
+
+	r := &ResourceObjectGenerator{}
+	data, err := r.generateObjectFile(codegen.VersionedKind{Kind: "Widget", Schema: schema}, "v1", "")
+	require.NoError(t, err)
+	out := string(data)
+
+	// No methods defined on the aliased Status type.
+	assert.NotContains(t, out, "func (s *Status) DeepCopy()")
+	assert.NotContains(t, out, "func(s *Status) DeepCopy()")
+	assert.NotContains(t, out, "func (s *Status) DeepCopyInto(")
+	assert.NotContains(t, out, "func(s *Status) DeepCopyInto(")
+	// But the non-aliased subresource and spec still get their methods.
+	assert.Contains(t, out, "func (s *Other) DeepCopyInto(dst *Other)")
+	assert.Contains(t, out, "func (s *Spec) DeepCopyInto(dst *Spec)")
+	// And the object's own DeepCopyInto still delegates to the aliased type's method.
+	assert.Contains(t, out, "o.Status.DeepCopyInto(&dst.Status)")
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/codegen/jennies/resourceobject.go
+++ b/codegen/jennies/resourceobject.go
@@ -134,6 +134,10 @@ func (r *ResourceObjectGenerator) generateObjectFile(kind codegen.VersionedKind,
 	if r.SubresourceTypesArePrefixed {
 		typePrefix = exportField(kind.Kind)
 	}
+	specGoType := false
+	if specVal := kind.Schema.LookupPath(cue.MakePath(cue.Str("spec"))); specVal.Exists() {
+		_, _, specGoType = goTypeOverride(specVal)
+	}
 	md := templates.ResourceObjectTemplateMetadata{
 		Package:              pkg,
 		TypeName:             kind.Kind,
@@ -143,6 +147,7 @@ func (r *ResourceObjectGenerator) generateObjectFile(kind codegen.VersionedKind,
 		Subresources:         make([]templates.SubresourceMetadata, 0),
 		CustomMetadataFields: customMetadataFields,
 		OpenAPIModelName:     openAPIName,
+		SpecIsExternalGoType: specGoType,
 	}
 	it, err := kind.Schema.Fields()
 	if err != nil {
@@ -153,10 +158,12 @@ func (r *ResourceObjectGenerator) generateObjectFile(kind codegen.VersionedKind,
 			continue
 		}
 		fieldName := exportField(it.Selector().String())
+		_, _, isExternalGoType := goTypeOverride(it.Value())
 		md.Subresources = append(md.Subresources, templates.SubresourceMetadata{
-			Name:     fieldName,
-			TypeName: typePrefix + fieldName,
-			JSONName: it.Selector().String(),
+			Name:             fieldName,
+			TypeName:         typePrefix + fieldName,
+			JSONName:         it.Selector().String(),
+			IsExternalGoType: isExternalGoType,
 		})
 	}
 	b := bytes.Buffer{}

--- a/codegen/templates/gotypealias.tmpl
+++ b/codegen/templates/gotypealias.tmpl
@@ -1,0 +1,13 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package {{.PackageName}}
+
+import {{.ImportAlias}} "{{.ImportPath}}"
+
+// {{.TypeName}} is a type alias to an externally-defined, shared type.
+type {{.TypeName}} = {{.ImportAlias}}.{{.ExternalType}}
+
+// New{{.TypeName}} creates a new {{.TypeName}} object.
+func New{{.TypeName}}() *{{.TypeName}} {
+	return &{{.TypeName}}{}
+}

--- a/codegen/templates/resourceobject.tmpl
+++ b/codegen/templates/resourceobject.tmpl
@@ -286,7 +286,7 @@ var _ resource.ListObject = &{{.TypeName}}List{}
 
 // Copy methods for all subresource types
 
-// DeepCopy creates a full deep copy of Spec
+{{ if not .SpecIsExternalGoType }}// DeepCopy creates a full deep copy of Spec
 func (s *{{.SpecTypeName}}) DeepCopy() *{{.SpecTypeName}} {
 	cpy := &{{.SpecTypeName}}{}
 	s.DeepCopyInto(cpy)
@@ -297,8 +297,8 @@ func (s *{{.SpecTypeName}}) DeepCopy() *{{.SpecTypeName}} {
 func (s *{{.SpecTypeName}}) DeepCopyInto(dst *{{.SpecTypeName}}) {
 	resource.CopyObjectInto(dst, s)
 }
-
-{{ range .Subresources }}// DeepCopy creates a full deep copy of {{.TypeName}}
+{{ end }}
+{{ range .Subresources }}{{ if not .IsExternalGoType }}// DeepCopy creates a full deep copy of {{.TypeName}}
 func(s *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
 	cpy := &{{.TypeName}}{}
 	s.DeepCopyInto(cpy)
@@ -309,4 +309,4 @@ func(s *{{.TypeName}}) DeepCopy() *{{.TypeName}} {
 func(s *{{.TypeName}}) DeepCopyInto(dst *{{.TypeName}}) {
 	resource.CopyObjectInto(dst, s)
 }
-{{ end }}
+{{ end }}{{ end }}

--- a/codegen/templates/templates.go
+++ b/codegen/templates/templates.go
@@ -64,6 +64,7 @@ var (
 	templateGoResourceClient, _       = template.ParseFS(templates, "resourceclient.tmpl")
 	templateGoVersionedRouteClient, _ = template.ParseFS(templates, "client.tmpl")
 	templateRuntimeObject, _          = template.ParseFS(templates, "runtimeobject.tmpl")
+	templateGoTypeAlias, _            = template.ParseFS(templates, "gotypealias.tmpl")
 
 	templateBackendPluginRouter, _          = template.ParseFS(templates, "plugin/plugin.tmpl")
 	templateBackendPluginResourceHandler, _ = template.ParseFS(templates, "plugin/handler_resource.tmpl")
@@ -125,6 +126,11 @@ type ResourceObjectTemplateMetadata struct {
 	OpenAPIModelName     string
 	Subresources         []SubresourceMetadata
 	CustomMetadataFields []ObjectMetadataField
+	// SpecIsExternalGoType is true when the spec type is a `@grafana_app_sdk(goType=...)` alias to a type
+	// defined in another package. When true, the DeepCopy/DeepCopyInto methods for the spec are not generated
+	// here (they must be provided by the external package, since Go does not allow defining methods on an alias
+	// to a non-local type).
+	SpecIsExternalGoType bool
 }
 
 // SubresourceMetadata is subresource information used in templates
@@ -133,11 +139,36 @@ type SubresourceMetadata struct {
 	TypeName string
 	JSONName string
 	Comment  string
+	// IsExternalGoType is true when this subresource's type is a `@grafana_app_sdk(goType=...)` alias to a type
+	// defined in another package. When true, the DeepCopy/DeepCopyInto methods for it are not generated here
+	// (they must be provided by the external package, since Go does not allow defining methods on an alias
+	// to a non-local type).
+	IsExternalGoType bool
 }
 
 // WriteResourceObject executes the Resource Object template, and writes out the generated go code to out
 func WriteResourceObject(metadata ResourceObjectTemplateMetadata, out io.Writer) error {
 	return templateResourceObject.Execute(out, metadata)
+}
+
+// GoTypeAliasMetadata is the metadata required by the go type alias template, used to emit a type alias to a
+// go type defined in another package (via the `@grafana_app_sdk(goType=...)` attribute).
+type GoTypeAliasMetadata struct {
+	// PackageName is the package of the generated file.
+	PackageName string
+	// ImportAlias is the alias used for the imported package in the generated file.
+	ImportAlias string
+	// ImportPath is the go import path of the package containing the externally-defined type.
+	ImportPath string
+	// TypeName is the name the alias takes within the generated package (e.g. Status or FooStatus).
+	TypeName string
+	// ExternalType is the name of the type within the imported package.
+	ExternalType string
+}
+
+// WriteGoTypeAlias executes the go type alias template, and writes out the generated go code to out
+func WriteGoTypeAlias(metadata GoTypeAliasMetadata, out io.Writer) error {
+	return templateGoTypeAlias.Execute(out, metadata)
 }
 
 type ResourceTSTemplateMetadata struct {

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_object_gen.go.txt
@@ -352,15 +352,3 @@ func (s *CustomKindSpec) DeepCopy() *CustomKindSpec {
 func (s *CustomKindSpec) DeepCopyInto(dst *CustomKindSpec) {
 	resource.CopyObjectInto(dst, s)
 }
-
-// DeepCopy creates a full deep copy of CustomKindStatus
-func (s *CustomKindStatus) DeepCopy() *CustomKindStatus {
-	cpy := &CustomKindStatus{}
-	s.DeepCopyInto(cpy)
-	return cpy
-}
-
-// DeepCopyInto deep copies CustomKindStatus into another CustomKindStatus object
-func (s *CustomKindStatus) DeepCopyInto(dst *CustomKindStatus) {
-	resource.CopyObjectInto(dst, s)
-}

--- a/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbygroup/customapp/v1_0/customkind_status_gen.go.txt
@@ -2,59 +2,12 @@
 
 package v1_0
 
-// +k8s:openapi-gen=true
-type CustomKindstatusOperatorState struct {
-	// lastEvaluation is the ResourceVersion last evaluated
-	LastEvaluation string `json:"lastEvaluation"`
-	// state describes the state of the lastEvaluation.
-	// It is limited to three possible states for machine evaluation.
-	State CustomKindStatusOperatorStateState `json:"state"`
-	// descriptiveState is an optional more descriptive state field which has no requirements on format
-	DescriptiveState *string `json:"descriptiveState,omitempty"`
-	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
-}
+import shared "codegen-tests/pkg/generated/shared"
 
-// NewCustomKindstatusOperatorState creates a new CustomKindstatusOperatorState object.
-func NewCustomKindstatusOperatorState() *CustomKindstatusOperatorState {
-	return &CustomKindstatusOperatorState{}
-}
-
-// OpenAPIModelName returns the OpenAPI model name for CustomKindstatusOperatorState.
-func (CustomKindstatusOperatorState) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindstatusOperatorState"
-}
-
-// +k8s:openapi-gen=true
-type CustomKindStatus struct {
-	StatusField1 string `json:"statusField1"`
-	// operatorStates is a map of operator ID to operator state evaluations.
-	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
-	OperatorStates map[string]CustomKindstatusOperatorState `json:"operatorStates,omitempty"`
-	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
-}
+// CustomKindStatus is a type alias to an externally-defined, shared type.
+type CustomKindStatus = shared.Status
 
 // NewCustomKindStatus creates a new CustomKindStatus object.
 func NewCustomKindStatus() *CustomKindStatus {
 	return &CustomKindStatus{}
-}
-
-// OpenAPIModelName returns the OpenAPI model name for CustomKindStatus.
-func (CustomKindStatus) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindStatus"
-}
-
-// +k8s:openapi-gen=true
-type CustomKindStatusOperatorStateState string
-
-const (
-	CustomKindStatusOperatorStateStateSuccess    CustomKindStatusOperatorStateState = "success"
-	CustomKindStatusOperatorStateStateInProgress CustomKindStatusOperatorStateState = "in_progress"
-	CustomKindStatusOperatorStateStateFailed     CustomKindStatusOperatorStateState = "failed"
-)
-
-// OpenAPIModelName returns the OpenAPI model name for CustomKindStatusOperatorStateState.
-func (CustomKindStatusOperatorStateState) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customapp.v1_0.CustomKindStatusOperatorStateState"
 }

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_object_gen.go.txt
@@ -352,15 +352,3 @@ func (s *Spec) DeepCopy() *Spec {
 func (s *Spec) DeepCopyInto(dst *Spec) {
 	resource.CopyObjectInto(dst, s)
 }
-
-// DeepCopy creates a full deep copy of Status
-func (s *Status) DeepCopy() *Status {
-	cpy := &Status{}
-	s.DeepCopyInto(cpy)
-	return cpy
-}
-
-// DeepCopyInto deep copies Status into another Status object
-func (s *Status) DeepCopyInto(dst *Status) {
-	resource.CopyObjectInto(dst, s)
-}

--- a/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_status_gen.go.txt
+++ b/codegen/testing/golden_generated/go/groupbykind/customkind/v1_0/customkind_status_gen.go.txt
@@ -2,59 +2,12 @@
 
 package v1_0
 
-// +k8s:openapi-gen=true
-type StatusOperatorState struct {
-	// lastEvaluation is the ResourceVersion last evaluated
-	LastEvaluation string `json:"lastEvaluation"`
-	// state describes the state of the lastEvaluation.
-	// It is limited to three possible states for machine evaluation.
-	State StatusOperatorStateState `json:"state"`
-	// descriptiveState is an optional more descriptive state field which has no requirements on format
-	DescriptiveState *string `json:"descriptiveState,omitempty"`
-	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
-}
+import shared "codegen-tests/pkg/generated/shared"
 
-// NewStatusOperatorState creates a new StatusOperatorState object.
-func NewStatusOperatorState() *StatusOperatorState {
-	return &StatusOperatorState{}
-}
-
-// OpenAPIModelName returns the OpenAPI model name for StatusOperatorState.
-func (StatusOperatorState) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customkind.v1_0.StatusOperatorState"
-}
-
-// +k8s:openapi-gen=true
-type Status struct {
-	StatusField1 string `json:"statusField1"`
-	// operatorStates is a map of operator ID to operator state evaluations.
-	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
-	OperatorStates map[string]StatusOperatorState `json:"operatorStates,omitempty"`
-	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
-}
+// Status is a type alias to an externally-defined, shared type.
+type Status = shared.Status
 
 // NewStatus creates a new Status object.
 func NewStatus() *Status {
 	return &Status{}
-}
-
-// OpenAPIModelName returns the OpenAPI model name for Status.
-func (Status) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customkind.v1_0.Status"
-}
-
-// +k8s:openapi-gen=true
-type StatusOperatorStateState string
-
-const (
-	StatusOperatorStateStateSuccess    StatusOperatorStateState = "success"
-	StatusOperatorStateStateInProgress StatusOperatorStateState = "in_progress"
-	StatusOperatorStateStateFailed     StatusOperatorStateState = "failed"
-)
-
-// OpenAPIModelName returns the OpenAPI model name for StatusOperatorStateState.
-func (StatusOperatorStateState) OpenAPIModelName() string {
-	return "codegen-tests.pkg.generated.customkind.v1_0.StatusOperatorStateState"
 }

--- a/docs/custom-kinds/writing-kinds.md
+++ b/docs/custom-kinds/writing-kinds.md
@@ -298,6 +298,44 @@ foov1: fooKind & {
 }
 ```
 
+### Sharing a go type across kinds (`goType`)
+
+By default, codegen generates a dedicated go type for each top-level schema field (`spec`, `status`, etc.) inline in the version package. If you want a field to instead reference a go type you maintain in another package — for example, a single `Status` type shared across many kinds — annotate the field with a `@grafana_app_sdk(goType="<import path>.<TypeName>")` attribute:
+
+```cue
+foov1: fooKind & {
+    schema: {
+        spec: {
+            name: string
+        }
+        // Instead of generating a Status type, alias the shared one from another package.
+        status: {
+            // The CUE shape still drives the CRD's status schema, so keep it in sync with the go type.
+            message?: string
+        } @grafana_app_sdk(goType="github.com/org/repo/apis/common.Status")
+    }
+}
+```
+
+Instead of a generated struct, codegen emits a type alias in the version package:
+
+```go
+import common "github.com/org/repo/apis/common"
+
+// Status is a type alias to an externally-defined, shared type.
+type Status = common.Status
+
+func NewStatus() *Status {
+    return &Status{}
+}
+```
+
+Notes and requirements:
+- **The CRD/OpenAPI schema still comes from your CUE.** The `goType` attribute only changes the *go* representation; the field's CUE shape continues to drive the generated CRD. Keep the CUE shape and the shared go type in agreement (or use a loose/`x-kubernetes-preserve-unknown-fields` status).
+- **The shared type must implement `DeepCopyInto(*T)` and `DeepCopy() *T`** (the standard k8s `deepcopy-gen`/`controller-gen` output). The generated resource object calls `DeepCopyInto` on the subresource, so it will not compile otherwise.
+- The alias keeps the field-derived type name (e.g. `Status`, or `FooStatus` when kinds are grouped by kind), so the generated codec, schema, and resource-object code are unaffected.
+- If you are replacing the auto-generated operator-state `status`, declare your own `status` field in the kind so the attribute has somewhere to live.
+
 ### Constraints
 
 [Bounds](https://cuelang.org/docs/tour/types/bounds/) can be added to your types, such as numerical bounds, or non-nil checks. These will only apply to the generated OpenAPI spec for your CRD, and will not be checked in your go or TypeScript types themselves (or in the generated Codecs). As such, the validation of the bounds is only checked on admission by the kubernetes API (via the apiextensions server that manages CRDs).


### PR DESCRIPTION
Idea: allow re-using external Go types. Example:

```cue
status: {
  statusField1: string
} @grafana_app_sdk(goType="codegen-tests/pkg/generated/shared.Status")			
```

The cue definition must still be written manually, but the generated Go code can import `shared.Status` and reuse that. For projects with multiple kinds and groups, this makes it easier to share types. Also, it enables importing _well known_ types, e.g. `metav1.Condition`.
