### PR TITLE
feat(plugins): mutate before validate in appadapter admission

### DIFF
--- a/plugin/appadapter/admission.go
+++ b/plugin/appadapter/admission.go
@@ -63,13 +63,10 @@ func (a *AdmissionAdapter) AdmissionReview(ctx context.Context, req *pluginv3.Ad
 		OldObject: oldObj,
 	}
 
-	if err := a.app.Validate(ctx, admissionReq); err != nil && !errors.Is(err, app.ErrNotImplemented) {
-		return admissionErrorResponse(err), nil
-	}
-
 	rsp := &pluginv3.AdmissionReviewResponse{}
 	rsp.SetAllowed(true)
 
+	// Mutate first, so that validation sees the object as it will be stored.
 	mutated, err := a.app.Mutate(ctx, admissionReq)
 	if err != nil && !errors.Is(err, app.ErrNotImplemented) {
 		return admissionErrorResponse(err), nil
@@ -79,7 +76,12 @@ func (a *AdmissionAdapter) AdmissionReview(ctx context.Context, req *pluginv3.Ad
 		if err != nil {
 			return admissionErrorResponse(err), nil
 		}
+		admissionReq.Object = mutated.UpdatedObject
 		rsp.SetObjectBytes(objectBytes)
+	}
+
+	if err := a.app.Validate(ctx, admissionReq); err != nil && !errors.Is(err, app.ErrNotImplemented) {
+		return admissionErrorResponse(err), nil
 	}
 
 	return rsp, nil

--- a/plugin/appadapter/admission_test.go
+++ b/plugin/appadapter/admission_test.go
@@ -219,6 +219,35 @@ func TestAdmissionAdapter_AdmissionReview(t *testing.T) {
 		}
 	})
 
+	t.Run("validates the mutated object and returns its bytes", func(t *testing.T) {
+		var validated string
+		a := NewAdmissionAdapter(&admissionFakeApp{
+			managedKinds: []resource.Kind{testKind()},
+			mutate: func(_ context.Context, req *app.AdmissionRequest) (*app.MutatingResponse, error) {
+				updated := req.Object.(*resource.TypedSpecObject[string])
+				updated.Spec = "mutated"
+				return &app.MutatingResponse{UpdatedObject: updated}, nil
+			},
+			validate: func(_ context.Context, req *app.AdmissionRequest) error {
+				validated = req.Object.(*resource.TypedSpecObject[string]).Spec
+				return nil
+			},
+		})
+
+		req := newAdmissionReviewRequest(pluginv3.AdmissionReviewRequest_OPERATION_CREATE, marshalFoo(t, "foo1", "hello"), nil)
+
+		rsp, err := a.AdmissionReview(context.Background(), req)
+		if err != nil {
+			t.Fatalf("AdmissionReview returned error: %v", err)
+		}
+		if !rsp.GetAllowed() {
+			t.Fatalf("expected allowed=true, got response: %+v", rsp)
+		}
+		if validated != "mutated" {
+			t.Fatalf("expected Validate to see the mutated object, got spec %q", validated)
+		}
+	})
+
 	t.Run("denies with structured details for an APIStatus error", func(t *testing.T) {
 		a := NewAdmissionAdapter(&admissionFakeApp{
 			managedKinds: []resource.Kind{testKind()},


### PR DESCRIPTION
Validation ran against the incoming object, so it never saw the changes a
mutating hook had just made and could admit an object that is invalid as
stored.

Run Mutate first and assign the mutated object back onto the admission
request before calling Validate.
