### PR TITLE
feat(codegen): Allow specification of single manifest output file.

### DIFF
--- a/cmd/grafana-app-sdk/generate.go
+++ b/cmd/grafana-app-sdk/generate.go
@@ -199,16 +199,30 @@ func generateKindsCue(parser *cuekind.Parser, cfg *config.Config) (codejen.Files
 	// Manifest CRD
 	var manifestFiles codejen.Files
 	if cfg.Definitions.GenManifest {
-		manifestFiles, err = generatorForManifest.Generate(cuekind.ManifestGenerator(
-			cfg.Definitions.Encoding,
-			cfg.Definitions.ManifestSchemas,
-			cfg.Definitions.ManifestVersion),
-			cfg.ManifestSelectors...)
+		// One manifest is generated per manifest selector, and a fixed filename would make
+		// every one of them collide on the same path, so reject the combination up-front.
+		if cfg.Definitions.ManifestFileName != "" && len(cfg.ManifestSelectors) > 1 {
+			return nil, fmt.Errorf("definitions.manifestFileName cannot be used with multiple "+
+				"manifestSelectors (%d configured): all manifests would be written to %q",
+				len(cfg.ManifestSelectors), cfg.Definitions.ManifestFileName)
+		}
+
+		manifestFiles, err = generatorForManifest.Generate(cuekind.ManifestGenerator(cuekind.ManifestGeneratorConfig{
+			Extension:      cfg.Definitions.Encoding,
+			FileName:       cfg.Definitions.ManifestFileName,
+			IncludeSchemas: cfg.Definitions.ManifestSchemas,
+			Version:        cfg.Definitions.ManifestVersion,
+		}), cfg.ManifestSelectors...)
 		if err != nil {
 			return nil, err
 		}
+		seenManifestPaths := make(map[string]struct{}, len(manifestFiles))
 		for i, f := range manifestFiles {
 			manifestFiles[i].RelativePath = filepath.Join(cfg.Definitions.Path, f.RelativePath)
+			if _, dup := seenManifestPaths[manifestFiles[i].RelativePath]; dup {
+				return nil, fmt.Errorf("multiple app manifests would be written to the same file %q", manifestFiles[i].RelativePath)
+			}
+			seenManifestPaths[manifestFiles[i].RelativePath] = struct{}{}
 		}
 	}
 

--- a/cmd/grafana-app-sdk/generate_test.go
+++ b/cmd/grafana-app-sdk/generate_test.go
@@ -91,3 +91,55 @@ func TestGenerateKindsCueGoDisabled(t *testing.T) {
 	assert.Positive(t, tsCount, "TypeScript files should still be generated when goEnabled is false")
 	assert.Positive(t, defCount, "CRD/manifest files should still be generated when goEnabled is false")
 }
+
+// TestGenerateKindsCueManifestFileNameMultipleSelectors verifies that a fixed manifest filename
+// is rejected when more than one manifest would be generated, rather than silently having each
+// manifest clobber the previous one.
+func TestGenerateKindsCueManifestFileNameMultipleSelectors(t *testing.T) {
+	cfg := testConfig(true)
+	cfg.Definitions.ManifestFileName = "my-manifest.json"
+	require.Len(t, cfg.ManifestSelectors, 2, "this test relies on more than one manifest selector")
+
+	_, err := generateKindsCue(testParser(t), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifestFileName")
+}
+
+// TestGenerateKindsCueManifestFileNameSingleSelector verifies that with a single manifest,
+// the configured filename is used verbatim inside the definitions path.
+func TestGenerateKindsCueManifestFileNameSingleSelector(t *testing.T) {
+	cfg := testConfig(true)
+	cfg.Definitions.ManifestFileName = "my-manifest.json"
+	cfg.ManifestSelectors = []string{"testManifest"}
+
+	files, err := generateKindsCue(testParser(t), cfg)
+	require.NoError(t, err)
+
+	want := filepath.Join(cfg.Definitions.Path, "my-manifest.json")
+	var found int
+	for _, f := range files {
+		if f.RelativePath == want {
+			found++
+		}
+	}
+	assert.Equal(t, 1, found, "expected exactly one manifest written to %s", want)
+}
+
+// TestGenerateKindsCueManifestFileNameUnset verifies the default filename is unchanged when
+// no manifestFileName is configured.
+func TestGenerateKindsCueManifestFileNameUnset(t *testing.T) {
+	cfg := testConfig(true)
+	cfg.ManifestSelectors = []string{"testManifest"}
+
+	files, err := generateKindsCue(testParser(t), cfg)
+	require.NoError(t, err)
+
+	want := filepath.Join(cfg.Definitions.Path, "test-app-manifest.json")
+	var found int
+	for _, f := range files {
+		if f.RelativePath == want {
+			found++
+		}
+	}
+	assert.Equal(t, 1, found, "expected the default manifest filename at %s", want)
+}

--- a/cmd/grafana-app-sdk/project_local.go
+++ b/cmd/grafana-app-sdk/project_local.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/codegen"
 	"github.com/grafana/grafana-app-sdk/codegen/config"
 	"github.com/grafana/grafana-app-sdk/codegen/cuekind"
+	"github.com/grafana/grafana-app-sdk/codegen/jennies"
 )
 
 //go:embed templates/local/* templates/local/scripts/* templates/local/generated/datasources/*
@@ -1024,12 +1025,10 @@ func updateLocalConfigFromManifest(envCfg *localEnvConfig, format, cuePath, conf
 			return err
 		}
 
-		fs, err := generator.Generate(cuekind.ManifestGenerator(
-			"json",
-			false,
-			"v1alpha1"),
-			cfg.ManifestSelectors...,
-		)
+		fs, err := generator.Generate(cuekind.ManifestGenerator(cuekind.ManifestGeneratorConfig{
+			Extension: "json",
+			Version:   jennies.VersionV1Alpha1,
+		}), cfg.ManifestSelectors...)
 		if err != nil {
 			return err
 		}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -25,6 +25,9 @@ type DefinitionsConfig struct {
 	Encoding        string
 	Path            string
 	ManifestVersion string
+	// ManifestFileName overrides the generated app manifest's filename (relative to Path).
+	// When empty, the filename defaults to "<appName>-manifest.<Encoding>".
+	ManifestFileName string
 }
 
 type CodegenConfig struct {

--- a/codegen/config/config_test.go
+++ b/codegen/config/config_test.go
@@ -22,6 +22,7 @@ func TestParseConfigOverridesDefaults(t *testing.T) {
 	assert.Equal(t, "yaml", cfg.Definitions.Encoding)
 	assert.Equal(t, "custom/defs", cfg.Definitions.Path)
 	assert.Equal(t, jennies.VersionV1Alpha1, cfg.Definitions.ManifestVersion)
+	assert.Equal(t, "custom-manifest.yaml", cfg.Definitions.ManifestFileName)
 
 	assert.False(t, cfg.Codegen.GoEnabled)
 	assert.Equal(t, "github.com/example/module", cfg.Codegen.GoModule)
@@ -44,6 +45,7 @@ func TestParseConfigDefaultFallback(t *testing.T) {
 	assert.Equal(t, "json", cfg.Definitions.Encoding)
 	assert.Equal(t, "definitions", cfg.Definitions.Path)
 	assert.Equal(t, jennies.VersionV1Alpha2, cfg.Definitions.ManifestVersion)
+	assert.Empty(t, cfg.Definitions.ManifestFileName)
 
 	assert.True(t, cfg.Codegen.GoEnabled)
 	assert.Equal(t, "pkg/generated/", cfg.Codegen.GoGenPath)

--- a/codegen/config/testing/config.cue
+++ b/codegen/config/testing/config.cue
@@ -5,10 +5,11 @@ configA: {
 		grouping: "group"
 	}
 	definitions: {
-		manifestSchemas: false
-		encoding:        "yaml"
-		path:            "custom/defs"
-		manifestVersion: "v1alpha1"
+		manifestSchemas:  false
+		encoding:         "yaml"
+		path:             "custom/defs"
+		manifestVersion:  "v1alpha1"
+		manifestFileName: "custom-manifest.yaml"
 	}
 	codegen: {
 		goEnabled:                      false

--- a/codegen/cuekind/def.cue
+++ b/codegen/cuekind/def.cue
@@ -41,6 +41,11 @@ _kubeObjectMetadata: {
 	// Encoding for kubernetes manifest files.
 	// Allowed values are "json" and "yaml"
 	encoding: *"json" | "yaml"
+	// Filename for the generated app manifest, relative to `path`.
+	// When empty, the filename defaults to "<appName>-manifest.<encoding>".
+	// Cannot be used when more than one manifest is generated (see manifestSelectors),
+	// as all manifests would be written to the same file.
+	manifestFileName: string | *""
 	// Whether the generated manifest JSON/YAML has CRD-compatible schemas or the default OpenAPI documents.
 	// Use "v1alpha1" for legacy CRD-compatible schemas and "v1alpha2" for the default format.
 	manifestVersion: "v1alpha1" | *"v1alpha2"

--- a/codegen/cuekind/generators.go
+++ b/codegen/cuekind/generators.go
@@ -137,15 +137,27 @@ func PostResourceGenerationGenerator(projectRepo, goGenPath string, groupKinds b
 	return g
 }
 
-func ManifestGenerator(extension string, includeSchemas bool, version string) *codejen.JennyList[codegen.AppManifest] {
+// ManifestGeneratorConfig configures the ManifestGenerator JennyList.
+type ManifestGeneratorConfig struct {
+	// Extension selects both the output encoder and, unless FileName is set, the filename suffix.
+	Extension string
+	// FileName, when non-empty, overrides the generated manifest's filename entirely.
+	// The encoder is still selected by Extension.
+	FileName       string
+	IncludeSchemas bool
+	Version        string
+}
+
+func ManifestGenerator(cfg ManifestGeneratorConfig) *codejen.JennyList[codegen.AppManifest] {
 	generator := &jennies.ManifestGenerator{
 		Encoder:         jsonEncoder,
-		FileExtension:   extension,
-		IncludeSchemas:  includeSchemas,
-		ManifestVersion: version,
+		FileExtension:   cfg.Extension,
+		FileName:        cfg.FileName,
+		IncludeSchemas:  cfg.IncludeSchemas,
+		ManifestVersion: cfg.Version,
 	}
 
-	switch extension {
+	switch cfg.Extension {
 	case "json":
 		generator.Encoder = jsonEncoder
 	case "yaml":

--- a/codegen/cuekind/generators_test.go
+++ b/codegen/cuekind/generators_test.go
@@ -114,13 +114,44 @@ func TestManifestGenerator(t *testing.T) {
 	t.Run("resource", func(t *testing.T) {
 		kinds, err := parser.ManifestParser().Parse("testManifest")
 		require.NoError(t, err)
-		files, err := ManifestGenerator("json", true, jennies.VersionV1Alpha1).Generate(kinds...)
+		files, err := ManifestGenerator(ManifestGeneratorConfig{
+			Extension:      "json",
+			IncludeSchemas: true,
+			Version:        jennies.VersionV1Alpha1,
+		}).Generate(kinds...)
 		require.NoError(t, err)
 		// Check number of files generated
 		// 5 -> object, spec, metadata, status, schema
 		assert.Len(t, files, 1)
 		// Check content against the golden files
 		compareToGolden(t, files, "manifest")
+	})
+
+	t.Run("filename override", func(t *testing.T) {
+		kinds, err := parser.ManifestParser().Parse("testManifest")
+		require.NoError(t, err)
+		files, err := ManifestGenerator(ManifestGeneratorConfig{
+			Extension:      "json",
+			FileName:       "my-manifest.json",
+			IncludeSchemas: true,
+			Version:        jennies.VersionV1Alpha1,
+		}).Generate(kinds...)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "my-manifest.json", files[0].RelativePath)
+	})
+
+	t.Run("empty filename uses the default", func(t *testing.T) {
+		kinds, err := parser.ManifestParser().Parse("testManifest")
+		require.NoError(t, err)
+		files, err := ManifestGenerator(ManifestGeneratorConfig{
+			Extension:      "yaml",
+			IncludeSchemas: true,
+			Version:        jennies.VersionV1Alpha1,
+		}).Generate(kinds...)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "test-app-manifest.yaml", files[0].RelativePath)
 	})
 }
 

--- a/codegen/jennies/manifest.go
+++ b/codegen/jennies/manifest.go
@@ -42,8 +42,11 @@ type ManifestOutputEncoder func(any) ([]byte, error)
 
 // ManifestGenerator generates a JSON/YAML App Manifest.
 type ManifestGenerator struct {
-	Encoder         ManifestOutputEncoder
-	FileExtension   string
+	Encoder       ManifestOutputEncoder
+	FileExtension string
+	// FileName overrides the generated manifest's filename. When empty, the filename
+	// defaults to "<appName>-manifest.<FileExtension>".
+	FileName        string
 	IncludeSchemas  bool
 	ManifestVersion string
 }
@@ -101,8 +104,12 @@ func (m *ManifestGenerator) Generate(appManifest codegen.AppManifest) (codejen.F
 	if err != nil {
 		return nil, err
 	}
+	fileName := m.FileName
+	if fileName == "" {
+		fileName = fmt.Sprintf("%s-manifest.%s", manifestData.AppName, m.FileExtension)
+	}
 	files = append(files, codejen.File{
-		RelativePath: fmt.Sprintf("%s-manifest.%s", manifestData.AppName, m.FileExtension),
+		RelativePath: fileName,
 		Data:         out,
 		From:         []codejen.NamedJenny{m},
 	})

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -37,6 +37,17 @@ config: {
 * kind TypeScript code will be written to the path in `config.codegen.tsGenPath`, with a folder for each unique kind-version combination
 * kind CRD files and app manifest will be written to `config.definitions.path`, encoded according to `config.definitions.encoding`
 
+By default the app manifest is named `<appName>-manifest.<encoding>`. Set `config.definitions.manifestFileName` to write it under a specific name instead (still relative to `config.definitions.path`):
+```cue
+config: {
+	definitions: {
+		path:             "definitions"
+		manifestFileName: "my-app.json"
+	}
+}
+```
+Because one manifest is generated per entry in `config.manifestSelectors`, `manifestFileName` can only be used when a single manifest is generated — otherwise every manifest would be written to the same file, so codegen errors out instead. Note that `manifestFileName` sets only the filename; the file's contents are still encoded according to `config.definitions.encoding`.
+
 Setting `config.codegen.goEnabled` to `false` disables go code generation entirely, for every kind. This is intended for frontend-only apps: no go files are written, and neither a `go.mod` nor the `go` binary is required to run codegen. TypeScript, CRD, and app manifest JSON/YAML generation are unaffected. To disable go codegen for an individual kind or version instead of the whole project, see [Toggling TypeScript/Go Codegen](./custom-kinds/writing-kinds.md#toggling-typescriptgo-codegen).
 
 > [!IMPORTANT]

--- a/docs/custom-kinds/writing-kinds.md
+++ b/docs/custom-kinds/writing-kinds.md
@@ -126,6 +126,8 @@ Generated code by default ends up in three different places (these paths can be 
 * `config.codegen.tsGenPath` (for example `plugin/src/generated/foo/v1`)
 * `config.definitions.path` (for example `definitions/`)
 
+Within `config.definitions.path`, the app manifest is named `<appName>-manifest.<encoding>` unless `config.definitions.manifestFileName` overrides it. That override is only valid when a single manifest is generated (see `config.manifestSelectors`).
+
 ### `pkg/generated`
 
 All generated go code ends up in `pkg/generated/<kind name>/<kind version>`. For each kind, there are at least six files that are generated (at least six, because each subresource generates its own go file):


### PR DESCRIPTION
For cases when a single app (and manifest) output is required, allow
specification of the exact file name, and error if multiple files
would have been written.

Part of https://github.com/grafana/plugin-tools/issues/2842
Part of https://github.com/grafana/grafana-app-platform-squad/issues/115