### PR TITLE
operator: handle deletion and resync updates before generation filtering

### DIFF
--- a/operator/opinionatedwatcher.go
+++ b/operator/opinionatedwatcher.go
@@ -289,35 +289,8 @@ func (o *OpinionatedWatcher) Update(ctx context.Context, src resource.Object, tg
 	logger := logging.FromContext(ctx).With("action", "update", "component", "OpinionatedWatcher", "kind", tgt.GroupVersionKind().Kind, "namespace", tgt.GetNamespace(), "name", tgt.GetName())
 	logger.Debug("Handling update")
 
-	// Only fire off Update if the generation has changed (so skip subresource updates)
-	if tgt.GetGeneration() > 0 && src.GetGeneration() == tgt.GetGeneration() {
-		return nil
-	}
-
-	// TODO: finalizers part of object metadata?
 	oldFinalizers := o.getFinalizers(src)
 	newFinalizers := o.getFinalizers(tgt)
-	if !slices.Contains(newFinalizers, o.finalizer) && tgt.GetDeletionTimestamp() == nil {
-		// Either the add somehow snuck past us (unlikely), or the original AddFunc call failed, and should be retried.
-		// Either way, we need to try calling AddFunc
-		logger.Debug("Missing finalizer, calling Add")
-		err := o.addFunc(ctx, tgt)
-		if err != nil {
-			span.SetStatus(codes.Error, fmt.Sprintf("watcher add error: %s", err.Error()))
-			return err
-		}
-		// Add the finalizer (which also updates `new` inline)
-		logger.Debug("Successful call to Add, add the finalizer to the object", "finalizer", o.finalizer)
-		err = o.finalizerUpdater.ReplaceFinalizer(ctx, tgt, o.addPendingFinalizer, o.finalizer)
-		if err != nil {
-			span.SetStatus(codes.Error, fmt.Sprintf("watcher add finalizer error: %s", err.Error()))
-			if chk, ok := errors.AsType[FinalizerError](err); ok {
-				logger = logger.With("status", chk.Status().Code, "message", chk.Status().Message, "request", chk.PatchRequest())
-			}
-			logger.Error("error adding finalizer", "error", err.Error(), "kind", tgt.GroupVersionKind().Kind, "namespace", tgt.GetNamespace(), "name", tgt.GetName())
-			return fmt.Errorf("error adding finalizer: %w", err)
-		}
-	}
 
 	// Check if the deletion timestamp is non-nil.
 	// This denotes that the resource was deletes, but has one or more finalizers blocking it from actually deleting.
@@ -364,9 +337,32 @@ func (o *OpinionatedWatcher) Update(ctx context.Context, src resource.Object, tg
 		return nil
 	}
 
+	if !slices.Contains(newFinalizers, o.finalizer) {
+		// Either the add event was missed, or the original AddFunc call failed. Use the
+		// complete Add path so the in-progress finalizer protects the side effect.
+		logger.Debug("Missing finalizer, calling Add")
+		return o.Add(ctx, tgt)
+	}
+
 	// Check if this was us adding our finalizer. If it was, we can ignore it.
 	if !slices.Contains(oldFinalizers, o.finalizer) && slices.Contains(newFinalizers, o.finalizer) {
 		logger.Debug("Finalizer add update, ignoring")
+		return nil
+	}
+
+	// A cache resync emits an update with the same resource version. It must call
+	// Sync even though the generation is unchanged so external state is verified.
+	if src.GetResourceVersion() != "" && src.GetResourceVersion() == tgt.GetResourceVersion() {
+		err := o.syncFunc(ctx, tgt)
+		if err != nil {
+			span.SetStatus(codes.Error, fmt.Sprintf("watcher sync error: %s", err.Error()))
+			return err
+		}
+		return nil
+	}
+
+	// Only fire off Update if the generation has changed (so skip subresource updates).
+	if tgt.GetGeneration() > 0 && src.GetGeneration() == tgt.GetGeneration() {
 		return nil
 	}
 

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -665,6 +665,86 @@ func TestOpinionatedWatcher_Delete(t *testing.T) {
 	assert.Nil(t, o.Delete(context.TODO(), schema.ZeroValue()))
 }
 
+func TestOpinionatedWatcher_DeletionRetries(t *testing.T) {
+	for _, event := range []string{"startup", "same generation update"} {
+		for _, owned := range []string{"normal", "pending", "both"} {
+			t.Run(event+"/"+owned, func(t *testing.T) {
+				schema := resource.NewSimpleSchema("group", "version", &resource.TypedSpecObject[string]{}, &resource.TypedList[*resource.TypedSpecObject[string]]{})
+				client := &mockPatchClient{}
+				watcher, err := NewOpinionatedWatcher(schema, client, OpinionatedWatcherConfig{})
+				require.NoError(t, err)
+				obj := schema.ZeroValue()
+				obj.SetGeneration(1)
+				obj.SetResourceVersion("2")
+				now := metav1.Now()
+				obj.SetDeletionTimestamp(&now)
+				finalizers := []string{"other.example/cleanup", "finished.example/cleanup"}
+				if owned != "pending" {
+					finalizers = append(finalizers, watcher.finalizer)
+				}
+				if owned != "normal" {
+					finalizers = append(finalizers, watcher.addPendingFinalizer)
+				}
+				obj.SetFinalizers(finalizers)
+				old := schema.ZeroValue()
+				old.SetGeneration(1)
+				old.SetResourceVersion("1")
+				handle := func() error {
+					if event == "startup" {
+						return watcher.Add(t.Context(), obj)
+					}
+					return watcher.Update(t.Context(), old, obj)
+				}
+
+				deleteErr := fmt.Errorf("downstream unavailable")
+				patchErr := fmt.Errorf("apiserver unavailable")
+				deleteCalls, patchCalls := 0, 0
+				watcher.DeleteFunc = func(context.Context, resource.Object) error {
+					deleteCalls++
+					if deleteCalls == 1 {
+						return deleteErr
+					}
+					return nil
+				}
+				client.PatchIntoFunc = func(_ context.Context, _ resource.Identifier, _ resource.PatchRequest, _ resource.PatchOptions, _ resource.Object) error {
+					patchCalls++
+					return patchErr
+				}
+
+				require.ErrorIs(t, handle(), deleteErr)
+				require.Zero(t, patchCalls)
+				require.Equal(t, finalizers, obj.GetFinalizers())
+				require.ErrorIs(t, handle(), patchErr)
+				require.Equal(t, finalizers, obj.GetFinalizers())
+
+				// A concurrent owner finishes cleanup before our patch.
+				conflicted := false
+				client.PatchIntoFunc = func(_ context.Context, _ resource.Identifier, req resource.PatchRequest, _ resource.PatchOptions, into resource.Object) error {
+					if !conflicted {
+						conflicted = true
+						return &apierrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusConflict}}
+					}
+					require.Equal(t, "3", req.Operations[1].Value)
+					into.SetFinalizers(req.Operations[0].Value.([]string))
+					return nil
+				}
+				client.GetIntoFunc = func(_ context.Context, _ resource.Identifier, into resource.Object) error {
+					current := append([]string(nil), finalizers[:1]...)
+					into.SetFinalizers(append(current, finalizers[2:]...))
+					into.SetResourceVersion("3")
+					return nil
+				}
+				require.NoError(t, handle())
+				require.True(t, conflicted)
+				require.Equal(t, []string{"other.example/cleanup"}, obj.GetFinalizers())
+				require.Equal(t, 3, deleteCalls)
+				require.NoError(t, handle())
+				require.Equal(t, 3, deleteCalls, "a completed finalizer must not repeat cleanup")
+			})
+		}
+	}
+}
+
 type mockPatchClient struct {
 	PatchIntoFunc func(context.Context, resource.Identifier, resource.PatchRequest, resource.PatchOptions, resource.Object) error
 	GetIntoFunc   func(context.Context, resource.Identifier, resource.Object) error

--- a/operator/opinionatedwatcher_test.go
+++ b/operator/opinionatedwatcher_test.go
@@ -362,7 +362,7 @@ func TestOpinionatedWatcher_Update(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("new cannot be nil"), err)
 	})
 
-	t.Run("same generation", func(t *testing.T) {
+	t.Run("same generation status update", func(t *testing.T) {
 		o.UpdateFunc = func(ctx context.Context, old resource.Object, new resource.Object) error {
 			assert.Fail(t, "update should not be called")
 			return nil
@@ -375,8 +375,137 @@ func TestOpinionatedWatcher_Update(t *testing.T) {
 		new := schema.ZeroValue()
 		old.SetGeneration(1)
 		new.SetGeneration(1)
+		old.SetResourceVersion("1")
+		new.SetResourceVersion("2")
+		old.SetFinalizers([]string{o.finalizer})
+		new.SetFinalizers([]string{o.finalizer})
+		o.SyncFunc = func(ctx context.Context, object resource.Object) error {
+			assert.Fail(t, "sync should not be called for a status update")
+			return nil
+		}
 		err := o.Update(context.TODO(), old, new)
 		assert.Nil(t, err)
+	})
+
+	t.Run("same generation deletion", func(t *testing.T) {
+		old := schema.ZeroValue()
+		old.SetGeneration(1)
+		old.SetResourceVersion("1")
+		old.SetFinalizers([]string{o.finalizer})
+
+		new := schema.ZeroValue()
+		new.SetGeneration(1)
+		new.SetResourceVersion("2")
+		new.SetFinalizers([]string{o.finalizer})
+		deletionTimestamp := metav1.Now()
+		new.SetDeletionTimestamp(&deletionTimestamp)
+
+		deleteCalls := 0
+		o.DeleteFunc = func(ctx context.Context, object resource.Object) error {
+			deleteCalls++
+			assert.Equal(t, new, object)
+			return nil
+		}
+		o.UpdateFunc = func(ctx context.Context, old resource.Object, new resource.Object) error {
+			assert.Fail(t, "update should not be called")
+			return nil
+		}
+		o.SyncFunc = func(ctx context.Context, object resource.Object) error {
+			assert.Fail(t, "sync should not be called")
+			return nil
+		}
+		client.PatchIntoFunc = func(ctx context.Context, identifier resource.Identifier, request resource.PatchRequest, options resource.PatchOptions, object resource.Object) error {
+			assert.Equal(t, resource.PatchOpReplace, request.Operations[0].Operation)
+			return nil
+		}
+
+		err := o.Update(context.TODO(), old, new)
+		require.NoError(t, err)
+		assert.Equal(t, 1, deleteCalls)
+	})
+
+	t.Run("cache resync", func(t *testing.T) {
+		old := schema.ZeroValue()
+		old.SetGeneration(1)
+		old.SetResourceVersion("7")
+		old.SetFinalizers([]string{o.finalizer})
+		new := schema.ZeroValue()
+		new.SetGeneration(1)
+		new.SetResourceVersion("7")
+		new.SetFinalizers([]string{o.finalizer})
+
+		syncCalls := 0
+		o.SyncFunc = func(ctx context.Context, object resource.Object) error {
+			syncCalls++
+			assert.Equal(t, new, object)
+			return nil
+		}
+		o.UpdateFunc = func(ctx context.Context, old resource.Object, new resource.Object) error {
+			assert.Fail(t, "update should not be called")
+			return nil
+		}
+		o.DeleteFunc = func(ctx context.Context, object resource.Object) error {
+			assert.Fail(t, "delete should not be called")
+			return nil
+		}
+		client.PatchIntoFunc = func(ctx context.Context, identifier resource.Identifier, request resource.PatchRequest, options resource.PatchOptions, object resource.Object) error {
+			assert.Fail(t, "patch should not be called")
+			return nil
+		}
+
+		err := o.Update(context.TODO(), old, new)
+		require.NoError(t, err)
+		assert.Equal(t, 1, syncCalls)
+	})
+
+	t.Run("same generation missing finalizer", func(t *testing.T) {
+		old := schema.ZeroValue()
+		old.SetGeneration(1)
+		old.SetResourceVersion("1")
+		new := schema.ZeroValue()
+		new.SetGeneration(1)
+		new.SetResourceVersion("2")
+
+		addCalls := 0
+		o.AddFunc = func(ctx context.Context, object resource.Object) error {
+			addCalls++
+			assert.Equal(t, new, object)
+			assert.Contains(t, object.GetFinalizers(), o.addPendingFinalizer)
+			return nil
+		}
+		o.UpdateFunc = func(ctx context.Context, old resource.Object, new resource.Object) error {
+			assert.Fail(t, "update should not be called")
+			return nil
+		}
+		o.DeleteFunc = func(ctx context.Context, object resource.Object) error {
+			assert.Fail(t, "delete should not be called")
+			return nil
+		}
+		o.SyncFunc = func(ctx context.Context, object resource.Object) error {
+			assert.Fail(t, "sync should not be called")
+			return nil
+		}
+		patchCalls := 0
+		client.PatchIntoFunc = func(ctx context.Context, identifier resource.Identifier, request resource.PatchRequest, options resource.PatchOptions, object resource.Object) error {
+			patchCalls++
+			switch patchCalls {
+			case 1:
+				assert.Equal(t, resource.PatchOpAdd, request.Operations[0].Operation)
+				object.SetFinalizers([]string{o.addPendingFinalizer})
+			case 2:
+				assert.Equal(t, resource.PatchOpReplace, request.Operations[0].Operation)
+				assert.Equal(t, o.finalizer, request.Operations[0].Value)
+				object.SetFinalizers([]string{o.finalizer})
+			default:
+				assert.Fail(t, "unexpected patch")
+			}
+			return nil
+		}
+
+		err := o.Update(context.TODO(), old, new)
+		require.NoError(t, err)
+		assert.Equal(t, 1, addCalls)
+		assert.Equal(t, 2, patchCalls)
 	})
 
 	t.Run("delete, not waiting on us", func(t *testing.T) {


### PR DESCRIPTION
## What Changed? Why?

`OpinionatedWatcher.Update` previously returned early for same-generation events before checking deletion or cache resync state. This can suppress finalizer cleanup and external-state reconciliation when the resource spec has not changed.

Handle deletion before generation filtering, send exact-resource-version cache resyncs to `Sync`, and recover missing finalizers through the complete pending-finalizer-protected `Add` path. Ordinary same-generation status updates remain filtered.

Regression tests cover those transitions plus repeated cleanup after downstream failures, finalizer patch failures, and resource-version conflicts. Both startup replay and same-generation updates preserve other owners' finalizers and handle normal, pending, or both SDK finalizers.

### How was it tested?

With Go 1.26.7:

- `go test ./operator/... ./simple/... -timeout=2m` passes. An earlier broad run timed out in an unchanged informer watcher/reconciler test; the isolated test and full package rerun passed.
- `go test -race ./operator -run TestOpinionatedWatcher` passes.
- `make lint LINT_ARGS=--timeout=5m` and the SDK CLI build pass.
- [Controller adoption #373](https://github.com/grafana/mimir-config-controller/pull/373) pins this commit and passes unit/race and envtest checks for startup cleanup, automatic retries, unrelated tenant progress, and lost DELETE responses.

Broader validation limits: the operator race suite reports a `TestConcurrentWatcher` test race, independently reproduced at unchanged base `7394780`. The all-module test run reached its local three-minute timeout in `cmd/grafana-app-sdk` and `codegen/cuekind` during import scanning; that run is not green. Go's test cache was retained.

### Where did you document your changes?

The ordering-sensitive branches and regression tests document the behavior. Deployment and recovery guidance is in [deployment_tools#709879](https://github.com/grafana/deployment_tools/pull/709879).

### Notes to Reviewers

This is the SDK prerequisite for durable Mimir controller cleanup. The backend authentication/idempotency fix is [backend-enterprise#14137](https://github.com/grafana/backend-enterprise/pull/14137). After review, release this SDK change and update the controller draft from its immutable commit pin to the reviewed release before merging it.

Arve owns CI follow-up, merges, releases, and rollout after draft publication.

Refs [the cleanup warning](https://raintank-corp.slack.com/archives/C060Z9BGVL0/p1788743251707049).
