### PR TITLE
feat(plugin): attempt to provide kube config from environment variables

### DIFF
--- a/plugin/kubeconfig.go
+++ b/plugin/kubeconfig.go
@@ -1,0 +1,92 @@
+package plugin
+
+import (
+	"errors"
+	"os"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/k8s"
+)
+
+// accessAudiences returns the deduped token-exchange audiences this app needs: its own group,
+// plus the group of every kind it accesses via manifestData.ExtraPermissions.
+func accessAudiences(manifestData app.ManifestData) []string {
+	seen := map[string]bool{manifestData.Group: true}
+	audiences := []string{manifestData.Group}
+	if manifestData.ExtraPermissions != nil {
+		for _, accessKind := range manifestData.ExtraPermissions.AccessKinds {
+			if seen[accessKind.Group] {
+				continue
+			}
+			seen[accessKind.Group] = true
+			audiences = append(audiences, accessKind.Group)
+		}
+	}
+	return audiences
+}
+
+// BuildKubeConfig builds the rest.Config from environment variables.
+//
+// Picks up configuration for API access from:
+// - API_ACCESS_ROUTER_URL
+// - API_ACCESS_CA_FILE (optional)
+// - API_ACCESS_INSECURE_TLS (optional)
+//
+// Configures token exchange if the following are set:
+// - API_ACCESS_CAP_TOKEN
+// - API_ACCESS_TOKEN_EXCHANGE_URL
+//
+// Otherwise falls back to standard auth, using either:
+// - API_ACCESS_BEARER_TOKEN or
+// - API_ACCESS_USERNAME/API_ACCESS_PASSWORD
+func BuildKubeConfig(manifestData app.ManifestData) (*rest.Config, error) {
+	routerURL := os.Getenv("API_ACCESS_ROUTER_URL")
+	if routerURL == "" {
+		return nil, errors.New("no url provided: set API_ACCESS_ROUTER_URL")
+	}
+
+	// Check if token exchange is configured.
+	tokenExchangeURL := os.Getenv("API_ACCESS_TOKEN_EXCHANGE_URL")
+	capToken := os.Getenv("API_ACCESS_CAP_TOKEN")
+	if tokenExchangeURL != "" || capToken != "" {
+		return k8s.NewTokenExchangeRestConfig(
+			k8s.TokenExchangeCredentials{
+				Token:            capToken,
+				TokenExchangeURL: tokenExchangeURL,
+			},
+			k8s.RemoteServiceTarget{
+				Host:        routerURL,
+				Audiences:   accessAudiences(manifestData),
+				InsecureTLS: os.Getenv("API_ACCESS_INSECURE_TLS") == "true",
+				CAFile:      os.Getenv("API_ACCESS_CA_FILE"),
+			},
+		)
+	}
+
+	// Fall back to auth without token exchange: either a bearer token or basic auth.
+	cfg := &rest.Config{
+		Host:    routerURL,
+		APIPath: "/apis",
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: os.Getenv("API_ACCESS_INSECURE_TLS") == "true",
+			CAFile:   os.Getenv("API_ACCESS_CA_FILE"),
+		},
+	}
+
+	if bearerToken := os.Getenv("API_ACCESS_BEARER_TOKEN"); bearerToken != "" {
+		cfg.BearerToken = bearerToken
+		return cfg, nil
+	}
+
+	username := os.Getenv("API_ACCESS_USERNAME")
+	password := os.Getenv("API_ACCESS_PASSWORD")
+	if username != "" && password != "" {
+		cfg.Username = username
+		cfg.Password = password
+		return cfg, nil
+	}
+
+	return nil, errors.New("no credentials provided: set API_ACCESS_BEARER_TOKEN or API_ACCESS_USERNAME/API_ACCESS_PASSWORD")
+}

--- a/plugin/run.go
+++ b/plugin/run.go
@@ -74,8 +74,22 @@ func Run(provider app.Provider, opts ...RunOption) error {
 		return errors.New("embedded manifest required")
 	}
 
+	if cfg.kubeConfig == nil {
+		kubeConfig, err := BuildKubeConfig(*manifestData)
+		if err != nil {
+			logging.DefaultLogger.Warn("no kube config for api access", "error", err)
+		} else {
+			cfg.kubeConfig = kubeConfig
+		}
+	}
+
+	var kubeConfig rest.Config
+	if cfg.kubeConfig != nil {
+		kubeConfig = *cfg.kubeConfig
+	}
+
 	appConfig := app.Config{
-		KubeConfig:     cfg.kubeConfig,
+		KubeConfig:     kubeConfig,
 		ManifestData:   *manifestData,
 		SpecificConfig: provider.SpecificConfig(),
 	}
@@ -125,9 +139,10 @@ func Run(provider app.Provider, opts ...RunOption) error {
 var manage = backendapp.Manage
 
 // WithKubeConfig sets the rest.Config used to communicate with the Kubernetes API server.
+// If not provided, Run will attempt to build one via BuildKubeConfig.
 func WithKubeConfig(kubeConfig rest.Config) RunOption {
 	return func(cfg *runConfig) {
-		cfg.kubeConfig = kubeConfig
+		cfg.kubeConfig = &kubeConfig
 	}
 }
 
@@ -156,7 +171,7 @@ func WithManageOpts(manageOpts backendapp.ManageOpts) RunOption {
 type RunOption func(cfg *runConfig)
 
 type runConfig struct {
-	kubeConfig rest.Config
+	kubeConfig *rest.Config
 	pluginID   string
 	appFunc    backendapp.InstanceFactoryFunc
 	manageOpts backendapp.ManageOpts


### PR DESCRIPTION
Run() now builds a rest.Config from the environment via BuildKubeConfig
when WithKubeConfig wasn't provided, warning instead of failing if that
also can't produce one.

https://github.com/grafana/grafana-app-platform-squad/issues/111
