### PR TITLE
feat(codegen): Support disabling Go codegen entirely.

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -86,8 +86,10 @@ func generateCmdFunc(cmd *cobra.Command, _ []string) error {
 			}
 		}
 
-		// Jennies that need to be run post-file-write
-		if cfg.Codegen.EnableK8sPostProcessing {
+		// Jennies that need to be run post-file-write.
+		// Post-processing is go-only (it reads the generated go types off disk), so it is skipped
+		// entirely when go codegen is disabled, regardless of enableK8sPostProcessing.
+		if cfg.Codegen.EnableK8sPostProcessing && cfg.Codegen.GoEnabled {
 			files, err = postGenerateFilesCue(parser, cfg)
 			if err != nil {
 				return err
@@ -113,8 +115,10 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 		return nil, err
 	}
 
+	// The go module path is only needed when go code is generated. A frontend-only project with
+	// `codegen: goEnabled: false` may have no go.mod at all, so only resolve it if it's needed.
 	goModule := cfg.Codegen.GoModule
-	if goModule == "" {
+	if goModule == "" && cfg.Codegen.GoEnabled {
 		goModule, err = getGoModule("go.mod")
 		if err != nil {
 			return nil, fmt.Errorf("unable to load go module from ./go.mod: %w. Set config.codegen.goModule with a value", err)
@@ -127,12 +131,15 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 	}
 
 	// Resource
-	resourceFiles, err := generatorForManifest.Generate(cuekind.ResourceGenerator(goModule, goModGenPath, cfg.GroupKinds()), cfg.ManifestSelectors...)
-	if err != nil {
-		return nil, err
-	}
-	for i, f := range resourceFiles {
-		resourceFiles[i].RelativePath = filepath.Join(cfg.Codegen.GoGenPath, f.RelativePath)
+	var resourceFiles codejen.Files
+	if cfg.Codegen.GoEnabled {
+		resourceFiles, err = generatorForManifest.Generate(cuekind.ResourceGenerator(goModule, goModGenPath, cfg.GroupKinds()), cfg.ManifestSelectors...)
+		if err != nil {
+			return nil, err
+		}
+		for i, f := range resourceFiles {
+			resourceFiles[i].RelativePath = filepath.Join(cfg.Codegen.GoGenPath, f.RelativePath)
+		}
 	}
 	tsResourceFiles, err := generatorForManifest.Generate(cuekind.TypeScriptResourceGenerator(), cfg.ManifestSelectors...)
 	if err != nil {
@@ -159,31 +166,34 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 		}
 	}
 
-	// Backwards-compatibility for manifests written to the base generated path
-	manifestPath := "manifestdata"
-	if m, _ := filepath.Glob(filepath.Join(goModGenPath, "*_manifest.go")); len(m) > 0 {
-		manifestPath = ""
-	}
-
-	manifestPkg := filepath.Base(manifestPath)
-	if manifestPath == "" {
-		manifestPkg = filepath.Base(goModGenPath)
-	}
-
 	// Manifest
-	goManifestFiles, err := generatorForManifest.Generate(cuekind.ManifestGoGenerator(cuekind.ManifestGoGeneratorConfig{
-		Package:            manifestPkg,
-		IncludeSchemas:     cfg.Definitions.ManifestSchemas,
-		ProjectRepo:        goModule,
-		GoGenPath:          goModGenPath,
-		ManifestGoFilePath: manifestPath,
-		GroupKinds:         cfg.GroupKinds(),
-	}), cfg.ManifestSelectors...)
-	if err != nil {
-		return nil, err
-	}
-	for i, f := range goManifestFiles {
-		goManifestFiles[i].RelativePath = filepath.Join(cfg.Codegen.GoGenPath, f.RelativePath)
+	var goManifestFiles codejen.Files
+	if cfg.Codegen.GoEnabled {
+		// Backwards-compatibility for manifests written to the base generated path
+		manifestPath := "manifestdata"
+		if m, _ := filepath.Glob(filepath.Join(goModGenPath, "*_manifest.go")); len(m) > 0 {
+			manifestPath = ""
+		}
+
+		manifestPkg := filepath.Base(manifestPath)
+		if manifestPath == "" {
+			manifestPkg = filepath.Base(goModGenPath)
+		}
+
+		goManifestFiles, err = generatorForManifest.Generate(cuekind.ManifestGoGenerator(cuekind.ManifestGoGeneratorConfig{
+			Package:            manifestPkg,
+			IncludeSchemas:     cfg.Definitions.ManifestSchemas,
+			ProjectRepo:        goModule,
+			GoGenPath:          goModGenPath,
+			ManifestGoFilePath: manifestPath,
+			GroupKinds:         cfg.GroupKinds(),
+		}), cfg.ManifestSelectors...)
+		if err != nil {
+			return nil, err
+		}
+		for i, f := range goManifestFiles {
+			goManifestFiles[i].RelativePath = filepath.Join(cfg.Codegen.GoGenPath, f.RelativePath)
+		}
 	}
 
 	// Manifest CRD

--- a/cmd/grafana-app-sdk/generate_test.go
+++ b/cmd/grafana-app-sdk/generate_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-app-sdk/codegen/config"
+	"github.com/grafana/grafana-app-sdk/codegen/cuekind"
+	"github.com/grafana/grafana-app-sdk/codegen/jennies"
+)
+
+// testConfig returns a config equivalent to the `configJson` selector in
+// codegen/cuekind/testing/config.cue, with go codegen enabled or disabled.
+func testConfig(goEnabled bool) *config.Config {
+	return &config.Config{
+		Kinds: &config.KindsConfig{Grouping: config.KindGroupingGroup},
+		Definitions: &config.DefinitionsConfig{
+			GenManifest:     true,
+			GenCRDs:         true,
+			ManifestSchemas: true,
+			Encoding:        "json",
+			Path:            "definitions",
+			ManifestVersion: jennies.VersionV1Alpha1,
+		},
+		Codegen: &config.CodegenConfig{
+			GoEnabled:    goEnabled,
+			GoModule:     "codegen-tests",
+			GoModGenPath: "pkg/generated",
+			GoGenPath:    "pkg/generated",
+			TsGenPath:    "plugin/src/generated",
+		},
+		ManifestSelectors: []string{"customManifest", "testManifest"},
+	}
+}
+
+func testParser(t *testing.T) *cuekind.Parser {
+	t.Helper()
+	c, err := cuekind.LoadCue(os.DirFS(filepath.Join("..", "..", "codegen", "cuekind", "testing")))
+	require.NoError(t, err)
+	parser, err := cuekind.NewParser(c, true)
+	require.NoError(t, err)
+	return parser
+}
+
+// TestGenerateKindsCueGoEnabled is the control case: with go codegen on, go files are generated
+// alongside the TypeScript and definition files.
+func TestGenerateKindsCueGoEnabled(t *testing.T) {
+	files, err := generateKindsCue(testParser(t), testConfig(true))
+	require.NoError(t, err)
+
+	var goCount, tsCount, defCount int
+	for _, f := range files {
+		switch filepath.Ext(f.RelativePath) {
+		case ".go":
+			goCount++
+		case ".ts":
+			tsCount++
+		case ".json":
+			defCount++
+		}
+	}
+	assert.Positive(t, goCount, "go files should be generated when goEnabled is true")
+	assert.Positive(t, tsCount, "TypeScript files should be generated")
+	assert.Positive(t, defCount, "CRD/manifest files should be generated")
+}
+
+// TestGenerateKindsCueGoDisabled verifies that `codegen: goEnabled: false` suppresses all go
+// output, while leaving TypeScript and CRD/manifest generation untouched.
+func TestGenerateKindsCueGoDisabled(t *testing.T) {
+	files, err := generateKindsCue(testParser(t), testConfig(false))
+	require.NoError(t, err)
+
+	var tsCount, defCount int
+	for _, f := range files {
+		assert.NotEqual(t, ".go", filepath.Ext(f.RelativePath),
+			"no go files should be generated when goEnabled is false, got %s", f.RelativePath)
+		assert.False(t, strings.HasSuffix(f.RelativePath, "_manifest.go"),
+			"the go app manifest should not be generated when goEnabled is false")
+		switch filepath.Ext(f.RelativePath) {
+		case ".ts":
+			tsCount++
+		case ".json":
+			defCount++
+		}
+	}
+	assert.Positive(t, tsCount, "TypeScript files should still be generated when goEnabled is false")
+	assert.Positive(t, defCount, "CRD/manifest files should still be generated when goEnabled is false")
+}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -28,6 +28,7 @@ type DefinitionsConfig struct {
 }
 
 type CodegenConfig struct {
+	GoEnabled                      bool
 	GoModule                       string
 	GoModGenPath                   string
 	GoGenPath                      string

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -23,6 +23,7 @@ func TestParseConfigOverridesDefaults(t *testing.T) {
 	assert.Equal(t, "custom/defs", cfg.Definitions.Path)
 	assert.Equal(t, jennies.VersionV1Alpha1, cfg.Definitions.ManifestVersion)
 
+	assert.False(t, cfg.Codegen.GoEnabled)
 	assert.Equal(t, "github.com/example/module", cfg.Codegen.GoModule)
 	assert.Equal(t, "internal/mod", cfg.Codegen.GoModGenPath)
 	assert.Equal(t, "alt/pkg/", cfg.Codegen.GoGenPath)
@@ -44,6 +45,7 @@ func TestParseConfigDefaultFallback(t *testing.T) {
 	assert.Equal(t, "definitions", cfg.Definitions.Path)
 	assert.Equal(t, jennies.VersionV1Alpha2, cfg.Definitions.ManifestVersion)
 
+	assert.True(t, cfg.Codegen.GoEnabled)
 	assert.Equal(t, "pkg/generated/", cfg.Codegen.GoGenPath)
 	assert.Equal(t, "plugin/src/generated/", cfg.Codegen.TsGenPath)
 	assert.False(t, cfg.Codegen.EnableK8sPostProcessing)

--- a/codegen/config/testing/config.cue
+++ b/codegen/config/testing/config.cue
@@ -11,6 +11,7 @@ configA: {
 		manifestVersion: "v1alpha1"
 	}
 	codegen: {
+		goEnabled:                      false
 		goModule:                       "github.com/example/module"
 		goModGenPath:                   "internal/mod"
 		goGenPath:                      "alt/pkg/"

--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -50,6 +50,11 @@ _kubeObjectMetadata: {
 }
 
 #CodegenConfig: {
+	// Whether to generate go code.
+	// Set this to false for frontend-only apps which have no go module: when false, no go files
+	// are generated, and neither a go.mod nor the `go` binary is required to run codegen.
+	// TypeScript, CRD, and app manifest JSON/YAML generation are unaffected.
+	goEnabled: bool | *true
 	// Module name found in go.mod.
 	// If absent it will be inferred from ./go.mod.
 	goModule: string | *""

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -24,6 +24,7 @@ config: {
 	}
 
 	codegen: {
+		goEnabled:                      true
 		goGenPath:                      "pkg/generated/"
 		tsGenPath:                      "plugin/src/generated/"
 		enableK8sPostProcessing:        false
@@ -32,9 +33,11 @@ config: {
 }
 ```
 `grafana-app-sdk generate` scans the `source` directory for CUE files, and parses all top-level fields in all present CUE files as CUE kinds. If kind validation encounters any errors, no files will be written, and the validation error(s) will be printed out. On successful generation: 
-* kind go code will be written to the path in `config.codegen.goGenPath`, with a package for each unique kind-version combination
+* kind go code will be written to the path in `config.codegen.goGenPath`, with a package for each unique kind-version combination (unless `config.codegen.goEnabled` is `false`)
 * kind TypeScript code will be written to the path in `config.codegen.tsGenPath`, with a folder for each unique kind-version combination
 * kind CRD files and app manifest will be written to `config.definitions.path`, encoded according to `config.definitions.encoding`
+
+Setting `config.codegen.goEnabled` to `false` disables go code generation entirely, for every kind. This is intended for frontend-only apps: no go files are written, and neither a `go.mod` nor the `go` binary is required to run codegen. TypeScript, CRD, and app manifest JSON/YAML generation are unaffected. To disable go codegen for an individual kind or version instead of the whole project, see [Toggling TypeScript/Go Codegen](./custom-kinds/writing-kinds.md#toggling-typescriptgo-codegen).
 
 > [!IMPORTANT]
 > Because the interfaces that the grafana-app-sdk libraries use can change, be sure to run kind code generation using a version of the `grafana-app-sdk` CLI that matches the version of the dependency you use in your project. Whenever you update the dependency, make sure you re-run the kind code generation as well.

--- a/docs/custom-kinds/writing-kinds.md
+++ b/docs/custom-kinds/writing-kinds.md
@@ -156,7 +156,12 @@ This directory also holds a generated JSON (or YAML) **manifest** for your app. 
 
 ### Toggling TypeScript/Go Codegen
 
-You can turn on or off code generation for front-end (TypeScript) and/or back-end (go) using the `codegen` property in your kind or version(s) in your CUE kind. The `codegen` field by default looks like:
+You can turn on or off code generation for front-end (TypeScript) and/or back-end (go) using the `codegen` property in your kind or version(s) in your CUE kind.
+
+> [!NOTE]
+> This is a per-kind (or per-version) toggle. To disable go code generation for the entire project, set `config.codegen.goEnabled` to `false` instead — see [Code Generation](../code-generation.md). That project-wide switch also removes the need for a `go.mod` and the `go` binary.
+
+The `codegen` field by default looks like:
 ```cue
 codegen: {
     ts: {


### PR DESCRIPTION
This lets frontend-only apps avoid needing `go` installed and having a `go.mod`.

Part of https://github.com/grafana/grafana-app-platform-squad/issues/111