### PR TITLE
feat(plugins): return structured admission errors from appadapter

### DIFF
--- a/plugin/appadapter/admission.go
+++ b/plugin/appadapter/admission.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	pluginv3 "github.com/grafana/grafana-app-sdk/plugin/genproto/grafana/plugin/v3"
@@ -39,7 +42,7 @@ func (a *AdmissionAdapter) AdmissionReview(ctx context.Context, req *pluginv3.Ad
 	gvk := req.GetKind()
 	kind, ok := findManagedKind(a.app, gvk.GetGroup(), gvk.GetVersion(), gvk.GetKind())
 	if !ok {
-		return nil, fmt.Errorf("no managed kind for %s/%s %s", gvk.GetGroup(), gvk.GetVersion(), gvk.GetKind())
+		return unmanagedKindResponse(a.app, gvk), nil
 	}
 
 	obj, err := decodeObject(kind, req.GetObjectBytes())
@@ -128,12 +131,49 @@ func admissionAction(op pluginv3.AdmissionReviewRequest_Operation) resource.Admi
 // admissionErrorResponse builds a denying AdmissionReviewResponse carrying
 // err's message as the failure status.
 func admissionErrorResponse(err error) *pluginv3.AdmissionReviewResponse {
+	rsp := &pluginv3.AdmissionReviewResponse{}
+	rsp.SetAllowed(false)
+	rsp.SetError(toStatusResult(err))
+	return rsp
+}
+
+// unmanagedKindResponse builds a denying AdmissionReviewResponse for a kind the
+// App does not manage. The host only sends an admission request when the
+// manifest declares a validation or mutation hook for the kind, so this
+// mismatch is a misconfiguration: the response lists the kinds the App does
+// manage to make that easier to spot.
+func unmanagedKindResponse(a app.App, gvk *pluginv3.GroupVersionKind) *pluginv3.AdmissionReviewResponse {
+	managed := a.ManagedKinds()
+	kinds := make([]string, len(managed))
+	for i, k := range managed {
+		kinds[i] = k.GroupVersionKind().String()
+	}
+
+	causes := []*pluginv3.StatusCause{
+		newStatusCause("the manifest requires mutation/validation, but the kind is not managed by this plugin"),
+		newStatusCause(fmt.Sprintf("managed kinds: %v", kinds)),
+	}
+
+	details := &pluginv3.StatusDetails{}
+	details.SetGroup(gvk.GetGroup())
+	details.SetKind(gvk.GetKind())
+	details.SetCauses(causes)
+
 	status := &pluginv3.StatusResult{}
 	status.SetStatus("Failure")
-	status.SetMessage(err.Error())
+	status.SetReason(string(metav1.StatusReasonServiceUnavailable))
+	status.SetCode(http.StatusServiceUnavailable)
+	status.SetMessage(fmt.Sprintf("no managed kind for %s/%s %s", gvk.GetGroup(), gvk.GetVersion(), gvk.GetKind()))
+	status.SetDetails(details)
 
 	rsp := &pluginv3.AdmissionReviewResponse{}
 	rsp.SetAllowed(false)
 	rsp.SetError(status)
 	return rsp
+}
+
+func newStatusCause(reason string) *pluginv3.StatusCause {
+	cause := &pluginv3.StatusCause{}
+	cause.SetReason(reason)
+	return cause
 }

--- a/plugin/appadapter/admission_test.go
+++ b/plugin/appadapter/admission_test.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	pluginv3 "github.com/grafana/grafana-app-sdk/plugin/genproto/grafana/plugin/v3"
@@ -164,14 +171,91 @@ func TestAdmissionAdapter_AdmissionReview(t *testing.T) {
 		}
 	})
 
-	t.Run("errors when the kind is not managed", func(t *testing.T) {
-		a := NewAdmissionAdapter(&admissionFakeApp{})
+	t.Run("denies with the managed kinds when the kind is not managed", func(t *testing.T) {
+		other := resource.Kind{
+			Schema: resource.NewSimpleSchema(
+				"other.grafana.app", "v1",
+				&resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{},
+				resource.WithKind("Bar"),
+			),
+			Codecs: map[resource.KindEncoding]resource.Codec{
+				resource.KindEncodingJSON: resource.NewJSONCodec(),
+			},
+		}
+		a := NewAdmissionAdapter(&admissionFakeApp{managedKinds: []resource.Kind{other}})
 
 		req := newAdmissionReviewRequest(pluginv3.AdmissionReviewRequest_OPERATION_CREATE, nil, nil)
 
-		_, err := a.AdmissionReview(context.Background(), req)
-		if err == nil {
-			t.Fatal("expected an error for an unmanaged kind")
+		rsp, err := a.AdmissionReview(context.Background(), req)
+		if err != nil {
+			t.Fatalf("AdmissionReview returned error: %v", err)
+		}
+		if rsp.GetAllowed() {
+			t.Fatal("expected allowed=false for an unmanaged kind")
+		}
+		status := rsp.GetError()
+		if status == nil {
+			t.Fatal("expected an error status")
+		}
+		if status.GetCode() != http.StatusServiceUnavailable {
+			t.Fatalf("unexpected code: %d", status.GetCode())
+		}
+		if status.GetReason() != string(metav1.StatusReasonServiceUnavailable) {
+			t.Fatalf("unexpected reason: %q", status.GetReason())
+		}
+		details := status.GetDetails()
+		if details == nil {
+			t.Fatal("expected status details")
+		}
+		if details.GetGroup() != "test.grafana.app" || details.GetKind() != "Foo" {
+			t.Fatalf("unexpected details: %+v", details)
+		}
+		causes := details.GetCauses()
+		if len(causes) != 2 {
+			t.Fatalf("expected 2 causes, got %d", len(causes))
+		}
+		if !strings.Contains(causes[1].GetReason(), "other.grafana.app/v1, Kind=Bar") {
+			t.Fatalf("expected the managed kinds to be listed, got %q", causes[1].GetReason())
+		}
+	})
+
+	t.Run("denies with structured details for an APIStatus error", func(t *testing.T) {
+		a := NewAdmissionAdapter(&admissionFakeApp{
+			managedKinds: []resource.Kind{testKind()},
+			validate: func(context.Context, *app.AdmissionRequest) error {
+				return apierrors.NewInvalid(
+					schema.GroupKind{Group: "test.grafana.app", Kind: "Foo"},
+					"foo1",
+					field.ErrorList{field.Required(field.NewPath("spec"), "spec is required")},
+				)
+			},
+		})
+
+		req := newAdmissionReviewRequest(pluginv3.AdmissionReviewRequest_OPERATION_CREATE, marshalFoo(t, "foo1", "hello"), nil)
+
+		rsp, err := a.AdmissionReview(context.Background(), req)
+		if err != nil {
+			t.Fatalf("AdmissionReview returned error: %v", err)
+		}
+		if rsp.GetAllowed() {
+			t.Fatal("expected allowed=false")
+		}
+		status := rsp.GetError()
+		if status.GetReason() != string(metav1.StatusReasonInvalid) {
+			t.Fatalf("unexpected reason: %q", status.GetReason())
+		}
+		if status.GetCode() != http.StatusUnprocessableEntity {
+			t.Fatalf("unexpected code: %d", status.GetCode())
+		}
+		details := status.GetDetails()
+		if details == nil || details.GetName() != "foo1" || details.GetKind() != "Foo" {
+			t.Fatalf("unexpected details: %+v", details)
+		}
+		if len(details.GetCauses()) != 1 {
+			t.Fatalf("expected 1 cause, got %+v", details.GetCauses())
+		}
+		if got := details.GetCauses()[0]; got.GetField() != "spec" || got.GetReason() != string(metav1.CauseTypeFieldValueRequired) {
+			t.Fatalf("unexpected cause: %+v", got)
 		}
 	})
 

--- a/plugin/appadapter/status.go
+++ b/plugin/appadapter/status.go
@@ -1,0 +1,50 @@
+package appadapter
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	pluginv3 "github.com/grafana/grafana-app-sdk/plugin/genproto/grafana/plugin/v3"
+)
+
+// toStatusResult converts err into a [pluginv3.StatusResult]. Errors which
+// implement [apierrors.APIStatus] (such as those returned by the k8s
+// apimachinery error helpers) keep their reason, code, and details so that
+// callers get a structured failure rather than an opaque message.
+func toStatusResult(err error) *pluginv3.StatusResult {
+	r := &pluginv3.StatusResult{}
+	r.SetStatus("Failure")
+
+	var apiStatus apierrors.APIStatus
+	if !errors.As(err, &apiStatus) {
+		r.SetMessage(err.Error())
+		return r
+	}
+
+	status := apiStatus.Status()
+	r.SetStatus(status.Status)
+	r.SetMessage(status.Message)
+	r.SetReason(string(status.Reason))
+	r.SetCode(status.Code)
+	if status.Details != nil {
+		details := &pluginv3.StatusDetails{}
+		details.SetName(status.Details.Name)
+		details.SetGroup(status.Details.Group)
+		details.SetKind(status.Details.Kind)
+		details.SetUid(string(status.Details.UID))
+		details.SetRetryAfterSeconds(status.Details.RetryAfterSeconds)
+
+		causes := make([]*pluginv3.StatusCause, len(status.Details.Causes))
+		for i, statusCause := range status.Details.Causes {
+			cause := &pluginv3.StatusCause{}
+			cause.SetReason(string(statusCause.Type))
+			cause.SetMessage(statusCause.Message)
+			cause.SetField(statusCause.Field)
+			causes[i] = cause
+		}
+		details.SetCauses(causes)
+		r.SetDetails(details)
+	}
+	return r
+}


### PR DESCRIPTION
Admission failures were flattened to a bare message, and a request for an
unmanaged kind returned a gRPC error the host cannot surface usefully.

Add toStatusResult, which preserves an error's reason, code, and details
(name/group/kind/uid/retryAfter plus causes) when it implements
apierrors.APIStatus, falling back to the message otherwise. Route
admissionErrorResponse through it.

An unmanaged kind now denies with a 503 ServiceUnavailable status whose
details name the requested group/kind and list the kinds the App does
manage, since the host only sends an admission request when the manifest
declares a hook for the kind.
