### PR TITLE
fix(apiserver): include API group in per-kind admission cache key

### DIFF
--- a/k8s/apiserver/admission.go
+++ b/k8s/apiserver/admission.go
@@ -32,7 +32,7 @@ func newAppAdmission(md app.ManifestData, appGetter func() app.App) *appAdmissio
 				if !k.Admission.SupportsAnyValidation() && !k.Admission.SupportsAnyMutation() {
 					continue
 				}
-				adm.perKindAdmission[fmt.Sprintf("%s/%s", v.Name, k.Kind)] = *k.Admission
+				adm.perKindAdmission[admissionKindKey(md.Group, v.Name, k.Kind)] = *k.Admission
 			}
 		}
 	}
@@ -150,10 +150,20 @@ func (ad *appAdmission) Handles(op admission.Operation) bool {
 }
 
 func (ad *appAdmission) getAdmissionInfo(gvk schema.GroupVersionKind) *app.AdmissionCapabilities {
-	if adm, ok := ad.perKindAdmission[fmt.Sprintf("%s/%s", gvk.Version, gvk.Kind)]; ok {
+	if adm, ok := ad.perKindAdmission[admissionKindKey(gvk.Group, gvk.Version, gvk.Kind)]; ok {
 		return &adm
 	}
 	return nil
+}
+
+// admissionKindKey builds the perKindAdmission map key for a group/version/kind. The group must be
+// included: appAdmission instances from every installed app are chained together into one
+// admission.Interface (see appinstaller.RegisterAdmission in Grafana core) and run against every
+// request regardless of which app it targets, so a group-less "version/kind" key lets two unrelated
+// apps whose kinds happen to share a Kind name and version (e.g. two apps both defining "Example"
+// v1alpha1) collide and answer admission requests for each other's objects.
+func admissionKindKey(group, version, kind string) string {
+	return fmt.Sprintf("%s/%s/%s", group, version, kind)
 }
 
 func translateAdmissionAttributes(a admission.Attributes) (*app.AdmissionRequest, error) {

--- a/k8s/apiserver/admission_test.go
+++ b/k8s/apiserver/admission_test.go
@@ -26,6 +26,7 @@ func TestAppAdmission_Admit(t *testing.T) {
 	badReq := admission.NewAttributesRecord(&metav1.Status{}, &metav1.Status{}, TestKind.GroupVersionKind(), "default", "foo", TestKind.GroupVersionResource(), "", admission.Operation("foo"), &metav1.UpdateOptions{}, false, nil)
 	manifestWithMutation := func(ops []app.AdmissionOperation) app.ManifestData {
 		return app.ManifestData{
+			Group: TestKind.Group(),
 			Versions: []app.ManifestVersion{{
 				Name:   TestKind.Version(),
 				Served: true,
@@ -148,6 +149,7 @@ func TestAppAdmission_Validate(t *testing.T) {
 	badReq := admission.NewAttributesRecord(&metav1.Status{}, &metav1.Status{}, TestKind.GroupVersionKind(), "default", "foo", TestKind.GroupVersionResource(), "", admission.Operation("foo"), &metav1.UpdateOptions{}, false, nil)
 	manifestWithValidation := func(ops []app.AdmissionOperation) app.ManifestData {
 		return app.ManifestData{
+			Group: TestKind.Group(),
 			Versions: []app.ManifestVersion{{
 				Name:   TestKind.Version(),
 				Served: true,


### PR DESCRIPTION
`appAdmission.perKindAdmission` was keyed by "version/kind" only, omitting
the API group. `appAdmission` instances from every installed app are
chained together into one `admission.Interface` by
`appinstaller.RegisterAdmission` in Grafana core, and that combined
interface runs against every admission request regardless of which app
it targets. With a group-less key, two unrelated apps whose kinds share
a Kind name and version (e.g. two apps both defining "Example"
v1alpha1) would collide in the map, causing one app's
validation/mutation capabilities to incorrectly answer admission
requests for the other app's objects.

Key the map (and look it up) by group/version/kind instead.

Part of https://github.com/grafana/grafana-app-platform-squad/issues/111