### PR TITLE
feat(plugins): Derive KubeConfig from service account env vars

### DIFF
--- a/plugin/run.go
+++ b/plugin/run.go
@@ -33,6 +33,11 @@ import (
 //
 //	err = plugin.Run(myapp.Provider(), plugin.WithKubeConfig(kubeConfig))
 //
+// If WithKubeConfig is not used, Run will attempt to build a rest.Config from
+// the plugin's provisioned service account (using the GF_APP_URL and
+// GF_PLUGIN_APP_CLIENT_SECRET environment variables made available by
+// Grafana). If those are not set, the App is given a zero-value rest.Config.
+//
 // Existing plugins that already have a plugin ID and an
 // backendapp.InstanceFactoryFunc (e.g. one built with app.New from an
 // existing datasource or app plugin) can keep using them via WithPluginID
@@ -69,13 +74,27 @@ func Run(provider app.Provider, opts ...RunOption) error {
 	if provider == nil {
 		return errors.New("provider cannot be nil")
 	}
+
+	// If the caller didn't explicitly provide a KubeConfig, fall back to one
+	// built from the plugin's provisioned service account, if available.
+	if cfg.kubeConfig == nil {
+		cfg.kubeConfig = serviceAccountKubeConfig()
+		if cfg.kubeConfig != nil {
+			backendlog.DefaultLogger.Debug("KubeConfig using plugin service account",
+				"host", cfg.kubeConfig.Host)
+		}
+	}
 	manifestData := provider.Manifest().ManifestData
 	if manifestData == nil {
 		return errors.New("embedded manifest required")
 	}
 
+	var kubeConfig rest.Config
+	if cfg.kubeConfig != nil {
+		kubeConfig = *cfg.kubeConfig
+	}
 	appConfig := app.Config{
-		KubeConfig:     cfg.kubeConfig,
+		KubeConfig:     kubeConfig,
 		ManifestData:   *manifestData,
 		SpecificConfig: provider.SpecificConfig(),
 	}
@@ -125,9 +144,11 @@ func Run(provider app.Provider, opts ...RunOption) error {
 var manage = backendapp.Manage
 
 // WithKubeConfig sets the rest.Config used to communicate with the Kubernetes API server.
+// Setting this overrides any KubeConfig that would otherwise be automatically derived
+// from the plugin's provisioned service account.
 func WithKubeConfig(kubeConfig rest.Config) RunOption {
 	return func(cfg *runConfig) {
-		cfg.kubeConfig = kubeConfig
+		cfg.kubeConfig = &kubeConfig
 	}
 }
 
@@ -156,7 +177,7 @@ func WithManageOpts(manageOpts backendapp.ManageOpts) RunOption {
 type RunOption func(cfg *runConfig)
 
 type runConfig struct {
-	kubeConfig rest.Config
+	kubeConfig *rest.Config
 	pluginID   string
 	appFunc    backendapp.InstanceFactoryFunc
 	manageOpts backendapp.ManageOpts

--- a/plugin/run_test.go
+++ b/plugin/run_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	backendapp "github.com/grafana/grafana-plugin-sdk-go/backend/app"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 	goplugin "github.com/hashicorp/go-plugin"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
@@ -158,6 +159,45 @@ func TestRun(t *testing.T) {
 		}
 		if got.SpecificConfig != "specific" {
 			t.Errorf("expected specific config to be passed through, got %v", got.SpecificConfig)
+		}
+	})
+
+	t.Run("derives kube config from service account env vars when WithKubeConfig is not used", func(t *testing.T) {
+		stubManage(t, nil)
+		p := newFakeProvider("my-app")
+		t.Setenv(config.AppURL, "https://grafana.example.com")
+		t.Setenv(config.AppClientSecret, "secret")
+
+		if err := Run(p); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := p.app.cfg.KubeConfig
+		if got.Host != "https://grafana.example.com" {
+			t.Errorf("expected Host %q, got %q", "https://grafana.example.com", got.Host)
+		}
+		if got.BearerToken != "secret" {
+			t.Errorf("expected BearerToken %q, got %q", "secret", got.BearerToken)
+		}
+	})
+
+	t.Run("WithKubeConfig overrides service account env vars", func(t *testing.T) {
+		stubManage(t, nil)
+		p := newFakeProvider("my-app")
+		t.Setenv(config.AppURL, "https://grafana.example.com")
+		t.Setenv(config.AppClientSecret, "secret")
+		kubeConfig := rest.Config{Host: "https://explicit.example.com"}
+
+		if err := Run(p, WithKubeConfig(kubeConfig)); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := p.app.cfg.KubeConfig
+		if got.Host != "https://explicit.example.com" {
+			t.Errorf("expected Host %q, got %q", "https://explicit.example.com", got.Host)
+		}
+		if got.BearerToken != "" {
+			t.Errorf("expected empty BearerToken, got %q", got.BearerToken)
 		}
 	})
 

--- a/plugin/serviceaccount.go
+++ b/plugin/serviceaccount.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/config"
+	"k8s.io/client-go/rest"
+)
+
+// serviceAccountKubeConfig builds a rest.Config from the plugin's provisioned
+// service account, if available; returns nil if not.
+//
+// Note:
+//   - Looks for GF_APP_URL and GF_PLUGIN_APP_CLIENT_SECRET.
+//   - Requires externalServiceAccounts feature toggle and
+//     [auth.managed_service_accounts] enabled=true
+//     (or GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED=true)
+//   - Requires an "iam" block set in plugin.json with necessary permissions.
+func serviceAccountKubeConfig() *rest.Config {
+	// We explicitly don't pass a context here, as we _only_ want
+	// configuration to be collected from environment variables.
+	gcfg := config.GrafanaConfigFromContext(context.Background())
+
+	appURL, err := gcfg.AppURL()
+	if err != nil {
+		return nil
+	}
+
+	secret, err := gcfg.PluginAppClientSecret()
+	if err != nil {
+		return nil
+	}
+
+	return &rest.Config{
+		Host:        appURL,
+		APIPath:     "/apis",
+		BearerToken: secret,
+	}
+}

--- a/plugin/serviceaccount_test.go
+++ b/plugin/serviceaccount_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/config"
+)
+
+func TestServiceAccountKubeConfig(t *testing.T) {
+	t.Run("returns nil when app URL is missing", func(t *testing.T) {
+		t.Setenv(config.AppClientSecret, "secret")
+
+		if cfg := serviceAccountKubeConfig(); cfg != nil {
+			t.Fatalf("expected nil, got config %+v", cfg)
+		}
+	})
+
+	t.Run("returns nil when client secret is missing", func(t *testing.T) {
+		t.Setenv(config.AppURL, "https://grafana.example.com")
+
+		if cfg := serviceAccountKubeConfig(); cfg != nil {
+			t.Fatalf("expected nil, got config %+v", cfg)
+		}
+	})
+
+	t.Run("builds a rest.Config from the service account env vars", func(t *testing.T) {
+		t.Setenv(config.AppURL, "https://grafana.example.com")
+		t.Setenv(config.AppClientSecret, "secret")
+
+		cfg := serviceAccountKubeConfig()
+		if cfg == nil {
+			t.Fatal("expected a non-nil config")
+		}
+		if cfg.Host != "https://grafana.example.com" {
+			t.Errorf("expected Host %q, got %q", "https://grafana.example.com", cfg.Host)
+		}
+		if cfg.APIPath != "/apis" {
+			t.Errorf("expected APIPath %q, got %q", "/apis", cfg.APIPath)
+		}
+		if cfg.BearerToken != "secret" {
+			t.Errorf("expected BearerToken %q, got %q", "secret", cfg.BearerToken)
+		}
+	})
+}


### PR DESCRIPTION
Run() now falls back to a rest.Config built from GF_APP_URL and
GF_PLUGIN_APP_CLIENT_SECRET when WithKubeConfig is not used.

Part of https://github.com/grafana/grafana-app-platform-squad/issues/111